### PR TITLE
AGE-1545: Add remote servers to mcp-catalog.yaml for Supabase, Stripe, Confluence, and Jira with DCR authentication

### DIFF
--- a/packages/server/src/catalog/mcp-catalog.yaml
+++ b/packages/server/src/catalog/mcp-catalog.yaml
@@ -47,3 +47,23 @@ mcp_servers:
       type: header
       headers:
         Authorization: Bearer YOUR_BRIGHT_DATA_API_TOKEN
+  - type: remote
+    name: supabase
+    url: https://mcp.supabase.com/mcp
+    auth:
+      type: dcr
+  - type: remote
+    name: stripe
+    url: https://mcp.stripe.com
+    auth:
+      type: dcr
+  - type: remote
+    name: confluence
+    url: https://mcp.atlassian.com/v1/mcp
+    auth:
+      type: dcr
+  - type: remote
+    name: jira
+    url: https://mcp.atlassian.com/v1/mcp
+    auth:
+      type: dcr


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> YAML-only catalog additions for UI discovery; no runtime or auth logic changes.
> 
> **Overview**
> Adds **four remote MCP server presets** to the shipped `mcp-catalog.yaml`, so `GET /settings/mcp-servers/catalog` exposes them for the settings UI to copy into user MCP config.
> 
> **Supabase** (`https://mcp.supabase.com/mcp`) and **Stripe** (`https://mcp.stripe.com`) are new vendor endpoints. **Confluence** and **Jira** both point at the shared Atlassian MCP URL (`https://mcp.atlassian.com/v1/mcp`) with distinct catalog names. All four use **`auth.type: dcr`**, matching existing presets like Linear and Notion—no static API keys in the catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7585469d6122e1449ef06c7f2583292884ddb93c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->