### PR TITLE
add skill disablement reason to capabilities

### DIFF
--- a/fern/openapi/openapi.json
+++ b/fern/openapi/openapi.json
@@ -1014,6 +1014,10 @@
                   "enabled": {
                     "description": "Whether skills are available. False when sandbox is not enabled (skills require a sandbox).",
                     "type": "boolean"
+                  },
+                  "reason": {
+                    "description": "Present when skills are disabled. Explains why.",
+                    "type": "string"
                   }
                 },
                 "required": [

--- a/packages/sdk/.fern/metadata.json
+++ b/packages/sdk/.fern/metadata.json
@@ -27,7 +27,7 @@
         "streamType": "web",
         "useDefaultRequestParameterValues": true
     },
-    "originGitCommit": "bc8937241999f54ac608bc8f77e321eb0180a8fb",
+    "originGitCommit": "38280abf13ab4acc6191e3b327785a0dc319086f",
     "originGitCommitIsDirty": true,
     "invokedBy": "ci",
     "requestedVersion": "0.0.0",

--- a/packages/sdk/reference.md
+++ b/packages/sdk/reference.md
@@ -632,7 +632,7 @@ await client.models.list();
 <dl>
 <dd>
 
-List sessions (newest first by default), token-paginated. Optional `agent_id` filters to sessions bound to that named agent. Pass `page_token` to fetch the next page, keeping the other query params constant.
+List sessions (newest first by default), token-paginated. Optional `agent_id` filters to sessions bound to that named agent; optional `created_by` filters by creator identity. Pass `page_token` to fetch the next page, keeping the other query params constant.
 </dd>
 </dl>
 </dd>

--- a/packages/sdk/src/api/resources/sessions/client/Client.ts
+++ b/packages/sdk/src/api/resources/sessions/client/Client.ts
@@ -24,7 +24,7 @@ export class SessionsClient {
     }
 
     /**
-     * List sessions (newest first by default), token-paginated. Optional `agent_id` filters to sessions bound to that named agent. Pass `page_token` to fetch the next page, keeping the other query params constant.
+     * List sessions (newest first by default), token-paginated. Optional `agent_id` filters to sessions bound to that named agent; optional `created_by` filters by creator identity. Pass `page_token` to fetch the next page, keeping the other query params constant.
      *
      * @param {TrueForge.ListSessionsRequest} request
      * @param {SessionsClient.RequestOptions} requestOptions - Request-specific configuration.
@@ -44,7 +44,7 @@ export class SessionsClient {
             async (
                 request: TrueForge.ListSessionsRequest,
             ): Promise<core.WithRawResponse<TrueForge.ListSessionsResponse>> => {
-                const { limit = 10, order, pageToken, startTimestamp, endTimestamp, agentId } = request;
+                const { limit = 10, order, pageToken, startTimestamp, endTimestamp, agentId, createdBy } = request;
                 const _queryParams: Record<string, unknown> = {
                     limit,
                     order:
@@ -60,6 +60,7 @@ export class SessionsClient {
                     start_timestamp: startTimestamp != null ? startTimestamp?.toISOString() : undefined,
                     end_timestamp: endTimestamp != null ? endTimestamp?.toISOString() : undefined,
                     agent_id: agentId,
+                    created_by: createdBy,
                 };
                 const _headers: core.Fetcher.Args["headers"] = mergeHeaders(
                     this._options?.headers,

--- a/packages/sdk/src/api/resources/sessions/client/requests/ListSessionsRequest.ts
+++ b/packages/sdk/src/api/resources/sessions/client/requests/ListSessionsRequest.ts
@@ -19,4 +19,6 @@ export interface ListSessionsRequest {
     endTimestamp?: Date;
     /** When set, only sessions bound to this agent id are returned. */
     agentId?: string;
+    /** When set, only sessions created by this identity are returned. */
+    createdBy?: string;
 }

