### PR TITLE
fix [connector settings]: fix ReferenceError in connector settings

### DIFF
--- a/packages/trueforge-ui-sdk/src/containers/SettingsBuilder/ConnectorSettings.tsx
+++ b/packages/trueforge-ui-sdk/src/containers/SettingsBuilder/ConnectorSettings.tsx
@@ -2,13 +2,13 @@
 
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 
+import { Button } from '@/atoms/primitives/Button.js';
+import { CenteredModal } from '@/atoms/primitives/CenteredModal.js';
+import SearchInput from '@/atoms/primitives/SearchInput.js';
+import { useMCPAuth } from '@/hooks/useMcpAuth.js';
 import { Icon } from '@/icons/Icon.js';
-import { Button } from '../../atoms/primitives/Button.js';
-import { CenteredModal } from '../../atoms/primitives/CenteredModal.js';
-import SearchInput from '../../atoms/primitives/SearchInput.js';
-import { useMCPAuth } from '../../hooks/useMcpAuth.js';
-import { useCatalogServer } from '../../server/ServerContext.js';
-import type { ConnectorAuth, ConnectorBase, ConnectorCatalogEntry } from '../../server/types.js';
+import { useCatalogServer } from '@/server/ServerContext.js';
+import type { ConnectorAuth, ConnectorBase, ConnectorCatalogEntry } from '@/server/types.js';
 import AddMcpServerForm, { type AddMcpServerDraft } from './AddMcpServerForm.js';
 import { AUTH_TYPE_LABELS } from './authTypeLabels.js';
 import ConnectorDetails from './ConnectorDetails.js';
@@ -34,6 +34,7 @@ const ConnectorSettings = () => {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
+  const [catalog, setCatalog] = useState<ConnectorCatalogEntry[]>([]);
   const [addMcpServerFormOpen, setAddMcpServerFormOpen] = useState(false);
   const [connectorAwaitingKey, setConnectorAwaitingKey] = useState<ConnectorCatalogEntry | null>(null);
   const [selectedConnector, setSelectedConnector] = useState<ConnectorBase | null>(null);
@@ -57,6 +58,7 @@ const ConnectorSettings = () => {
         connectorCatalog.listConnectors(),
         connectorCatalog.getConnectorCatalog(),
       ]);
+      setCatalog(available);
       const configured = listed ?? [];
       const seenIds = new Set(configured.map(connector => connector.id));
       const ordered: ConnectorListItem[] = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized UI fix in connector settings with no auth or data-model changes.
> 
> **Overview**
> Fixes a **ReferenceError** on the connector settings screen where `connectorIconMap` depended on `catalog` but no `catalog` state existed.
> 
> Adds `catalog` state (initialized to `[]`), and sets it in `refresh` from the `getConnectorCatalog()` result so connector logos resolve after load. Import paths in this file are switched from relative `../../…` to the `@/` alias for primitives, hooks, and server modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50c900e252ed51a9f1ba3661c9e902b2e3deee40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->