### PR TITLE
Improve session store CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm test
 
   # Gate store suites so they do not start unless session-store paths changed.
-  store-changes:
+  agent-session-store-changes:
     name: Detect Session Store Changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -80,8 +80,8 @@ jobs:
 
   postgres-store-tests:
     name: Postgres Session Store Tests
-    needs: store-changes
-    if: needs.store-changes.outputs.store == 'true'
+    needs: agent-session-store-changes
+    if: needs.agent-session-store-changes.outputs.store == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -128,8 +128,8 @@ jobs:
 
   sqlite-store-tests:
     name: SQLite Session Store Tests
-    needs: store-changes
-    if: needs.store-changes.outputs.store == 'true'
+    needs: agent-session-store-changes
+    if: needs.agent-session-store-changes.outputs.store == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,46 @@ jobs:
       - name: Test
         run: pnpm test
 
+  # Gate store suites so they do not start unless session-store paths changed.
+  store-changes:
+    name: Detect Session Store Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      store: ${{ steps.filter.outputs.store }}
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Detect session-store path changes
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            store:
+              - 'packages/server/src/db/**'
+              - 'packages/server/tsup.config.ts'
+              - 'packages/server/tests/db/**'
+              - 'packages/server/jest.store.postgres.config.cjs'
+              - 'packages/server/jest.store.sqlite.config.cjs'
+              - 'packages/server/package.json'
+              - 'packages/harness/src/agent-session/**'
+              - 'packages/harness/tests/agent-session/**'
+              - 'pnpm-workspace.yaml'
+              - '.github/workflows/ci.yml'
+
   postgres-store-tests:
     name: Postgres Session Store Tests
+    needs: store-changes
+    if: needs.store-changes.outputs.store == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
-      pull-requests: read
 
     services:
       postgres:
@@ -73,97 +106,53 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Detect session-store path changes
-        uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            store:
-              - 'packages/server/src/db/**'
-              - 'packages/server/tsup.config.ts'
-              - 'packages/server/tests/**'
-              - 'packages/server/jest.store.postgres.config.cjs'
-              - 'packages/harness/src/agent-session/**'
-              - 'packages/harness/tests/agent-session/**'
-
-      - name: Skip — no session-store changes
-        if: steps.filter.outputs.store != 'true'
-        run: echo "No session-store paths changed; skipping Postgres store tests."
-
       - name: Setup pnpm
-        if: steps.filter.outputs.store == 'true'
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        if: steps.filter.outputs.store == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies
-        if: steps.filter.outputs.store == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        if: steps.filter.outputs.store == 'true'
         run: pnpm build
 
       - name: Postgres session store contract tests
-        if: steps.filter.outputs.store == 'true'
         env:
           SESSION_STORE_TEST_PG_URL: postgres://proto:proto@localhost:55432/proto
         run: pnpm --dir packages/server test:store:postgres
 
   sqlite-store-tests:
     name: SQLite Session Store Tests
+    needs: store-changes
+    if: needs.store-changes.outputs.store == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
-      pull-requests: read
 
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Detect session-store path changes
-        uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            store:
-              - 'packages/server/src/db/**'
-              - 'packages/server/tsup.config.ts'
-              - 'packages/server/tests/**'
-              - 'packages/server/jest.store.sqlite.config.cjs'
-              - 'packages/harness/src/agent-session/**'
-              - 'packages/harness/tests/agent-session/**'
-              - 'pnpm-workspace.yaml'
-
-      - name: Skip — no session-store changes
-        if: steps.filter.outputs.store != 'true'
-        run: echo "No session-store paths changed; skipping SQLite store tests."
-
       - name: Setup pnpm
-        if: steps.filter.outputs.store == 'true'
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        if: steps.filter.outputs.store == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies
-        if: steps.filter.outputs.store == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        if: steps.filter.outputs.store == 'true'
         run: pnpm build
 
       - name: SQLite session store contract tests
-        if: steps.filter.outputs.store == 'true'
         run: pnpm --dir packages/server test:store:sqlite

--- a/packages/harness/src/agent-session/store/AGENTS.md
+++ b/packages/harness/src/agent-session/store/AGENTS.md
@@ -1,0 +1,3 @@
+- `ISessionStore` is the session/turn persistence contract (no streaming/SSE); Postgres, SQLite, and `InMemorySessionStore` MUST implement it, and shared behavior MUST live in `storeContractSuite.ts` (backend wrappers only bind a store).
+- Changing an `ISessionStore` method, input, error, or semantic MUST update the interface, every implementation, and the contract suite in the same change.
+- Path filters for `agent-session-store-changes` in `.github/workflows/ci.yml` MUST stay synchronized when store or contract-test paths are added, moved, or renamed.

--- a/packages/harness/src/agent-session/store/CLAUDE.md
+++ b/packages/harness/src/agent-session/store/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
- Run Postgres/SQLite store contract tests only when session-store paths change
- Skip those jobs entirely on unrelated PRs to avoid unnecessary runners and Postgres startup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only gating and documentation; risk is missing store regressions if path filters drift from real test locations, which the new AGENTS.md explicitly calls out.
> 
> **Overview**
> **CI no longer spins up Postgres/SQLite session store contract jobs on every PR.** A new `agent-session-store-changes` job runs `dorny/paths-filter` once and exports a `store` flag; `postgres-store-tests` and `sqlite-store-tests` `needs` that job and are skipped entirely when `store` is not `true`, replacing per-step `if` checks and in-job “skip” echo steps.
> 
> **Path filters are narrowed and aligned** with store work: e.g. `packages/server/tests/db/**` instead of all of `tests/**`, explicit Jest store configs and `packages/server/package.json`, and `.github/workflows/ci.yml` so workflow edits re-run store suites. `pull-requests: read` is dropped from the store test jobs (only the detector needs it).
> 
> **Harness store docs** add `AGENTS.md` describing `ISessionStore`, contract suite expectations, and the rule that `agent-session-store-changes` paths must stay in sync when store or contract-test locations change; `CLAUDE.md` references that file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6925235929fb26862ba3946c3da41e8a622beded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->