--- a/packages/sdk/src/api/types/GetCapabilitiesResponseDataSkill.ts
+++ b/packages/sdk/src/api/types/GetCapabilitiesResponseDataSkill.ts
@@ -3,4 +3,6 @@
 export interface GetCapabilitiesResponseDataSkill {
     /** Whether skills are available. False when sandbox is not enabled (skills require a sandbox). */
     enabled: boolean;
+    /** Present when skills are disabled. Explains why. */
+    reason?: string;
 }

--- a/packages/sdk/src/api/types/Session.ts
+++ b/packages/sdk/src/api/types/Session.ts
@@ -5,6 +5,7 @@ import type * as TrueForge from "../index.js";
 export interface Session {
     agent: TrueForge.SessionAgent;
     createdAt: string;
+    createdBy: string;
     id: string;
     title: string | null;
     updatedAt: string;

--- a/packages/sdk/src/serialization/types/GetCapabilitiesResponseDataSkill.ts
+++ b/packages/sdk/src/serialization/types/GetCapabilitiesResponseDataSkill.ts
@@ -9,10 +9,12 @@ export const GetCapabilitiesResponseDataSkill: core.serialization.ObjectSchema<
     TrueForge.GetCapabilitiesResponseDataSkill
 > = core.serialization.object({
     enabled: core.serialization.boolean(),
+    reason: core.serialization.string().optional(),
 });
 
 export declare namespace GetCapabilitiesResponseDataSkill {
     export interface Raw {
         enabled: boolean;
+        reason?: string | null;
     }
 }

--- a/packages/sdk/src/serialization/types/Session.ts
+++ b/packages/sdk/src/serialization/types/Session.ts
@@ -9,6 +9,7 @@ export const Session: core.serialization.ObjectSchema<serializers.Session.Raw, T
     core.serialization.object({
         agent: SessionAgent,
         createdAt: core.serialization.property("created_at", core.serialization.string()),
+        createdBy: core.serialization.property("created_by", core.serialization.string()),
         id: core.serialization.string(),
         title: core.serialization.string().nullable(),
         updatedAt: core.serialization.property("updated_at", core.serialization.string()),
@@ -18,6 +19,7 @@ export declare namespace Session {
     export interface Raw {
         agent: SessionAgent.Raw;
         created_at: string;
+        created_by: string;
         id: string;
         title?: string | null;
         updated_at: string;

--- a/packages/sdk/tests/wire/server.test.ts
+++ b/packages/sdk/tests/wire/server.test.ts
@@ -9,7 +9,11 @@ describe("ServerClient", () => {
         const client = new TrueForge({ maxRetries: 0, baseUrl: server.baseUrl });
 
         const rawResponseBody = {
-            data: { sandbox: { enabled: true }, settings: { enabled: true }, skill: { enabled: true } },
+            data: {
+                sandbox: { enabled: true },
+                settings: { enabled: true },
+                skill: { enabled: true, reason: "reason" },
+            },
         };
 
         server
@@ -31,6 +35,7 @@ describe("ServerClient", () => {
                 },
                 skill: {
                     enabled: true,
+                    reason: "reason",
                 },
             },
         });

--- a/packages/sdk/tests/wire/sessions.test.ts
+++ b/packages/sdk/tests/wire/sessions.test.ts
@@ -14,6 +14,7 @@ describe("SessionsClient", () => {
                 {
                     agent: { agent_id: "agent_id", type: "ref" },
                     created_at: "created_at",
+                    created_by: "created_by",
                     id: "id",
                     title: "title",
                     updated_at: "updated_at",
@@ -38,6 +39,7 @@ describe("SessionsClient", () => {
                         type: "ref",
                     },
                     createdAt: "created_at",
+                    createdBy: "created_by",
                     id: "id",
                     title: "title",
                     updatedAt: "updated_at",
@@ -78,6 +80,7 @@ describe("SessionsClient", () => {
             data: {
                 agent: { agent_id: "agent_id", type: "ref" },
                 created_at: "created_at",
+                created_by: "created_by",
                 id: "id",
                 title: "title",
                 updated_at: "updated_at",
@@ -106,6 +109,7 @@ describe("SessionsClient", () => {
                     type: "ref",
                 },
                 createdAt: "created_at",
+                createdBy: "created_by",
                 id: "id",
                 title: "title",
                 updatedAt: "updated_at",
@@ -196,6 +200,7 @@ describe("SessionsClient", () => {
             data: {
                 agent: { agent_id: "agent_id", type: "ref" },
                 created_at: "created_at",
+                created_by: "created_by",
                 id: "id",
                 title: "title",
                 updated_at: "updated_at",
@@ -218,6 +223,7 @@ describe("SessionsClient", () => {
                     type: "ref",
                 },
                 createdAt: "created_at",
+                createdBy: "created_by",
                 id: "id",
                 title: "title",
                 updatedAt: "updated_at",
@@ -262,6 +268,7 @@ describe("SessionsClient", () => {
             data: {
                 agent: { agent_id: "agent_id", type: "ref" },
                 created_at: "created_at",
+                created_by: "created_by",
                 id: "id",
                 title: "title",
                 updated_at: "updated_at",
@@ -285,6 +292,7 @@ describe("SessionsClient", () => {
                     type: "ref",
                 },
                 createdAt: "created_at",
+                createdBy: "created_by",
                 id: "id",
                 title: "title",
                 updatedAt: "updated_at",

--- a/packages/server/src/apis/capabilities.ts
+++ b/packages/server/src/apis/capabilities.ts
@@ -12,7 +12,12 @@ export function createCapabilitiesRouter(deps: { sandboxProviderStore: ISandboxP
       {
         data: {
           sandbox: { enabled: sandboxEnabled },
-          skill: { enabled: sandboxEnabled },
+          skill: sandboxEnabled
+            ? { enabled: true }
+            : {
+                enabled: false,
+                reason: 'Skills run in a sandbox, which is not configured.',
+              },
           settings: { enabled: true },
         },
       },

--- a/packages/server/src/routes/capabilityRoutes.ts
+++ b/packages/server/src/routes/capabilityRoutes.ts
@@ -10,6 +10,7 @@ const GetCapabilitiesResponseSchema = z
         enabled: z
           .boolean()
           .describe('Whether skills are available. False when sandbox is not enabled (skills require a sandbox).'),
+        reason: z.string().optional().describe('Present when skills are disabled. Explains why.'),
       }),
       settings: z.object({
         enabled: z.boolean().describe('Whether the settings UI/API is enabled.'),

--- a/packages/server/tests/unit/apis/capabilities.test.ts
+++ b/packages/server/tests/unit/apis/capabilities.test.ts
@@ -15,7 +15,10 @@ describe('capabilities routers', () => {
     expect(await empty.json()).toEqual({
       data: {
         sandbox: { enabled: false },
-        skill: { enabled: false },
+        skill: {
+          enabled: false,
+          reason: 'Skills run in a sandbox, which is not configured.',
+        },
         settings: { enabled: true },
       },
     });


### PR DESCRIPTION
This is for UI to show why it is disabled. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API fields and query params with backward-compatible optional `reason`; required `created_by` on Session is a breaking contract change for API consumers that must handle the new field.
> 
> **Overview**
> Adds an optional **`reason`** on capabilities **`skill`** when skills are disabled (no sandbox configured), with server copy *"Skills run in a sandbox, which is not configured."* so the UI can explain why skills are unavailable instead of only showing `enabled: false`.
> 
> Also extends the sessions API/SDK: **`Session`** now includes required **`created_by`**, list sessions accepts optional **`created_by`** query filtering, and generated OpenAPI/Fern SDK types, serializers, docs, and wire tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e559bda03f4cbe9b033edc193086692810b1390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->