### PR TITLE
AGE-1379: add sub-agent completion tool.response in agentthreadcontext

### DIFF
--- a/packages/harness/src/agent-session/TurnHandle.ts
+++ b/packages/harness/src/agent-session/TurnHandle.ts
@@ -328,8 +328,14 @@ export class TurnHandle<TTurnCustom extends object = Record<string, never>> {
     switch (event.type) {
       case HarnessEventType.MODEL_MESSAGE:
       case HarnessEventType.MODEL_MESSAGE_DELTA:
+        // Stream only — durable model content lands via AGENT_CONTEXT_APPEND.output.
+        return event;
+
       case HarnessEventType.TOOL_RESPONSE:
-        // Stream only — durable model/tool content lands via AGENT_CONTEXT_APPEND.output.
+        await this.store.appendToEvents({
+          ...scope,
+          events: [event],
+        });
         return event;
 
       case InternalEventType.AGENT_CREATE_SUBAGENT:

--- a/packages/harness/src/core/runtime/AgentThread.ts
+++ b/packages/harness/src/core/runtime/AgentThread.ts
@@ -212,30 +212,6 @@ function buildSandboxCreatedEvent(info: SandboxInfo): SandboxCreatedEvent {
   };
 }
 
-/** Persistable tool.response events for orchestrator LLMToolMessages in a send() context batch. */
-function toolResponseEventsFromContextMessages(
-  threadId: string,
-  contextMessages: (LLMUserMessage | LLMToolMessage)[],
-): ToolResponseEvent[] {
-  const output: ToolResponseEvent[] = [];
-  for (const m of contextMessages) {
-    if (m.role !== 'tool') {
-      continue;
-    }
-    output.push({
-      type: EventType.TOOL_RESPONSE,
-      id: newEventId(),
-      created_at: new Date().toISOString(),
-      thread_id: threadId,
-      tool_call_id: m.tool_call_id,
-      // Empty on purpose: matches the streamed sub-agent close event. Real result lives in
-      // LLM context (send_to_parent.content) and thread.done output, not this closer.
-      content: '',
-    });
-  }
-  return output;
-}
-
 function buildModelMessageEvent({
   assistantMessage,
   threadId,
@@ -651,10 +627,9 @@ export class AgentThread {
         });
       }
       if (contextMessages.length > 0) {
-        // Orchestrator-only LLMToolMessages (sub-agent completion): persist tool.response for listEvents.
         yield* this.appendToContext({
           context: contextMessages,
-          output: toolResponseEventsFromContextMessages(this.threadId, contextMessages),
+          output: [],
         });
       }
     } finally {

--- a/packages/harness/src/core/runtime/AgentThread.ts
+++ b/packages/harness/src/core/runtime/AgentThread.ts
@@ -1202,9 +1202,10 @@ export class AgentThread {
     for (const msg of agentToolMessages) {
       yield msg;
     }
+    // tool.response is persisted by the session/response layer when yielded; only mutate context here.
     yield* this.appendToContext({
       context: toolCallResults.map(t => t.message),
-      output: agentToolMessages,
+      output: [],
     });
 
     if (authRequirementInfo.length > 0) {

--- a/packages/harness/src/core/runtime/AgentThread.ts
+++ b/packages/harness/src/core/runtime/AgentThread.ts
@@ -212,6 +212,30 @@ function buildSandboxCreatedEvent(info: SandboxInfo): SandboxCreatedEvent {
   };
 }
 
+/** Persistable tool.response events for orchestrator LLMToolMessages in a send() context batch. */
+function toolResponseEventsFromContextMessages(
+  threadId: string,
+  contextMessages: (LLMUserMessage | LLMToolMessage)[],
+): ToolResponseEvent[] {
+  const output: ToolResponseEvent[] = [];
+  for (const m of contextMessages) {
+    if (m.role !== 'tool') {
+      continue;
+    }
+    output.push({
+      type: EventType.TOOL_RESPONSE,
+      id: newEventId(),
+      created_at: new Date().toISOString(),
+      thread_id: threadId,
+      tool_call_id: m.tool_call_id,
+      // Empty on purpose: matches the streamed sub-agent close event. Real result lives in
+      // LLM context (send_to_parent.content) and thread.done output, not this closer.
+      content: '',
+    });
+  }
+  return output;
+}
+
 function buildModelMessageEvent({
   assistantMessage,
   threadId,
@@ -627,7 +651,11 @@ export class AgentThread {
         });
       }
       if (contextMessages.length > 0) {
-        yield* this.appendToContext({ context: contextMessages, output: [] });
+        // Orchestrator-only LLMToolMessages (sub-agent completion): persist tool.response for listEvents.
+        yield* this.appendToContext({
+          context: contextMessages,
+          output: toolResponseEventsFromContextMessages(this.threadId, contextMessages),
+        });
       }
     } finally {
       this.contextBusy = false;

--- a/packages/harness/src/core/runtime/AgentThreadOrchestrator.ts
+++ b/packages/harness/src/core/runtime/AgentThreadOrchestrator.ts
@@ -342,7 +342,11 @@ export class AgentThreadOrchestrator {
               content: '',
             };
             yield parentToolResponse;
-            yield* this.sendToThread(chunk.parent.thread_id, [chunk.send_to_parent]);
+            const parentEvents = parentThread.send([chunk.send_to_parent]);
+            for await (const event of parentEvents) {
+              const includesSendToParent = event.context.includes(chunk.send_to_parent);
+              yield includesSendToParent ? { ...event, output: [parentToolResponse] } : event;
+            }
           }
           yield chunk;
           this.agentThreads.delete(chunk.thread_id);

--- a/packages/harness/src/core/runtime/AgentThreadOrchestrator.ts
+++ b/packages/harness/src/core/runtime/AgentThreadOrchestrator.ts
@@ -342,11 +342,7 @@ export class AgentThreadOrchestrator {
               content: '',
             };
             yield parentToolResponse;
-            const parentEvents = parentThread.send([chunk.send_to_parent]);
-            for await (const event of parentEvents) {
-              const includesSendToParent = event.context.includes(chunk.send_to_parent);
-              yield includesSendToParent ? { ...event, output: [parentToolResponse] } : event;
-            }
+            yield* this.sendToThread(chunk.parent.thread_id, [chunk.send_to_parent]);
           }
           yield chunk;
           this.agentThreads.delete(chunk.thread_id);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes turn event persistence and context-append wiring for all tool calls; incorrect handling could cause missing or duplicate tool.response in replay/API consumers.
> 
> **Overview**
> **`tool.response` events are now written to the turn event store** when they stream out of execution, instead of being treated as stream-only like model deltas. **`AgentThread`** still yields each `tool.response` for live consumers, but **`appendToContext` no longer puts those events in `AGENT_CONTEXT_APPEND.output`**—only the tool-role context rows are appended—so persistence happens once at the session/`TurnHandle` layer.
> 
> Model message / delta handling is split out explicitly: they remain **stream-only**, with durable assistant content still coming from **`AGENT_CONTEXT_APPEND.output`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2906ad9a38f7800485dab9663f25e2f6c3507d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->