### PR TITLE
Trigger Fern SDK regeneration in CI.

### DIFF
--- a/fern/README.md
+++ b/fern/README.md
@@ -1,0 +1,6 @@
+# Fern
+
+OpenAPI and the TypeScript SDK are generated in CI. Edit server routes, not
+`openapi/openapi.json` or `packages/sdk`.
+
+Bump: 1

--- a/fern/openapi/openapi.json
+++ b/fern/openapi/openapi.json
@@ -2649,22 +2649,24 @@
             }
           },
           {
-            "description": "Inclusive lower bound on `created_at` (ISO-8601).",
+            "description": "Inclusive lower bound on `created_at` (ISO-8601 / RFC 3339).",
             "in": "query",
             "name": "start_timestamp",
             "required": false,
             "schema": {
-              "description": "Inclusive lower bound on `created_at` (ISO-8601).",
+              "description": "Inclusive lower bound on `created_at` (ISO-8601 / RFC 3339).",
+              "format": "date-time",
               "type": "string"
             }
           },
           {
-            "description": "Inclusive upper bound on `created_at` (ISO-8601).",
+            "description": "Inclusive upper bound on `created_at` (ISO-8601 / RFC 3339).",
             "in": "query",
             "name": "end_timestamp",
             "required": false,
             "schema": {
-              "description": "Inclusive upper bound on `created_at` (ISO-8601).",
+              "description": "Inclusive upper bound on `created_at` (ISO-8601 / RFC 3339).",
+              "format": "date-time",
               "type": "string"
             }
           }

--- a/packages/sdk/.fern/metadata.json
+++ b/packages/sdk/.fern/metadata.json
@@ -26,8 +26,8 @@
         "streamType": "web",
         "useDefaultRequestParameterValues": true
     },
-    "originGitCommit": "124289a5430e1855ea5559ea906e0e07e8dfb0e1",
-    "originGitCommitIsDirty": false,
+    "originGitCommit": "3f8a9c36b25d9afae08083043597d641199b100c",
+    "originGitCommitIsDirty": true,
     "invokedBy": "ci",
     "requestedVersion": "0.0.0",
     "ciProvider": "github",

--- a/packages/sdk/src/api/resources/sessions/client/Client.ts
+++ b/packages/sdk/src/api/resources/sessions/client/Client.ts
@@ -57,8 +57,8 @@ export class SessionsClient {
                               })
                             : undefined,
                     page_token: pageToken,
-                    start_timestamp: startTimestamp,
-                    end_timestamp: endTimestamp,
+                    start_timestamp: startTimestamp != null ? startTimestamp?.toISOString() : undefined,
+                    end_timestamp: endTimestamp != null ? endTimestamp?.toISOString() : undefined,
                 };
                 const _headers: core.Fetcher.Args["headers"] = mergeHeaders(
                     this._options?.headers,

--- a/packages/sdk/src/api/resources/sessions/client/requests/ListSessionsRequest.ts
+++ b/packages/sdk/src/api/resources/sessions/client/requests/ListSessionsRequest.ts
@@ -13,8 +13,8 @@ export interface ListSessionsRequest {
     order?: TrueHarness.ListSessionsOrder;
     /** Opaque token from a previous response `next_page_token`. */
     pageToken?: string;
-    /** Inclusive lower bound on `created_at` (ISO-8601). */
-    startTimestamp?: string;
-    /** Inclusive upper bound on `created_at` (ISO-8601). */
-    endTimestamp?: string;
+    /** Inclusive lower bound on `created_at` (ISO-8601 / RFC 3339). */
+    startTimestamp?: Date;
+    /** Inclusive upper bound on `created_at` (ISO-8601 / RFC 3339). */
+    endTimestamp?: Date;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> SDK consumers must pass `Date` instead of ISO strings for session list filters—a small breaking change at the client boundary.
> 
> **Overview**
> Adds **`fern/README.md`** explaining that OpenAPI and the TypeScript SDK are produced in CI (edit server routes, not generated artifacts) and includes a **Bump** counter used to trigger regeneration.
> 
> **List sessions** query filters `start_timestamp` and `end_timestamp` are now modeled as **`date-time`** in OpenAPI (RFC 3339 wording). The regenerated SDK exposes them as **`Date`** on `ListSessionsRequest` and serializes them with **`toISOString()`** in the sessions client.
> 
> `packages/sdk` metadata reflects the latest CI Fern run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19670f38812cb32e8309b8a50ebd1c8c97514225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->