### PR TITLE
feat: integrate resolveMCPAuth  into session and turn APIs

### DIFF
--- a/packages/server/src/apis/turns.ts
+++ b/packages/server/src/apis/turns.ts
@@ -20,6 +20,7 @@ import {
   isFileContentPart,
   McpConnectionError,
   VercelAILLM,
+  type IOAuthTokenStore,
   type SandboxProvider,
   type VercelAIProviderConfig,
 } from '@truefoundry/utils-core/core';
@@ -62,6 +63,7 @@ export interface TurnsRouterDeps {
   activeTurns: ActiveTurnRegistry;
   modelProviderStore: IModelProviderStore;
   mcpServerStore: IMcpServerStore;
+  tokenStore: IOAuthTokenStore;
   skillStore: ISkillStore;
   /** Resumable live turn-event transport: create-turn writes, subscribe polls. */
   eventSubscriptions: EventSubscriptionRegistry<TurnStreamingEvent>;
@@ -76,6 +78,7 @@ export interface TurnsRouterDeps {
  */
 function createTurnResolver(deps: {
   mcpServerStore: IMcpServerStore;
+  tokenStore: IOAuthTokenStore;
   skillStore: ISkillStore;
   sandboxProvider?: SandboxProvider | undefined;
   logger: Logger;
@@ -83,7 +86,7 @@ function createTurnResolver(deps: {
   modelName: string;
   providerConfig: VercelAIProviderConfig;
 }): TurnResourceResolver {
-  const { mcpServerStore, skillStore, logger, signal, modelName, providerConfig } = deps;
+  const { mcpServerStore, tokenStore, skillStore, logger, signal, modelName, providerConfig } = deps;
   const sandboxProvider = deps.sandboxProvider;
   return new TurnResourceResolver({
     llm: name => {
@@ -101,6 +104,8 @@ function createTurnResolver(deps: {
         tenant_id: TENANT_ID,
         name,
         store: mcpServerStore,
+        tokenStore,
+        clientName: configuration.OAUTH_CLIENT_NAME,
       }),
     ...(sandboxProvider
       ? {
@@ -282,6 +287,7 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
     });
     const resolver = createTurnResolver({
       mcpServerStore: deps.mcpServerStore,
+      tokenStore: deps.tokenStore,
       skillStore: deps.skillStore,
       sandboxProvider: deps.sandboxProvider,
       logger: deps.logger,

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -124,6 +124,7 @@ export function createServerApp(deps: ServerDeps) {
       activeTurns: deps.activeTurns,
       modelProviderStore: deps.modelProviderStore,
       mcpServerStore: deps.mcpServerStore,
+      tokenStore: deps.tokenStore,
       skillStore: deps.skillStore,
       eventSubscriptions: deps.eventSubscriptions,
       ...(deps.sandboxProvider ? { sandboxProvider: deps.sandboxProvider } : {}),

--- a/packages/server/src/runtime/dbSessionResources.ts
+++ b/packages/server/src/runtime/dbSessionResources.ts
@@ -2,12 +2,23 @@
  * DB-backed model/MCP/skill resolution for /api/v1/sessions admit and turns.
  */
 import type { AgentSpec } from '@truefoundry/utils-core/agent-session';
-import type { GitSkill, VercelAIProviderConfig } from '@truefoundry/utils-core/core';
+import {
+  isMcpAuthRequired,
+  resolveMcpAuth,
+  type GitSkill,
+  type IOAuthTokenStore,
+  type RemoteMcpHeaders,
+  type VercelAIProviderConfig,
+} from '@truefoundry/utils-core/core';
 import { HTTPException } from 'hono/http-exception';
-import type { IMcpServerStore } from '../db/mcpServerStore';
+import type { IMcpServerStore, McpServerRecord } from '../db/mcpServerStore';
 import type { IModelProviderStore } from '../db/modelProviderStore';
 import type { ISkillStore } from '../db/skillStore';
-import { resolveConfiguredMcpRequestHeaders } from '../schemas/mcpServer';
+
+export interface DbMcpConnection {
+  url: string;
+  headers: RemoteMcpHeaders;
+}
 
 /** Split `provider/model` FQN. Returns undefined when the shape is not exactly one slash. */
 export function parseModelFqn(name: string): { providerName: string; modelName: string } | undefined {
@@ -62,19 +73,52 @@ export async function getDbProviderConfig({
   };
 }
 
+function dcrHeadersResolver(params: {
+  record: McpServerRecord;
+  tokenStore: IOAuthTokenStore;
+  mcpServerStore: IMcpServerStore;
+  clientName: string;
+}): RemoteMcpHeaders {
+  const { record, tokenStore, mcpServerStore, clientName } = params;
+  return async () => {
+    const result = await resolveMcpAuth({
+      tokenStore,
+      mcpServerStore,
+      serverId: record.id,
+      mcpServerUrl: record.manifest.url,
+      mcpServerName: record.name,
+      clientName,
+    });
+    if (isMcpAuthRequired(result)) {
+      // Wire `id` must match RemoteMCP.id (AgentSpec name), not the DB row ULID —
+      // init events, tool-call metadata, and snapshots all key by name.
+      return {
+        authRequired: {
+          servers: [{ id: record.name, name: record.name, auth_url: result.authUrl.href }],
+        },
+      };
+    }
+    return { headers: result.headers };
+  };
+}
+
 /**
- * Load MCP url + request headers for a DB-configured server name.
+ * Load MCP url + OAuth headers resolver for a DB-configured server.
  * Throws HTTPException(400) if the server is not registered.
  */
 export async function getDbMcpConnection({
   tenant_id,
   name,
   store,
+  tokenStore,
+  clientName,
 }: {
   tenant_id: string;
   name: string;
   store: IMcpServerStore;
-}): Promise<{ url: string; headers: Record<string, string> }> {
+  tokenStore: IOAuthTokenStore;
+  clientName: string;
+}): Promise<DbMcpConnection> {
   const record = await store.getServer({ tenant_id, name });
   if (record === undefined) {
     throw new HTTPException(400, {
@@ -83,7 +127,12 @@ export async function getDbMcpConnection({
   }
   return {
     url: record.manifest.url,
-    headers: resolveConfiguredMcpRequestHeaders(record.manifest),
+    headers: dcrHeadersResolver({
+      record,
+      tokenStore,
+      mcpServerStore: store,
+      clientName,
+    }),
   };
 }
 

--- a/packages/server/src/runtime/dbSessionResources.ts
+++ b/packages/server/src/runtime/dbSessionResources.ts
@@ -103,7 +103,8 @@ function dcrHeadersResolver(params: {
 }
 
 /**
- * Load MCP url + OAuth headers resolver for a DB-configured server.
+ * Load MCP url + headers for a DB-configured server.
+ * DCR uses resolveMcpAuth; no-auth servers get empty static headers.
  * Throws HTTPException(400) if the server is not registered.
  */
 export async function getDbMcpConnection({
@@ -125,14 +126,20 @@ export async function getDbMcpConnection({
       message: `Unknown MCP server "${name}" — not configured`,
     });
   }
+  if (record.manifest.auth?.type === 'dcr') {
+    return {
+      url: record.manifest.url,
+      headers: dcrHeadersResolver({
+        record,
+        tokenStore,
+        mcpServerStore: store,
+        clientName,
+      }),
+    };
+  }
   return {
     url: record.manifest.url,
-    headers: dcrHeadersResolver({
-      record,
-      tokenStore,
-      mcpServerStore: store,
-      clientName,
-    }),
+    headers: {},
   };
 }
 

--- a/packages/server/src/schemas/mcpServer.ts
+++ b/packages/server/src/schemas/mcpServer.ts
@@ -3,9 +3,8 @@
  * document, admin/chat list projections, and auth_status. Catalog file schemas
  * live in mcpCatalog.ts.
  *
- * Auth mirrors gateway MCP header/DCR shapes in reduced form: `header` stores
- * shared request headers on the row; `dcr` is the OAuth/DCR stub until real
- * token exchange lands.
+ * Auth: `header` stores shared request headers on the row (settings listTools);
+ * turn execution resolves DCR tokens via resolveMcpAuth.
  */
 import { z } from '@hono/zod-openapi';
 import { isOAuthAccessTokenUsable, type OAuthToken } from '@truefoundry/utils-core/core';
@@ -96,7 +95,8 @@ export type McpServerReadEntry = z.infer<typeof McpServerReadEntrySchema>;
 
 /**
  * Headers for live MCP calls against a configured server.
- * Only `auth.type === 'header'` contributes; DCR uses tokens later.
+ * Only `auth.type === 'header'` contributes. Turn execution uses DCR via
+ * resolveMcpAuth instead of this helper.
  */
 export function resolveConfiguredMcpRequestHeaders(manifest: McpServerManifest): Record<string, string> {
   if (manifest.auth?.type === 'header') {

--- a/packages/server/tests/unit/apis/deletedSessionCrud.test.ts
+++ b/packages/server/tests/unit/apis/deletedSessionCrud.test.ts
@@ -11,6 +11,7 @@ import { SqliteMcpServerStore } from '../../../src/db/sqlite/mcp-server-store/Sq
 import { SqliteModelProviderStore } from '../../../src/db/sqlite/model-provider-store/SqliteModelProviderStore';
 import { SqliteSessionStore } from '../../../src/db/sqlite/session-store/SqliteSessionStore';
 import { SqliteSkillStore } from '../../../src/db/sqlite/skill-store/SqliteSkillStore';
+import { SqliteOAuthTokenStore } from '../../../src/db/sqlite/token-store/SqliteOAuthTokenStore';
 import { ActiveTurnRegistry } from '../../../src/runtime/activeTurns';
 import { EventSubscriptionRegistry } from '../../../src/runtime/event-subscription/index.js';
 import { ListSessionsResponseSchema } from '../../../src/schemas/session';
@@ -24,6 +25,7 @@ describe('public CRUD after session deletion', () => {
     const activeTurns = new ActiveTurnRegistry();
     const modelProviderStore = new SqliteModelProviderStore(db);
     const mcpServerStore = new SqliteMcpServerStore(db);
+    const tokenStore = new SqliteOAuthTokenStore(db);
     const skillStore = new SqliteSkillStore(db);
     const app = new OpenAPIHono();
 
@@ -49,6 +51,7 @@ describe('public CRUD after session deletion', () => {
         activeTurns,
         modelProviderStore,
         mcpServerStore,
+        tokenStore,
         skillStore,
         eventSubscriptions: new EventSubscriptionRegistry(undefined),
         logger: createLogger({ silent: true }),

--- a/packages/server/tests/unit/apis/turnStreamAfterDelete.test.ts
+++ b/packages/server/tests/unit/apis/turnStreamAfterDelete.test.ts
@@ -9,6 +9,7 @@ import { SqliteMcpServerStore } from '../../../src/db/sqlite/mcp-server-store/Sq
 import { SqliteModelProviderStore } from '../../../src/db/sqlite/model-provider-store/SqliteModelProviderStore';
 import { SqliteSessionStore } from '../../../src/db/sqlite/session-store/SqliteSessionStore';
 import { SqliteSkillStore } from '../../../src/db/sqlite/skill-store/SqliteSkillStore';
+import { SqliteOAuthTokenStore } from '../../../src/db/sqlite/token-store/SqliteOAuthTokenStore';
 import { ActiveTurnRegistry } from '../../../src/runtime/activeTurns';
 import { EventSubscriptionRegistry } from '../../../src/runtime/event-subscription/index.js';
 
@@ -64,6 +65,7 @@ describe('turn SSE after session deletion', () => {
         activeTurns: new ActiveTurnRegistry(),
         modelProviderStore,
         mcpServerStore: new SqliteMcpServerStore(db),
+        tokenStore: new SqliteOAuthTokenStore(db),
         skillStore: new SqliteSkillStore(db),
         eventSubscriptions: new EventSubscriptionRegistry(undefined),
         logger,

--- a/packages/server/tests/unit/runtime/getDbMcpConnection.test.ts
+++ b/packages/server/tests/unit/runtime/getDbMcpConnection.test.ts
@@ -138,4 +138,27 @@ describe('getDbMcpConnection', () => {
       headers: { Authorization: 'Bearer live-access' },
     });
   });
+
+  it('returns empty static headers when the server has no auth', async () => {
+    await mcpServerStore.upsertServer({
+      tenant_id: TENANT_ID,
+      name: 'open-mcp',
+      manifest: {
+        type: 'remote',
+        name: 'open-mcp',
+        url: 'https://mcp.open.example/mcp',
+      },
+    });
+
+    const connection = await getDbMcpConnection({
+      tenant_id: TENANT_ID,
+      name: 'open-mcp',
+      store: mcpServerStore,
+      tokenStore,
+      clientName: 'test-client',
+    });
+
+    expect(connection.url).toBe('https://mcp.open.example/mcp');
+    expect(connection.headers).toEqual({});
+  });
 });

--- a/packages/server/tests/unit/runtime/getDbMcpConnection.test.ts
+++ b/packages/server/tests/unit/runtime/getDbMcpConnection.test.ts
@@ -1,0 +1,141 @@
+import { TENANT_ID } from '../../../src/apis/sessions';
+import { migrateSqliteToLatest } from '../../../src/db/migrateSqlite';
+import { createSqliteDb } from '../../../src/db/sqlite/client';
+import { SqliteMcpServerStore } from '../../../src/db/sqlite/mcp-server-store/SqliteMcpServerStore';
+import { SqliteOAuthTokenStore } from '../../../src/db/sqlite/token-store/SqliteOAuthTokenStore';
+import { getDbMcpConnection } from '../../../src/runtime/dbSessionResources';
+
+describe('getDbMcpConnection', () => {
+  let mcpServerStore: SqliteMcpServerStore;
+  let tokenStore: SqliteOAuthTokenStore;
+
+  beforeAll(async () => {
+    const db = createSqliteDb(':memory:');
+    await migrateSqliteToLatest(db);
+    mcpServerStore = new SqliteMcpServerStore(db);
+    tokenStore = new SqliteOAuthTokenStore(db);
+  });
+
+  it('returns an async DCR headers resolver keyed by server name on authRequired', async () => {
+    const asOrigin = 'https://auth.example.com';
+    const mcpUrl = 'https://mcp.oauth.example/sse';
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+      if (url.includes('oauth-protected-resource')) {
+        return new Response(JSON.stringify({ resource: mcpUrl, authorization_servers: [asOrigin] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('oauth-authorization-server') || url.includes('openid-configuration')) {
+        return new Response(
+          JSON.stringify({
+            issuer: asOrigin,
+            authorization_endpoint: `${asOrigin}/authorize`,
+            token_endpoint: `${asOrigin}/token`,
+            registration_endpoint: `${asOrigin}/register`,
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+            grant_types_supported: ['authorization_code', 'refresh_token'],
+            token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.includes('/register') && init?.method === 'POST') {
+        return new Response(
+          JSON.stringify({
+            client_id: 'dyn-client-1',
+            client_secret: 'dyn-secret-1',
+            token_endpoint_auth_method: 'client_secret_post',
+            redirect_uris: [`${process.env['PUBLIC_BASE_URL'] ?? ''}/api/v1/mcp-servers/oauth/callback`],
+            grant_types: ['authorization_code', 'refresh_token'],
+            response_types: ['code'],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response(`unexpected url: ${url}`, { status: 404 });
+    }) as typeof fetch;
+
+    try {
+      const record = await mcpServerStore.upsertServer({
+        tenant_id: TENANT_ID,
+        name: 'oauth-mcp',
+        manifest: {
+          type: 'remote',
+          name: 'oauth-mcp',
+          url: mcpUrl,
+          auth: { type: 'dcr' },
+        },
+      });
+
+      const connection = await getDbMcpConnection({
+        tenant_id: TENANT_ID,
+        name: 'oauth-mcp',
+        store: mcpServerStore,
+        tokenStore,
+        clientName: 'test-client',
+      });
+
+      expect(connection.url).toBe(mcpUrl);
+      expect(typeof connection.headers).toBe('function');
+      if (typeof connection.headers !== 'function') {
+        throw new Error('expected async headers resolver');
+      }
+
+      const headersResult = await connection.headers();
+      expect('authRequired' in headersResult).toBe(true);
+      if (!('authRequired' in headersResult)) {
+        throw new Error('expected authRequired');
+      }
+      expect(headersResult.authRequired.servers).toEqual([
+        {
+          id: 'oauth-mcp',
+          name: 'oauth-mcp',
+          auth_url: expect.stringContaining(`${asOrigin}/authorize`),
+        },
+      ]);
+      expect(record.id).not.toBe('oauth-mcp');
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it('returns Bearer headers when a usable token is already stored', async () => {
+    const record = await mcpServerStore.upsertServer({
+      tenant_id: TENANT_ID,
+      name: 'tokened-mcp',
+      manifest: {
+        type: 'remote',
+        name: 'tokened-mcp',
+        url: 'https://mcp.tokened.example/mcp',
+        auth: { type: 'dcr' },
+      },
+    });
+    await tokenStore.saveToken({
+      id: record.id,
+      token: {
+        accessToken: 'live-access',
+        refreshToken: null,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        scope: null,
+      },
+    });
+
+    const connection = await getDbMcpConnection({
+      tenant_id: TENANT_ID,
+      name: 'tokened-mcp',
+      store: mcpServerStore,
+      tokenStore,
+      clientName: 'test-client',
+    });
+    if (typeof connection.headers !== 'function') {
+      throw new Error('expected async headers resolver');
+    }
+    await expect(connection.headers()).resolves.toEqual({
+      headers: { Authorization: 'Bearer live-access' },
+    });
+  });
+});


### PR DESCRIPTION
…

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth/token handling on the turn MCP path and alters header-auth behavior during turns (empty headers unless DCR), which can break header-authenticated MCP tools in sessions.
> 
> **Overview**
> Turn execution now wires **`IOAuthTokenStore`** into MCP resolution so DCR-configured servers get tokens (or an **`authRequired`** payload with authorize URLs) through **`resolveMcpAuth`**, instead of static header maps on the connection.
> 
> **`getDbMcpConnection`** returns an async header resolver for **`auth.type === 'dcr'`** (Bearer when a stored token is usable; **`authRequired.servers`** keyed by configured **name**, not DB id). Servers without DCR now expose **empty static headers** at turn time—header auth is no longer merged here (settings **`listTools`** still uses **`resolveConfiguredMcpRequestHeaders`**). The turns router and app wiring pass **`tokenStore`** and **`OAUTH_CLIENT_NAME`**; unit tests cover DCR, stored token, and no-auth cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc061d1cf753b063b4829ad2267560ac7c4a05e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->