### PR TITLE
feat: enhance getDbMcpConnection to support configured static headers…

### DIFF
--- a/packages/server/src/runtime/dbSessionResources.ts
+++ b/packages/server/src/runtime/dbSessionResources.ts
@@ -14,6 +14,7 @@ import { HTTPException } from 'hono/http-exception';
 import type { IMcpServerStore, McpServerRecord } from '../db/mcpServerStore';
 import type { IModelProviderStore } from '../db/modelProviderStore';
 import type { ISkillStore } from '../db/skillStore';
+import { resolveConfiguredMcpRequestHeaders } from '../schemas/mcpServer';
 
 export interface DbMcpConnection {
   url: string;
@@ -104,7 +105,7 @@ function dcrHeadersResolver(params: {
 
 /**
  * Load MCP url + headers for a DB-configured server.
- * DCR uses resolveMcpAuth; no-auth servers get empty static headers.
+ * DCR uses resolveMcpAuth; header / no-auth use resolveConfiguredMcpRequestHeaders.
  * Throws HTTPException(400) if the server is not registered.
  */
 export async function getDbMcpConnection({
@@ -139,7 +140,7 @@ export async function getDbMcpConnection({
   }
   return {
     url: record.manifest.url,
-    headers: {},
+    headers: resolveConfiguredMcpRequestHeaders(record.manifest),
   };
 }
 

--- a/packages/server/tests/unit/runtime/getDbMcpConnection.test.ts
+++ b/packages/server/tests/unit/runtime/getDbMcpConnection.test.ts
@@ -161,4 +161,28 @@ describe('getDbMcpConnection', () => {
     expect(connection.url).toBe('https://mcp.open.example/mcp');
     expect(connection.headers).toEqual({});
   });
+
+  it('returns configured static headers for header-auth servers', async () => {
+    await mcpServerStore.upsertServer({
+      tenant_id: TENANT_ID,
+      name: 'header-mcp',
+      manifest: {
+        type: 'remote',
+        name: 'header-mcp',
+        url: 'https://mcp.header.example/mcp',
+        auth: { type: 'header', headers: { Authorization: 'Bearer static-token' } },
+      },
+    });
+
+    const connection = await getDbMcpConnection({
+      tenant_id: TENANT_ID,
+      name: 'header-mcp',
+      store: mcpServerStore,
+      tokenStore,
+      clientName: 'test-client',
+    });
+
+    expect(connection.url).toBe('https://mcp.header.example/mcp');
+    expect(connection.headers).toEqual({ Authorization: 'Bearer static-token' });
+  });
 });


### PR DESCRIPTION
… for header-auth servers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix that reuses existing header resolution; DCR flow unchanged. Slightly increases exposure of stored static tokens on outbound MCP calls, which is intended for header-auth servers.
> 
> **Overview**
> **Fixes missing auth on DB-backed MCP connections** for non-DCR servers during agent sessions. `getDbMcpConnection` no longer always returns empty headers for servers that are not DCR; it now uses `resolveConfiguredMcpRequestHeaders` on the manifest, matching how configured MCP servers are wired elsewhere (e.g. list-tools).
> 
> **Header-auth servers** get their configured static headers (e.g. `Authorization: Bearer …`); **no-auth** servers still get `{}`. DCR behavior is unchanged (async resolver via `resolveMcpAuth`).
> 
> A unit test covers the header-auth path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47d4e6c86c8975343816bfb78f50b70e306e678c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->