### PR TITLE
Restore the comma that #57 dropped from the root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "start": "STANDALONE=false NODE_ENV=production pnpm --filter @truefoundry/utils start",
     "test:store:local": "bash scripts/test-store-local.sh",
     "test": "pnpm --filter @truefoundry/utils-core test && pnpm --filter @truefoundry/trueforge-ui test && pnpm --filter @truefoundry/utils test && pnpm --filter frontend test",
-    "typecheck": "pnpm --filter @truefoundry/utils-core typecheck && pnpm --filter @truefoundry/trueforge-ui typecheck && pnpm --filter @truefoundry/utils typecheck && pnpm --filter frontend typecheck"
+    "typecheck": "pnpm --filter @truefoundry/utils-core typecheck && pnpm --filter @truefoundry/trueforge-ui typecheck && pnpm --filter @truefoundry/utils typecheck && pnpm --filter frontend typecheck",
     "chart:deps": "helm dependency build charts/trueforge",
     "chart:lint": "helm lint charts/trueforge --values charts/trueforge/ci/lint-values.yaml",
     "chart:template": "helm template trueforge charts/trueforge --values charts/trueforge/ci/lint-values.yaml",


### PR DESCRIPTION
`main`'s root `package.json` is not valid JSON, so **CI fails on every branch in the repo**, including PRs that touch nothing related.

## What is wrong

```json
    "typecheck": "pnpm --filter @truefoundry/utils-core typecheck && ..."   <- comma missing
    "chart:deps": "helm dependency build charts/trueforge",
```

`pnpm/action-setup` reads the `packageManager` field out of this file, so every job dies in its **Setup pnpm** step, roughly five seconds in, before anything is built or tested:

```
SyntaxError: Expected ',' or '}' after property value in JSON at position 3331 (line 35 column 5)
    at JSON.parse (<anonymous>)
    at readTarget (/home/runner/work/_actions/pnpm/action-setup/v4/dist/index.js:1:7352)
```

## How it got in

b3bc1d4 ("Add trueforge Helm chart and release pipeline", #57) appended four `chart:*` scripts to the end of `scripts`. That branch was cut before a461744 removed the `ui:shot` / `ui:clean` scripts, so on the branch `"typecheck"` was still followed by a comma and the file parsed fine. On merge, Git spliced the chart lines in after main's now comma-less `"typecheck"` line. The merge was clean line by line, so nothing flagged it, and an unparseable `package.json` landed on main. Walking main confirms it: e73dbd8 valid, b3bc1d4 invalid.

## The fix

One comma. `package.json` parses again and `pnpm install --frozen-lockfile` resolves against it.

Every other open PR needs to merge main after this lands to pick the fix up.

Made with [Cursor](https://cursor.com)