### PR TITLE
Add new remote servers to mcp-catalog.yaml

### DIFF
--- a/packages/server/src/catalog/mcp-catalog.yaml
+++ b/packages/server/src/catalog/mcp-catalog.yaml
@@ -8,5 +8,42 @@ mcp_servers:
     auth:
       type: dcr
   - type: remote
+    name: notion
+    url: https://mcp.notion.com/mcp
+    auth:
+      type: dcr
+  - type: remote
+    name: sentry
+    url: https://mcp.sentry.dev/mcp
+    auth:
+      type: dcr
+  - type: remote
     name: deepwiki
     url: https://mcp.deepwiki.com/mcp
+  - type: remote
+    name: exa
+    url: https://mcp.exa.ai/mcp
+  - type: remote
+    name: parallel-web
+    url: https://search.parallel.ai/mcp
+  - type: remote
+    name: github
+    url: https://api.githubcopilot.com/mcp/
+    auth:
+      type: header
+      headers:
+        Authorization: Bearer YOUR_GITHUB_PAT
+  - type: remote
+    name: tavily
+    url: https://mcp.tavily.com/mcp
+    auth:
+      type: header
+      headers:
+        Authorization: Bearer YOUR_TAVILY_API_KEY
+  - type: remote
+    name: bright-data
+    url: https://mcp.brightdata.com/mcp
+    auth:
+      type: header
+      headers:
+        Authorization: Bearer YOUR_BRIGHT_DATA_API_TOKEN


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> YAML-only catalog additions with no execution path or auth logic changes; placeholders are documentation for user-supplied tokens.
> 
> **Overview**
> Expands the **shipped MCP server catalog** (`mcp-catalog.yaml`) so the settings UI can offer more one-click remote presets via `GET /api/v1/settings/mcp-servers/catalog`.
> 
> **New presets:** Notion and Sentry (DCR auth), Exa and Parallel Web (no auth block in YAML), plus GitHub Copilot MCP, Tavily, and Bright Data (header `Authorization` with placeholder bearer tokens users replace when copying into `PUT` bodies).
> 
> No runtime or API behavior changes—catalog remains discovery-only and is inlined at build time like existing entries (e.g. Linear, Deepwiki).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2d44f3457f5f484cfe9906807040a9e69b9cee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->