### PR TITLE
AGE-1583: Add logos in catalog

### DIFF
--- a/fern/openapi/openapi.json
+++ b/fern/openapi/openapi.json
@@ -335,6 +335,11 @@
           "auth": {
             "$ref": "#/components/schemas/ConfiguredMcpServerAuth"
           },
+          "logo": {
+            "description": "URL of the MCP server logo asset.",
+            "format": "uri",
+            "type": "string"
+          },
           "name": {
             "$ref": "#/components/schemas/ResourceName"
           },
@@ -357,6 +362,11 @@
       "CatalogProvider": {
         "additionalProperties": false,
         "properties": {
+          "logo": {
+            "description": "URL of the provider logo asset.",
+            "format": "uri",
+            "type": "string"
+          },
           "models": {
             "items": {
               "$ref": "#/components/schemas/ModelEntry"

--- a/packages/sdk/.fern/metadata.json
+++ b/packages/sdk/.fern/metadata.json
@@ -27,7 +27,7 @@
         "streamType": "web",
         "useDefaultRequestParameterValues": true
     },
-    "originGitCommit": "2fa4d1229e085b8dab98f45717ebd82db9311e5c",
+    "originGitCommit": "7867a963653c80bce32ed8148adf74c3bfbc2314",
     "originGitCommitIsDirty": true,
     "invokedBy": "ci",
     "requestedVersion": "0.0.0",

--- a/packages/sdk/pnpm-lock.yaml
+++ b/packages/sdk/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.1
-        version: 4.1.10(@types/node@20.19.43)(msw@2.11.2(@types/node@20.19.43)(typescript@5.9.3))(vite@8.2.0(@types/node@20.19.43)(terser@5.49.1))
+        version: 4.1.10(@types/node@20.19.43)(msw@2.11.2(@types/node@20.19.43)(typescript@5.9.3))(vite@8.2.0(@types/node@20.19.43)(terser@5.49.2))
       webpack:
         specifier: ^5.105.4
         version: 5.109.2
@@ -159,95 +159,95 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@oxc-project/types@0.142.0':
-    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
-  '@rolldown/binding-android-arm64@1.2.2':
-    resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.2.2':
-    resolution: {integrity: sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==}
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.2.2':
-    resolution: {integrity: sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==}
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.2.2':
-    resolution: {integrity: sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==}
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
-    resolution: {integrity: sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.2':
-    resolution: {integrity: sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.2.2':
-    resolution: {integrity: sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==}
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
-    resolution: {integrity: sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.2':
-    resolution: {integrity: sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.2.2':
-    resolution: {integrity: sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==}
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.2.2':
-    resolution: {integrity: sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==}
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.2.2':
-    resolution: {integrity: sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==}
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.2':
-    resolution: {integrity: sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.2.2':
-    resolution: {integrity: sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==}
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -733,8 +733,8 @@ packages:
   rettime@0.7.0:
     resolution: {integrity: sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==}
 
-  rolldown@1.2.2:
-    resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -797,8 +797,8 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  terser@5.49.1:
-    resolution: {integrity: sha512-7A2xlQ5EnGT8KPA92dUh6RbRYTVw8hEaEN9L1K68l4UOXFuV511NnAqObGoRqGOQofQcMypisu1s3xawCEHrvA==}
+  terser@5.49.2:
+    resolution: {integrity: sha512-rGbJiKeQ4WDe3EXlDAIaQcwftVfv2Q8o1awFNfvXolJYKkb1AuZY1RTOmqx4LJXZENbWZA7eIsYGHuEzHsi1nQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1098,48 +1098,48 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@oxc-project/types@0.142.0': {}
+  '@oxc-project/types@0.143.0': {}
 
-  '@rolldown/binding-android-arm64@1.2.2':
+  '@rolldown/binding-android-arm64@1.2.3':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.2.2':
+  '@rolldown/binding-darwin-arm64@1.2.3':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.2.2':
+  '@rolldown/binding-darwin-x64@1.2.3':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.2.2':
+  '@rolldown/binding-freebsd-x64@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.2':
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.2.2':
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.2':
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.2.2':
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.2.2':
+  '@rolldown/binding-linux-x64-musl@1.2.3':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.2.2':
+  '@rolldown/binding-openharmony-arm64@1.2.3':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.2':
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.2.2':
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -1174,14 +1174,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(msw@2.11.2(@types/node@20.19.43)(typescript@5.9.3))(vite@8.2.0(@types/node@20.19.43)(terser@5.49.1))':
+  '@vitest/mocker@4.1.10(msw@2.11.2(@types/node@20.19.43)(typescript@5.9.3))(vite@8.2.0(@types/node@20.19.43)(terser@5.49.2))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.11.2(@types/node@20.19.43)(typescript@5.9.3)
-      vite: 8.2.0(@types/node@20.19.43)(terser@5.49.1)
+      vite: 8.2.0(@types/node@20.19.43)(terser@5.49.2)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -1487,7 +1487,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.49.1
+      terser: 5.49.2
       webpack: 5.109.2
 
   msw@2.11.2(@types/node@20.19.43)(typescript@5.9.3):
@@ -1548,25 +1548,25 @@ snapshots:
 
   rettime@0.7.0: {}
 
-  rolldown@1.2.2:
+  rolldown@1.2.3:
     dependencies:
-      '@oxc-project/types': 0.142.0
+      '@oxc-project/types': 0.143.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.2.2
-      '@rolldown/binding-darwin-arm64': 1.2.2
-      '@rolldown/binding-darwin-x64': 1.2.2
-      '@rolldown/binding-freebsd-x64': 1.2.2
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.2
-      '@rolldown/binding-linux-arm64-gnu': 1.2.2
-      '@rolldown/binding-linux-arm64-musl': 1.2.2
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.2
-      '@rolldown/binding-linux-s390x-gnu': 1.2.2
-      '@rolldown/binding-linux-x64-gnu': 1.2.2
-      '@rolldown/binding-linux-x64-musl': 1.2.2
-      '@rolldown/binding-openharmony-arm64': 1.2.2
-      '@rolldown/binding-win32-arm64-msvc': 1.2.2
-      '@rolldown/binding-win32-x64-msvc': 1.2.2
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
 
   schema-utils@4.3.3:
     dependencies:
@@ -1618,7 +1618,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser@5.49.1:
+  terser@5.49.2:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.18.0
@@ -1666,22 +1666,22 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite@8.2.0(@types/node@20.19.43)(terser@5.49.1):
+  vite@8.2.0(@types/node@20.19.43)(terser@5.49.2):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
       postcss: 8.5.25
-      rolldown: 1.2.2
+      rolldown: 1.2.3
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 20.19.43
       fsevents: 2.3.3
-      terser: 5.49.1
+      terser: 5.49.2
 
-  vitest@4.1.10(@types/node@20.19.43)(msw@2.11.2(@types/node@20.19.43)(typescript@5.9.3))(vite@8.2.0(@types/node@20.19.43)(terser@5.49.1)):
+  vitest@4.1.10(@types/node@20.19.43)(msw@2.11.2(@types/node@20.19.43)(typescript@5.9.3))(vite@8.2.0(@types/node@20.19.43)(terser@5.49.2)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.11.2(@types/node@20.19.43)(typescript@5.9.3))(vite@8.2.0(@types/node@20.19.43)(terser@5.49.1))
+      '@vitest/mocker': 4.1.10(msw@2.11.2(@types/node@20.19.43)(typescript@5.9.3))(vite@8.2.0(@types/node@20.19.43)(terser@5.49.2))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -1698,7 +1698,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.0(@types/node@20.19.43)(terser@5.49.1)
+      vite: 8.2.0(@types/node@20.19.43)(terser@5.49.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.43

--- a/packages/sdk/src/api/types/CatalogMcpServer.ts
+++ b/packages/sdk/src/api/types/CatalogMcpServer.ts
@@ -4,6 +4,8 @@ import type * as TrueHarness from "../index.js";
 
 export interface CatalogMcpServer {
     auth?: TrueHarness.ConfiguredMcpServerAuth;
+    /** URL of the MCP server logo asset. */
+    logo?: string;
     name: TrueHarness.ResourceName;
     type: TrueHarness.McpServerType;
     /** URL of the remote MCP server. */

--- a/packages/sdk/src/api/types/CatalogProvider.ts
+++ b/packages/sdk/src/api/types/CatalogProvider.ts
@@ -3,6 +3,8 @@
 import type * as TrueHarness from "../index.js";
 
 export interface CatalogProvider {
+    /** URL of the provider logo asset. */
+    logo?: string;
     models: TrueHarness.ModelEntry[];
     name: TrueHarness.ResourceName;
     type: TrueHarness.CatalogProviderType;

--- a/packages/sdk/src/serialization/types/CatalogMcpServer.ts
+++ b/packages/sdk/src/serialization/types/CatalogMcpServer.ts
@@ -12,6 +12,7 @@ export const CatalogMcpServer: core.serialization.ObjectSchema<
     TrueHarness.CatalogMcpServer
 > = core.serialization.object({
     auth: ConfiguredMcpServerAuth.optional(),
+    logo: core.serialization.string().optional(),
     name: ResourceName,
     type: McpServerType,
     url: core.serialization.string(),
@@ -20,6 +21,7 @@ export const CatalogMcpServer: core.serialization.ObjectSchema<
 export declare namespace CatalogMcpServer {
     export interface Raw {
         auth?: ConfiguredMcpServerAuth.Raw | null;
+        logo?: string | null;
         name: ResourceName.Raw;
         type: McpServerType.Raw;
         url: string;

--- a/packages/sdk/src/serialization/types/CatalogProvider.ts
+++ b/packages/sdk/src/serialization/types/CatalogProvider.ts
@@ -11,6 +11,7 @@ export const CatalogProvider: core.serialization.ObjectSchema<
     serializers.CatalogProvider.Raw,
     TrueHarness.CatalogProvider
 > = core.serialization.object({
+    logo: core.serialization.string().optional(),
     models: core.serialization.list(ModelEntry),
     name: ResourceName,
     type: CatalogProviderType,
@@ -18,6 +19,7 @@ export const CatalogProvider: core.serialization.ObjectSchema<
 
 export declare namespace CatalogProvider {
     export interface Raw {
+        logo?: string | null;
         models: ModelEntry.Raw[];
         name: ResourceName.Raw;
         type: CatalogProviderType.Raw;

--- a/packages/sdk/tests/wire/settings/mcpServers.test.ts
+++ b/packages/sdk/tests/wire/settings/mcpServers.test.ts
@@ -117,7 +117,9 @@ describe("McpServersClient", () => {
         const server = mockServerPool.createServer();
         const client = new TrueHarness({ maxRetries: 0, baseUrl: server.baseUrl });
 
-        const rawResponseBody = { data: [{ auth: { type: "dcr" }, name: "name", type: "remote", url: "url" }] };
+        const rawResponseBody = {
+            data: [{ auth: { type: "dcr" }, logo: "logo", name: "name", type: "remote", url: "url" }],
+        };
 
         server
             .mockEndpoint()
@@ -134,6 +136,7 @@ describe("McpServersClient", () => {
                     auth: {
                         type: "dcr",
                     },
+                    logo: "logo",
                     name: "name",
                     type: "remote",
                     url: "url",

--- a/packages/sdk/tests/wire/settings/modelProviders.test.ts
+++ b/packages/sdk/tests/wire/settings/modelProviders.test.ts
@@ -163,7 +163,14 @@ describe("ModelProvidersClient", () => {
         const client = new TrueHarness({ maxRetries: 0, baseUrl: server.baseUrl });
 
         const rawResponseBody = {
-            data: [{ models: [{ model_id: "model_id", name: "name", properties: {} }], name: "name", type: "openai" }],
+            data: [
+                {
+                    logo: "logo",
+                    models: [{ model_id: "model_id", name: "name", properties: {} }],
+                    name: "name",
+                    type: "openai",
+                },
+            ],
         };
 
         server
@@ -178,6 +185,7 @@ describe("ModelProvidersClient", () => {
         expect(response).toEqual({
             data: [
                 {
+                    logo: "logo",
                     models: [
                         {
                             modelId: "model_id",

--- a/packages/server/src/catalog/mcp-catalog.yaml
+++ b/packages/server/src/catalog/mcp-catalog.yaml
@@ -4,30 +4,37 @@
 mcp_servers:
   - type: remote
     name: linear
+    logo: https://assets.production.truefoundry.com/linear.svg
     url: https://mcp.linear.app/mcp
     auth:
       type: dcr
   - type: remote
     name: notion
+    logo: https://assets.production.truefoundry.com/notion.svg
     url: https://mcp.notion.com/mcp
     auth:
       type: dcr
   - type: remote
     name: sentry
+    logo: https://assets.production.truefoundry.com/sentry-dark.svg
     url: https://mcp.sentry.dev/mcp
     auth:
       type: dcr
   - type: remote
     name: deepwiki
+    logo: https://assets.production.truefoundry.com/deepwiki.png
     url: https://mcp.deepwiki.com/mcp
   - type: remote
     name: exa
+    logo: https://assets.production.truefoundry.com/exa.svg
     url: https://mcp.exa.ai/mcp
   - type: remote
     name: parallel-web
+    logo: https://assets.production.truefoundry.com/parallel-web.svg
     url: https://search.parallel.ai/mcp
   - type: remote
     name: github
+    logo: https://assets.production.truefoundry.com/github-dark.svg
     url: https://api.githubcopilot.com/mcp/
     auth:
       type: header
@@ -35,6 +42,7 @@ mcp_servers:
         Authorization: Bearer YOUR_GITHUB_PAT
   - type: remote
     name: tavily
+    logo: https://assets.production.truefoundry.com/tavily.svg
     url: https://mcp.tavily.com/mcp
     auth:
       type: header
@@ -42,6 +50,7 @@ mcp_servers:
         Authorization: Bearer YOUR_TAVILY_API_KEY
   - type: remote
     name: bright-data
+    logo: https://assets.production.truefoundry.com/bright-data.png
     url: https://mcp.brightdata.com/mcp
     auth:
       type: header
@@ -49,21 +58,25 @@ mcp_servers:
         Authorization: Bearer YOUR_BRIGHT_DATA_API_TOKEN
   - type: remote
     name: supabase
+    logo: https://assets.production.truefoundry.com/supabase.svg
     url: https://mcp.supabase.com/mcp
     auth:
       type: dcr
   - type: remote
     name: stripe
+    logo: https://assets.production.truefoundry.com/stripe.svg
     url: https://mcp.stripe.com
     auth:
       type: dcr
   - type: remote
     name: confluence
+    logo: https://assets.production.truefoundry.com/confluence.svg
     url: https://mcp.atlassian.com/v1/mcp
     auth:
       type: dcr
   - type: remote
     name: jira
+    logo: https://assets.production.truefoundry.com/jira.png
     url: https://mcp.atlassian.com/v1/mcp
     auth:
       type: dcr

--- a/packages/server/src/catalog/model-catalog.yaml
+++ b/packages/server/src/catalog/model-catalog.yaml
@@ -4,6 +4,7 @@
 providers:
   - type: openai
     name: openai
+    logo: https://assets.production.truefoundry.com/openai.svg
     models:
       - model_id: chat-latest
         name: chat-latest
@@ -307,6 +308,7 @@ providers:
             - max
   - type: anthropic
     name: anthropic
+    logo: https://assets.production.truefoundry.com/anthropic.svg
     models:
       - model_id: claude-fable-5
         name: claude-fable-5
@@ -393,6 +395,7 @@ providers:
           max_output_tokens: 128000
   - type: google-gemini
     name: google-gemini
+    logo: https://assets.production.truefoundry.com/google-gemini.svg
     models:
       - model_id: gemini-2.5-flash-lite
         name: gemini-2-5-flash-lite
@@ -494,6 +497,7 @@ providers:
           context_length: 256000
   - type: fireworks
     name: fireworks
+    logo: https://assets.production.truefoundry.com/fireworks.svg
     models:
       - model_id: accounts/fireworks/models/deepseek-v4-flash
         name: deepseek-v4-flash
@@ -565,6 +569,7 @@ providers:
           context_length: 1048576
   - type: zai
     name: zai
+    logo: https://assets.production.truefoundry.com/zai.svg
     models:
       - model_id: glm-4.5
         name: glm-4-5
@@ -592,6 +597,7 @@ providers:
         properties: {}
   - type: moonshot
     name: moonshot
+    logo: https://assets.production.truefoundry.com/moonshot.png
     models:
       - model_id: kimi-k2.6
         name: kimi-k2-6
@@ -615,6 +621,7 @@ providers:
             - max
   - type: alibaba
     name: alibaba
+    logo: https://assets.production.truefoundry.com/alibaba.png
     models:
       - model_id: deepseek-v3.2
         name: deepseek-v3-2

--- a/packages/server/src/schemas/mcpCatalog.ts
+++ b/packages/server/src/schemas/mcpCatalog.ts
@@ -11,6 +11,7 @@ export const CatalogMcpServerSchema = z
   .object({
     type: McpServerTypeSchema,
     name: NameSchema,
+    logo: z.url().optional().describe('URL of the MCP server logo asset.'),
     url: z.url().describe('URL of the remote MCP server.'),
     auth: McpServerAuthSettingsSchema.optional(),
   })

--- a/packages/server/src/schemas/modelCatalog.ts
+++ b/packages/server/src/schemas/modelCatalog.ts
@@ -11,6 +11,7 @@ export const CatalogProviderSchema = z
   .object({
     type: ProviderTypeSchema.exclude(['custom']),
     name: NameSchema,
+    logo: z.url().optional().describe('URL of the provider logo asset.'),
     models: z.array(ModelEntrySchema).min(1),
   })
   .strict()

--- a/packages/server/tests/unit/apis/modelProviders.test.ts
+++ b/packages/server/tests/unit/apis/modelProviders.test.ts
@@ -136,13 +136,16 @@ describe('catalog presets are configurable', () => {
   // ships must therefore be in the configuration union; five of them once were not.
   it.each(ModelCatalog.load().list())('PUT accepts the $type preset', async preset => {
     const { settingsRouter } = await createRouters();
+    // `logo` is catalog-only discovery metadata — omit it from the configured PUT body.
+    const { logo, ...presetWithoutLogo } = preset;
     const body = {
-      ...preset,
+      ...presetWithoutLogo,
       auth: { api_key: `sk-${preset.name}` },
       // Alibaba is the one catalog type that also needs a base_url: a MaaS host embeds the
       // workspace id, so there is nothing to default to.
       ...(preset.type === 'alibaba' ? { base_url: 'https://ws-x.ap-southeast-1.maas.aliyuncs.com/v1' } : {}),
     };
+    expect(logo === undefined || typeof logo === 'string').toBe(true);
     const response = await settingsRouter.request('/model-providers', putInit(body));
     expect(response.status).toBe(200);
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive, optional catalog metadata with no changes to configured resources or auth flows; incidental SDK lockfile bumps only.
> 
> **Overview**
> Adds an optional **`logo`** field (HTTPS asset URL) to **discovery-only** catalog entries for MCP servers and model providers, so the settings UI can show branding when listing presets from the catalog APIs.
> 
> The change threads through **OpenAPI**, server **Zod** schemas (`CatalogMcpServer` / `CatalogProvider`), shipped **`mcp-catalog.yaml`** and **`model-catalog.yaml`** (TrueFoundry CDN URLs per entry), and the **regenerated TypeScript SDK** plus wire tests. **`logo` is not part of configured PUT bodies**—unit tests explicitly omit it when copying a catalog preset into `PUT /settings/model-providers`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89522f1480aec4c474fabd113d71e46690f33148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->