### PR TITLE
Bump version from 0.1.6 to 0.1.7

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truefoundry/utils",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "TrueFoundry agent core and session library",
   "author": "Truefoundry",
   "license": "UNLICENSED",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only change with no runtime or API modifications.
> 
> **Overview**
> Bumps the published **`@truefoundry/utils`** package version in `packages/harness/package.json` from **0.1.6** to **0.1.7**. No code, dependency, or export changes—release metadata only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 840251528244123cb13eea59b6fd296d0150b0b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->