### PR TITLE
AGE-1612: add delete route for disconnecting OAuth from configured MCP servers

### DIFF
--- a/fern/openapi/openapi.json
+++ b/fern/openapi/openapi.json
@@ -4356,6 +4356,53 @@
       }
     },
     "/api/v1/settings/mcp-servers/{name}/authorize": {
+      "delete": {
+        "description": "For auth.type dcr, deletes the stored OAuth token and returns the server with auth_status auth_required, keeping the dynamically registered OAuth client so the next authorize can reuse it. No-op for header or no-auth servers (returns the server unchanged).",
+        "parameters": [
+          {
+            "description": "Configured MCP server name.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "Configured MCP server name.",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutMcpServerResponse"
+                }
+              }
+            },
+            "description": "The MCP server after disconnect (auth_required for dcr)."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "MCP server not found."
+          }
+        },
+        "summary": "Disconnect OAuth for a configured MCP server",
+        "tags": [
+          "MCP Servers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "mcpServers"
+        ],
+        "x-fern-sdk-method-name": "delete_authorize"
+      },
       "get": {
         "description": "For servers without auth returns not_required, and for header credentials returns authenticated (no browser flow). For auth.type dcr, returns authenticated when a usable (or refreshable) token exists; otherwise runs DCR if needed and returns auth_required with an authorization URL. Optional redirect_url is where the OAuth callback then redirects the browser; without it the callback returns JSON.",
         "parameters": [

--- a/packages/sdk/.fern/metadata.json
+++ b/packages/sdk/.fern/metadata.json
@@ -27,7 +27,7 @@
         "streamType": "web",
         "useDefaultRequestParameterValues": true
     },
-    "originGitCommit": "7867a963653c80bce32ed8148adf74c3bfbc2314",
+    "originGitCommit": "c499a2b97a1791a40e2ced533b26065c809d364b",
     "originGitCommitIsDirty": true,
     "invokedBy": "ci",
     "requestedVersion": "0.0.0",

--- a/packages/sdk/reference.md
+++ b/packages/sdk/reference.md
@@ -1321,6 +1321,69 @@ await client.settings.mcpServers.authorize("name");
 </dl>
 </details>
 
+<details><summary><code>client.settings.mcpServers.<a href="/src/api/resources/settings/resources/mcpServers/client/Client.ts">deleteAuthorize</a>(name) -> TrueHarness.PutMcpServerResponse</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+For auth.type dcr, deletes the stored OAuth token and returns the server with auth_status auth_required, keeping the dynamically registered OAuth client so the next authorize can reuse it. No-op for header or no-auth servers (returns the server unchanged).
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```typescript
+await client.settings.mcpServers.deleteAuthorize("name");
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**name:** `string` — Configured MCP server name.
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**requestOptions:** `McpServersClient.RequestOptions` 
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
 <details><summary><code>client.settings.mcpServers.<a href="/src/api/resources/settings/resources/mcpServers/client/Client.ts">listTools</a>(name) -> TrueHarness.ListMcpServerToolsResponse</code></summary>
 <dl>
 <dd>

--- a/packages/sdk/src/api/resources/settings/resources/mcpServers/client/Client.ts
+++ b/packages/sdk/src/api/resources/settings/resources/mcpServers/client/Client.ts
@@ -362,6 +362,89 @@ export class McpServersClient {
     }
 
     /**
+     * For auth.type dcr, deletes the stored OAuth token and returns the server with auth_status auth_required, keeping the dynamically registered OAuth client so the next authorize can reuse it. No-op for header or no-auth servers (returns the server unchanged).
+     *
+     * @param {string} name - Configured MCP server name.
+     * @param {McpServersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link TrueHarness.NotFoundError}
+     * @throws {@link errors.TrueHarnessError}
+     * @throws {@link errors.TrueHarnessTimeoutError}
+     *
+     * @example
+     *     await client.settings.mcpServers.deleteAuthorize("name")
+     */
+    public deleteAuthorize(
+        name: string,
+        requestOptions?: McpServersClient.RequestOptions,
+    ): core.HttpResponsePromise<TrueHarness.PutMcpServerResponse> {
+        return core.HttpResponsePromise.fromPromise(this.__deleteAuthorize(name, requestOptions));
+    }
+
+    private async __deleteAuthorize(
+        name: string,
+        requestOptions?: McpServersClient.RequestOptions,
+    ): Promise<core.WithRawResponse<TrueHarness.PutMcpServerResponse>> {
+        const _headers: core.Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, requestOptions?.headers);
+        const _response = await (this._options.fetcher ?? core.fetcher)({
+            url: core.url.join(
+                (await core.Supplier.get(this._options.baseUrl)) ??
+                    (await core.Supplier.get(this._options.environment)),
+                `api/v1/settings/mcp-servers/${core.url.encodePathParam(name)}/authorize`,
+            ),
+            method: "DELETE",
+            headers: _headers,
+            queryString: core.url.queryBuilder().mergeAdditional(requestOptions?.queryParams).build(),
+            timeoutMs: (requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000,
+            maxRetries: requestOptions?.maxRetries ?? this._options?.maxRetries,
+            abortSignal: requestOptions?.abortSignal,
+            fetchFn: this._options?.fetch,
+            logging: this._options.logging,
+        });
+        if (_response.ok) {
+            return {
+                data: serializers.PutMcpServerResponse.parseOrThrow(_response.body, {
+                    unrecognizedObjectKeys: "passthrough",
+                    allowUnrecognizedUnionMembers: true,
+                    allowUnrecognizedEnumValues: true,
+                    skipValidation: true,
+                    breadcrumbsPrefix: ["response"],
+                }),
+                rawResponse: _response.rawResponse,
+            };
+        }
+
+        if (_response.error.reason === "status-code") {
+            switch (_response.error.statusCode) {
+                case 404:
+                    throw new TrueHarness.NotFoundError(
+                        serializers.RequestErrorResponse.parseOrThrow(_response.error.body, {
+                            unrecognizedObjectKeys: "passthrough",
+                            allowUnrecognizedUnionMembers: true,
+                            allowUnrecognizedEnumValues: true,
+                            skipValidation: true,
+                            breadcrumbsPrefix: ["response"],
+                        }),
+                        _response.rawResponse,
+                    );
+                default:
+                    throw new errors.TrueHarnessError({
+                        statusCode: _response.error.statusCode,
+                        body: _response.error.body,
+                        rawResponse: _response.rawResponse,
+                    });
+            }
+        }
+
+        return handleNonStatusCodeError(
+            _response.error,
+            _response.rawResponse,
+            "DELETE",
+            "/api/v1/settings/mcp-servers/{name}/authorize",
+        );
+    }
+
+    /**
      * All tools exposed by the given configured MCP server (non-paginated), as returned by the MCP `tools/list` call.
      *
      * @param {string} name - Configured MCP server name.

--- a/packages/sdk/tests/wire/settings/mcpServers.test.ts
+++ b/packages/sdk/tests/wire/settings/mcpServers.test.ts
@@ -223,6 +223,64 @@ describe("McpServersClient", () => {
         }).rejects.toThrow(TrueHarnessTypes.InternalServerError);
     });
 
+    test("delete_authorize (1)", async () => {
+        const server = mockServerPool.createServer();
+        const client = new TrueHarness({ maxRetries: 0, baseUrl: server.baseUrl });
+
+        const rawResponseBody = {
+            data: {
+                auth: { type: "dcr" },
+                auth_status: { authorization_url: "authorization_url", status: "authenticated" },
+                name: "name",
+                type: "remote",
+                url: "url",
+            },
+        };
+
+        server
+            .mockEndpoint()
+            .delete("/api/v1/settings/mcp-servers/name/authorize")
+            .respondWith()
+            .statusCode(200)
+            .jsonBody(rawResponseBody)
+            .build();
+
+        const response = await client.settings.mcpServers.deleteAuthorize("name");
+        expect(response).toEqual({
+            data: {
+                auth: {
+                    type: "dcr",
+                },
+                authStatus: {
+                    authorizationUrl: "authorization_url",
+                    status: "authenticated",
+                },
+                name: "name",
+                type: "remote",
+                url: "url",
+            },
+        });
+    });
+
+    test("delete_authorize (2)", async () => {
+        const server = mockServerPool.createServer();
+        const client = new TrueHarness({ maxRetries: 0, baseUrl: server.baseUrl });
+
+        const rawResponseBody = { error: { message: "message" } };
+
+        server
+            .mockEndpoint()
+            .delete("/api/v1/settings/mcp-servers/name/authorize")
+            .respondWith()
+            .statusCode(404)
+            .jsonBody(rawResponseBody)
+            .build();
+
+        await expect(async () => {
+            return await client.settings.mcpServers.deleteAuthorize("name");
+        }).rejects.toThrow(TrueHarnessTypes.NotFoundError);
+    });
+
     test("list_tools (1)", async () => {
         const server = mockServerPool.createServer();
         const client = new TrueHarness({ maxRetries: 0, baseUrl: server.baseUrl });

--- a/packages/server/src/apis/mcpServers.ts
+++ b/packages/server/src/apis/mcpServers.ts
@@ -20,6 +20,7 @@ import configuration from '../config';
 import type { IMcpServerStore, McpServerRecord } from '../db/mcpServerStore';
 import {
   authorizeConfiguredMcpServerRoute,
+  deleteConfiguredMcpServerAuthRoute,
   getMcpServerCatalogRoute,
   listAvailableMcpServersRoute,
   listConfiguredMcpServersRoute,
@@ -241,6 +242,20 @@ export function createMcpServersRouter(deps: McpServersRouterDeps) {
     }
   };
 
+  const deleteAuthHandler: RouteHandler<typeof deleteConfiguredMcpServerAuthRoute> = async c => {
+    const { name } = c.req.valid('param');
+    const record = await deps.mcpServerStore.getServer({ tenant_id: TENANT_ID, name });
+    if (!record) {
+      return c.json({ error: { message: `MCP server not found: ${name}` } }, 404);
+    }
+    if (record.manifest.auth?.type !== 'dcr') {
+      return c.json({ error: { message: `Disconnect is only supported for auth.type dcr MCP servers: ${name}` } }, 400);
+    }
+    // Drop the user token only — keep oauth_server / oauth_client so re-authorize can skip DCR.
+    await deps.tokenStore.deleteToken({ id: record.id });
+    return c.json({ data: toConfiguredMcpServer({ record, token: undefined }) }, 200);
+  };
+
   const router = new OpenAPIHono();
   // Static `/catalog` before `/{name}/…` so "catalog" is not captured as a name.
   router.openapi(getMcpServerCatalogRoute, catalogHandler);
@@ -248,6 +263,7 @@ export function createMcpServersRouter(deps: McpServersRouterDeps) {
   router.openapi(putMcpServerRoute, putHandler);
   router.openapi(listMcpServerToolsRoute, listToolsHandler);
   router.openapi(authorizeConfiguredMcpServerRoute, authorizeHandler);
+  router.openapi(deleteConfiguredMcpServerAuthRoute, deleteAuthHandler);
   return router;
 }
 

--- a/packages/server/src/apis/mcpServers.ts
+++ b/packages/server/src/apis/mcpServers.ts
@@ -253,7 +253,7 @@ export function createMcpServersRouter(deps: McpServersRouterDeps) {
     if (record.manifest.auth?.type === 'dcr') {
       await deps.tokenStore.deleteToken({ id: record.id });
     }
-    return c.json({ data: toConfiguredMcpServer({ record }) }, 200);
+    return c.json({ data: toConfiguredMcpServer({ record, token: undefined }) }, 200);
   };
 
   const router = new OpenAPIHono();

--- a/packages/server/src/apis/mcpServers.ts
+++ b/packages/server/src/apis/mcpServers.ts
@@ -248,12 +248,12 @@ export function createMcpServersRouter(deps: McpServersRouterDeps) {
     if (!record) {
       return c.json({ error: { message: `MCP server not found: ${name}` } }, 404);
     }
-    if (record.manifest.auth?.type !== 'dcr') {
-      return c.json({ error: { message: `Disconnect is only supported for auth.type dcr MCP servers: ${name}` } }, 400);
+    // DCR: drop the user token only — keep oauth_server / oauth_client so re-authorize can skip DCR.
+    // Header / no-auth: no-op.
+    if (record.manifest.auth?.type === 'dcr') {
+      await deps.tokenStore.deleteToken({ id: record.id });
     }
-    // Drop the user token only — keep oauth_server / oauth_client so re-authorize can skip DCR.
-    await deps.tokenStore.deleteToken({ id: record.id });
-    return c.json({ data: toConfiguredMcpServer({ record, token: undefined }) }, 200);
+    return c.json({ data: toConfiguredMcpServer({ record }) }, 200);
   };
 
   const router = new OpenAPIHono();

--- a/packages/server/src/routes/mcpServerRoutes.ts
+++ b/packages/server/src/routes/mcpServerRoutes.ts
@@ -184,26 +184,22 @@ export const authorizeConfiguredMcpServerRoute = createRoute({
 
 export const deleteConfiguredMcpServerAuthRoute = createRoute({
   method: 'delete',
-  path: '/{name}/auth',
+  path: '/{name}/authorize',
   tags: [MCP_SERVERS_TAG],
   summary: 'Disconnect OAuth for a configured MCP server',
   'x-fern-sdk-group-name': ['settings', 'mcpServers'],
-  'x-fern-sdk-method-name': 'delete_auth',
+  'x-fern-sdk-method-name': 'delete_authorize',
   description:
-    'Deletes the stored OAuth token for an auth.type dcr MCP server and returns the server with ' +
-    'auth_status auth_required. Keeps the dynamically registered OAuth client so the next authorize ' +
-    'can reuse it. Not supported for header or no-auth servers.',
+    'For auth.type dcr, deletes the stored OAuth token and returns the server with auth_status ' +
+    'auth_required, keeping the dynamically registered OAuth client so the next authorize can reuse it. ' +
+    'No-op for header or no-auth servers (returns the server unchanged).',
   request: {
     params: McpServerNameParamsSchema,
   },
   responses: {
     200: {
       content: { 'application/json': { schema: PutMcpServerResponseSchema } },
-      description: 'The MCP server after disconnect, with auth_status auth_required.',
-    },
-    400: {
-      content: { 'application/json': { schema: RequestErrorResponseSchema } },
-      description: 'MCP server is not auth.type dcr.',
+      description: 'The MCP server after disconnect (auth_required for dcr).',
     },
     404: {
       content: { 'application/json': { schema: RequestErrorResponseSchema } },

--- a/packages/server/src/routes/mcpServerRoutes.ts
+++ b/packages/server/src/routes/mcpServerRoutes.ts
@@ -181,3 +181,33 @@ export const authorizeConfiguredMcpServerRoute = createRoute({
     },
   },
 });
+
+export const deleteConfiguredMcpServerAuthRoute = createRoute({
+  method: 'delete',
+  path: '/{name}/auth',
+  tags: [MCP_SERVERS_TAG],
+  summary: 'Disconnect OAuth for a configured MCP server',
+  'x-fern-sdk-group-name': ['settings', 'mcpServers'],
+  'x-fern-sdk-method-name': 'delete_auth',
+  description:
+    'Deletes the stored OAuth token for an auth.type dcr MCP server and returns the server with ' +
+    'auth_status auth_required. Keeps the dynamically registered OAuth client so the next authorize ' +
+    'can reuse it. Not supported for header or no-auth servers.',
+  request: {
+    params: McpServerNameParamsSchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: PutMcpServerResponseSchema } },
+      description: 'The MCP server after disconnect, with auth_status auth_required.',
+    },
+    400: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'MCP server is not auth.type dcr.',
+    },
+    404: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'MCP server not found.',
+    },
+  },
+});

--- a/packages/server/tests/unit/apis/mcpServers.test.ts
+++ b/packages/server/tests/unit/apis/mcpServers.test.ts
@@ -285,4 +285,71 @@ describe('mcp-servers routers', () => {
       globalThis.fetch = realFetch;
     }
   });
+
+  it('DELETE /{name}/authorize removes the DCR token, keeps the client, and reports auth_required', async () => {
+    await settingsRouter.request('/', putInit(putBodyWithDcr));
+    const record = await mcpServerStore.getServer({ tenant_id: TENANT_ID, name: putBodyWithDcr.name });
+    if (!record) {
+      throw new Error('expected DCR server to exist');
+    }
+
+    await mcpServerStore.saveClient({
+      id: record.id,
+      record: {
+        server: {
+          authorizationEndpoint: 'https://auth.example.com/authorize',
+          tokenEndpoint: 'https://auth.example.com/token',
+          codeChallengeMethodsSupported: ['S256'],
+        },
+        client: {
+          clientId: 'keep-me',
+          clientSecret: 'keep-secret',
+        },
+      },
+    });
+    await tokenStore.saveToken({
+      id: record.id,
+      token: {
+        accessToken: 'access-1',
+        refreshToken: 'refresh-1',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        scope: null,
+      },
+    });
+
+    const response = await settingsRouter.request(`/${putBodyWithDcr.name}/authorize`, { method: 'DELETE' });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      data: { ...putBodyWithDcr, auth_status: { status: 'auth_required' } },
+    });
+    expect(await tokenStore.getToken({ id: record.id })).toBeUndefined();
+    expect(await mcpServerStore.getClient({ id: record.id })).toEqual({
+      server: {
+        authorizationEndpoint: 'https://auth.example.com/authorize',
+        tokenEndpoint: 'https://auth.example.com/token',
+        codeChallengeMethodsSupported: ['S256'],
+      },
+      client: {
+        clientId: 'keep-me',
+        clientSecret: 'keep-secret',
+      },
+    });
+  });
+
+  it('DELETE /{name}/authorize is a no-op for non-DCR servers and 404s unknowns', async () => {
+    const noAuth = await settingsRouter.request('/deepwiki/authorize', { method: 'DELETE' });
+    expect(noAuth.status).toBe(200);
+    expect(await noAuth.json()).toEqual({
+      data: { ...putBody, auth_status: { status: 'not_required' } },
+    });
+
+    const headerAuth = await settingsRouter.request('/private-mcp/authorize', { method: 'DELETE' });
+    expect(headerAuth.status).toBe(200);
+    expect(await headerAuth.json()).toEqual({
+      data: { ...putBodyWithHeaderAuth, auth_status: { status: 'authenticated' } },
+    });
+
+    const missing = await settingsRouter.request('/missing/authorize', { method: 'DELETE' });
+    expect(missing.status).toBe(404);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches OAuth token lifecycle for MCP DCR servers; scope is narrow (delete token only, no client revocation) but auth-related.
> 
> **Overview**
> Adds **`DELETE /api/v1/settings/mcp-servers/{name}/authorize`** so users can disconnect OAuth for a configured MCP server without removing the server itself.
> 
> For **DCR** servers, the handler removes the stored OAuth token via `tokenStore.deleteToken` and returns the server with **`auth_status: auth_required`**, while **keeping** the dynamically registered OAuth client so a later authorize can skip DCR. **Header** and **no-auth** servers are unchanged (no-op, 200). Unknown names return **404**.
> 
> The OpenAPI spec, Fern-generated TypeScript SDK (`deleteAuthorize`), wire tests, and server unit tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e91999b9f6e082876ff5ba190506b6ba7174a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->