### PR TITLE
Declare InternalPassthroughEvent as an explicit interface.

### DIFF
--- a/packages/harness/src/core/runtime/AgentThread.types.ts
+++ b/packages/harness/src/core/runtime/AgentThread.types.ts
@@ -60,12 +60,15 @@ export interface InternalCapabilityStateEvent {
   state: unknown;
 }
 
-export const InternalPassthroughEventSchema = z.object({
+export interface InternalPassthroughEvent {
+  type: typeof InternalEventType.PASSTHROUGH;
+  event: RegisteredPassthroughEvent;
+}
+
+export const InternalPassthroughEventSchema: z.ZodType<InternalPassthroughEvent> = z.object({
   type: z.literal(InternalEventType.PASSTHROUGH),
   event: z.custom<RegisteredPassthroughEvent>(),
 });
-
-export type InternalPassthroughEvent = z.infer<typeof InternalPassthroughEventSchema>;
 
 export type InternalMCPServerAuthInfo = MCPServerAuthInfo & {
   thread_ids: string[];


### PR DESCRIPTION
Annotate the schema as z.ZodType<InternalPassthroughEvent> instead of inferring the type from it; the shape is unchanged so the public type surface stays identical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-definition-only refactor in harness runtime types; no runtime behavior or validation shape changes.
> 
> **Overview**
> **`InternalPassthroughEvent`** is now defined as an explicit `interface` (same fields as before) instead of being inferred from Zod via `z.infer`.
> 
> The Zod schema is annotated as `z.ZodType<InternalPassthroughEvent>` so the schema validates against the declared type rather than being the source of truth. This matches the pattern used for other internal events like **`InternalCapabilityStateEvent`** and keeps the public type surface unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcdc7d39624943356e97bb5f5c034efd5aadbd3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->