### PR TITLE
[DO NOT MERGE] Add get-dcr-registration-url script and update package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "ui:shot": "node ui-shots/shot.mjs",
     "ui:clean": "node ui-shots/clean.mjs",
     "pack:dry": "pnpm --filter @truefoundry/utils pack:dry",
+    "get-dcr-registration-url": "pnpm --filter @truefoundry/utils get-dcr-registration-url",
+    "mcp-oauth-client": "pnpm --filter @truefoundry/utils mcp-oauth-client",
     "postinstall": "pnpm --filter @truefoundry/utils build:gen",
     "prepare": "husky || true"
   },

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -57,7 +57,9 @@
     "build:check": "node scripts/check-dist.mjs",
     "typecheck": "pnpm run build:gen && tsc --noEmit",
     "test": "pnpm run build:gen && jest --config jest.config.cjs",
-    "pack:dry": "cd dist && pnpm pack --dry-run"
+    "pack:dry": "cd dist && pnpm pack --dry-run",
+    "get-dcr-registration-url": "tsx scripts/get-dcr-registration-url.ts",
+    "mcp-oauth-client": "tsx scripts/mcp-oauth-client.ts"
   },
   "dependencies": {
     "@daytona/sdk": "^0.190.0",
@@ -87,6 +89,7 @@
     "esbuild-plugin-file-path-extensions": "^2.1.4",
     "jest": "^29.7.0",
     "tsup": "^8.5.0",
+    "tsx": "^4.23.1",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/harness/scripts/get-dcr-registration-url.ts
+++ b/packages/harness/scripts/get-dcr-registration-url.ts
@@ -1,0 +1,102 @@
+import {
+  discoverOAuthServerInfo,
+  extractWWWAuthenticateParams,
+  registerClient,
+  startAuthorization,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import { randomBytes } from 'node:crypto';
+
+const REDIRECT_URL = 'http://localhost:8080/callback';
+
+/** Probe the MCP endpoint unauthenticated to get WWW-Authenticate (resource_metadata, scope). */
+async function probeMcpChallenge(mcpUrl: string): Promise<{
+  resourceMetadataUrl: URL | undefined;
+  scope: string | undefined;
+}> {
+  const response = await fetch(mcpUrl, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json, text/event-stream',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'harness-dcr-sample', version: '0.0.0' },
+      },
+    }),
+  });
+
+  const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
+  console.log('challenge_status:', response.status);
+  console.log('challenge_resource_metadata:', resourceMetadataUrl?.toString() ?? '(none)');
+  console.log('challenge_scope:', scope ?? '(none)');
+  return { resourceMetadataUrl, scope };
+}
+
+async function main(): Promise<void> {
+  const mcpUrl = process.argv[2];
+  if (!mcpUrl) {
+    console.error('Usage: pnpm get-dcr-registration-url <mcp-server-url>');
+    process.exit(1);
+  }
+
+  const { resourceMetadataUrl, scope: challengeScope } = await probeMcpChallenge(mcpUrl);
+
+  const { authorizationServerUrl, authorizationServerMetadata, resourceMetadata } = await discoverOAuthServerInfo(
+    mcpUrl,
+    { resourceMetadataUrl },
+  );
+  const registrationEndpoint = authorizationServerMetadata?.registration_endpoint;
+  if (!registrationEndpoint) {
+    console.error('No registration_endpoint found for', mcpUrl);
+    process.exit(1);
+  }
+
+  // SEP-835: WWW-Authenticate scope → PRM scopes_supported → AS scopes_supported
+  const scopesSupported = resourceMetadata?.scopes_supported ?? authorizationServerMetadata?.scopes_supported ?? [];
+  const scope = challengeScope ?? (scopesSupported.length > 0 ? scopesSupported.join(' ') : undefined);
+  const state = randomBytes(32).toString('hex');
+  const resource = resourceMetadata?.resource ? new URL(resourceMetadata.resource) : new URL(mcpUrl);
+
+  console.log('registration_endpoint:', registrationEndpoint);
+  console.log('scopes_supported:', scopesSupported.length > 0 ? scopesSupported.join(', ') : '(none)');
+  console.log('resolved_scope:', scope ?? '(none)');
+
+  const client = await registerClient(authorizationServerUrl, {
+    metadata: authorizationServerMetadata,
+    clientMetadata: {
+      client_name: 'harness-dcr-sample',
+      redirect_uris: [REDIRECT_URL],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      ...(scope !== undefined ? { scope } : {}),
+    },
+  });
+
+  console.log('registered client:');
+  console.log(JSON.stringify(client, null, 2));
+
+  const { authorizationUrl, codeVerifier } = await startAuthorization(authorizationServerUrl, {
+    metadata: authorizationServerMetadata,
+    clientInformation: client,
+    redirectUrl: REDIRECT_URL,
+    resource,
+    scope,
+    state,
+  });
+
+  console.log('authorization_url:', authorizationUrl.toString());
+  console.log('code_verifier:', codeVerifier);
+  console.log('state:', state);
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/packages/harness/scripts/mcp-oauth-client.ts
+++ b/packages/harness/scripts/mcp-oauth-client.ts
@@ -1,0 +1,139 @@
+import {
+  UnauthorizedError,
+  type OAuthClientProvider,
+  type OAuthDiscoveryState,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type {
+  OAuthClientInformationMixed,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import { randomBytes } from 'node:crypto';
+
+const REDIRECT_URL = 'http://localhost:8080/callback';
+
+/** Minimal in-memory provider — same shape as the SDK example / default DCR client. */
+class InMemoryOAuthClientProvider implements OAuthClientProvider {
+  private _clientInformation: OAuthClientInformationMixed | undefined;
+  private _tokens: OAuthTokens | undefined;
+  private _codeVerifier: string | undefined;
+  private _discoveryState: OAuthDiscoveryState | undefined;
+
+  constructor(
+    private readonly _redirectUrl: string,
+    private readonly _clientMetadata: OAuthClientMetadata,
+    private readonly onRedirect: (url: URL) => void,
+  ) {}
+
+  get redirectUrl(): string {
+    return this._redirectUrl;
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return this._clientMetadata;
+  }
+
+  state(): string {
+    return randomBytes(32).toString('hex');
+  }
+
+  clientInformation(): OAuthClientInformationMixed | undefined {
+    return this._clientInformation;
+  }
+
+  saveClientInformation(info: OAuthClientInformationMixed): void {
+    this._clientInformation = info;
+    console.log('registered client:');
+    console.log(JSON.stringify(info, null, 2));
+  }
+
+  tokens(): OAuthTokens | undefined {
+    return this._tokens;
+  }
+
+  saveTokens(tokens: OAuthTokens): void {
+    this._tokens = tokens;
+  }
+
+  redirectToAuthorization(url: URL): void {
+    this.onRedirect(url);
+  }
+
+  saveCodeVerifier(verifier: string): void {
+    this._codeVerifier = verifier;
+  }
+
+  codeVerifier(): string {
+    if (!this._codeVerifier) {
+      throw new Error('No code verifier saved');
+    }
+    return this._codeVerifier;
+  }
+
+  saveDiscoveryState(state: OAuthDiscoveryState): void {
+    this._discoveryState = state;
+    const metadata = state.authorizationServerMetadata;
+    const scopes = state.resourceMetadata?.scopes_supported ?? metadata?.scopes_supported ?? [];
+
+    console.log('authorization_server:', state.authorizationServerUrl);
+    console.log('resource_metadata_url:', state.resourceMetadataUrl ?? '(none)');
+    console.log('resource:', state.resourceMetadata?.resource ?? '(none)');
+    console.log('registration_endpoint:', metadata?.registration_endpoint ?? '(none)');
+    console.log('authorization_endpoint:', metadata?.authorization_endpoint ?? '(none)');
+    console.log('token_endpoint:', metadata?.token_endpoint ?? '(none)');
+    console.log('scopes_supported:', scopes.length > 0 ? scopes.join(', ') : '(none)');
+  }
+
+  discoveryState(): OAuthDiscoveryState | undefined {
+    return this._discoveryState;
+  }
+}
+
+async function main(): Promise<void> {
+  const mcpUrl = process.argv[2];
+  if (!mcpUrl) {
+    console.error('Usage: pnpm mcp-oauth-client <mcp-server-url>');
+    process.exit(1);
+  }
+
+  const authProvider = new InMemoryOAuthClientProvider(
+    REDIRECT_URL,
+    {
+      client_name: 'harness-oauth-sample',
+      redirect_uris: [REDIRECT_URL],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    },
+    url => {
+      console.log('authorization_url:', url.toString());
+    },
+  );
+
+  const client = new Client({ name: 'harness-oauth-sample', version: '0.0.0' });
+  const transport = new StreamableHTTPClientTransport(new URL(mcpUrl), { authProvider });
+
+  try {
+    await client.connect(transport);
+    console.log('already authorized');
+  } catch (error) {
+    if (!(error instanceof UnauthorizedError)) {
+      throw error;
+    }
+    // discovery / registration / authorization_url already printed via provider hooks
+  }
+
+  console.log('client_id:', authProvider.clientInformation()?.client_id);
+  try {
+    console.log('code_verifier:', authProvider.codeVerifier());
+  } catch {
+    // verifier only exists after startAuthorization ran
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@swc/core@1.15.46)(jiti@1.21.7)(postcss@8.5.22)(supports-color@8.1.1)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^7.0.2
         version: 7.0.2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Developer-only scripts and package.json wiring; no production auth paths or runtime behavior changes.
> 
> **Overview**
> Adds **two dev-only CLI scripts** in `@truefoundry/utils` (harness) for manually exercising MCP OAuth with dynamic client registration, plus root/workspace wiring to run them via `pnpm`.
> 
> **`get-dcr-registration-url`** probes an MCP URL (unauthenticated `initialize`), discovers the authorization server, registers a public OAuth client, and prints registration metadata plus `authorization_url`, `code_verifier`, and `state` for a localhost callback.
> 
> **`mcp-oauth-client`** connects with `StreamableHTTPClientTransport` and an in-memory `OAuthClientProvider`, driving the same discovery/DCR/authorize flow when connect returns `UnauthorizedError`, and logging endpoints and client details.
> 
> Package changes: new `tsx` devDependency and script entries in `packages/harness/package.json`; matching `get-dcr-registration-url` and `mcp-oauth-client` scripts at the workspace root that delegate to the utils package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1b422e34130f764f7e4920ef1e0f4d771d92ef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->