### PR TITLE
Refactor agent handling to use agentId consistently across components

### DIFF
--- a/packages/trueforge-ui-sdk/src/atoms/AgentHistoryFilterButton.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/AgentHistoryFilterButton.tsx
@@ -122,10 +122,10 @@ export function AgentHistoryFilterButton() {
           <p className="px-2 py-3 text-center text-xs text-muted-foreground">Loading…</p>
         ) : (
           agents.map(agent => {
-            const active = selected === agent.name;
+            const active = selected === agent.agentId;
             return (
               <button
-                key={agent.name}
+                key={agent.agentId}
                 type="button"
                 role="menuitem"
                 className={cn(
@@ -133,7 +133,7 @@ export function AgentHistoryFilterButton() {
                   'hover:bg-accent hover:text-accent-foreground',
                   active && 'bg-accent',
                 )}
-                onClick={() => pick(agent.name)}
+                onClick={() => pick(agent.agentId)}
               >
                 <span className="min-w-0 truncate">{agent.name}</span>
                 {active ? <Icon name="check" className="size-3.5 shrink-0" /> : null}

--- a/packages/trueforge-ui-sdk/src/atoms/AgentsLibrary.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/AgentsLibrary.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 
 import { Icon } from '../icons/Icon.js';
 import { useOptionalServer } from '../server/ServerContext.js';
-import { libraryAgentId, useOptionalShellMode } from '../server/ShellModeContext.js';
+import { useOptionalShellMode } from '../server/ShellModeContext.js';
 import type { AgentLibraryEntry, AgentSpec } from '../server/types.js';
 import { auiButtonClass } from './lib/buttonClasses.js';
 import { cn } from './lib/cn.js';
@@ -128,23 +128,21 @@ export function AgentsLibrary({ open, onOpenChange, onSelectAgent }: AgentsLibra
   };
 
   const handleTry = (agent: AgentLibraryEntry) => {
-    const id = libraryAgentId(agent);
     closeLibrary();
     onSelectAgent?.(agent.name);
     shell?.selectLibraryAgent({
       isMutable: false,
-      agentId: id,
+      agentId: agent.agentId,
       agentName: agent.name,
     });
   };
 
   const handleEdit = (agent: AgentLibraryEntry, agentSpec: AgentSpec) => {
-    const id = libraryAgentId(agent);
     closeLibrary();
     onSelectAgent?.(agent.name);
     shell?.selectLibraryAgent({
       isMutable: true,
-      agentId: id,
+      agentId: agent.agentId,
       agentName: agent.name,
       agentSpec,
     });
@@ -186,7 +184,7 @@ export function AgentsLibrary({ open, onOpenChange, onSelectAgent }: AgentsLibra
               const showEdit = canEdit && agentSpec != null;
               return (
                 <AgentLibraryRow
-                  key={libraryAgentId(agent)}
+                  key={agent.agentId}
                   agent={agent}
                   showEdit={showEdit}
                   onTry={() => handleTry(agent)}

--- a/packages/trueforge-ui-sdk/src/server/ShellModeContext.tsx
+++ b/packages/trueforge-ui-sdk/src/server/ShellModeContext.tsx
@@ -132,8 +132,8 @@ function initialMode(config: AgentConfig, mutableSeed: AgentSpec): ShellMode {
   }
 }
 
-function libraryAgentId(agent: Pick<AgentLibraryEntry, 'agentId' | 'name'>): string {
-  return agent.agentId ?? agent.name;
+function libraryAgentId(agent: Pick<AgentLibraryEntry, 'agentId'>): string {
+  return agent.agentId;
 }
 
 export function ShellModeProvider({

--- a/packages/trueforge-ui-sdk/src/server/types.ts
+++ b/packages/trueforge-ui-sdk/src/server/types.ts
@@ -40,12 +40,12 @@ export interface ConnectorState {
 /**
  * Agents library row — SDK-minimal.
  * Hosts extend via `TAgent extends AgentLibraryEntry` for richer metadata/spec shapes.
- * `agentSpec` enables Edit (mutable); Try Agent works with `name` alone.
+ * `agentSpec` enables Edit (mutable); Try works with `name` + `agentId`.
  */
 export interface AgentLibraryEntry {
   name: string;
-  /** Stable id when distinct from display `name`. Falls back to `name` when omitted. */
-  agentId?: string;
+  /** Stable id used for selection, history filters, and session binding. */
+  agentId: string;
   /** Published agent spec — required for Edit; optional for Try-only hosts. */
   agentSpec?: AgentSpec;
 }

--- a/packages/trueforge-ui-sdk/test/atoms/AgentHistoryFilterButton.test.tsx
+++ b/packages/trueforge-ui-sdk/test/atoms/AgentHistoryFilterButton.test.tsx
@@ -31,7 +31,10 @@ beforeEach(() => {
 
 function mockServer(partial: Partial<AgentUIServer> = {}): AgentUIServer {
   return createMockAgentUIServer({
-    searchAgents: async () => [{ name: 'from-sdk' }, { name: 'other' }],
+    searchAgents: async () => [
+      { name: 'From SDK', agentId: 'from-sdk' },
+      { name: 'Other', agentId: 'other' },
+    ],
     ...partial,
   });
 }
@@ -85,7 +88,10 @@ describe('AgentHistoryFilterButton', () => {
   });
 
   it('opens popover and sets history filter on agent click', async () => {
-    const searchAgents = vi.fn(async () => [{ name: 'from-sdk' }, { name: 'other' }]);
+    const searchAgents = vi.fn(async () => [
+      { name: 'From SDK', agentId: 'from-sdk' },
+      { name: 'Other', agentId: 'other' },
+    ]);
     const server = mockServer({ searchAgents });
     render(<AgentHistoryFilterButton />, {
       wrapper: wrap({ agentConfig: { mode: 'AgentLibraryWithComposer' }, server }),
@@ -94,10 +100,10 @@ describe('AgentHistoryFilterButton', () => {
     expect(screen.getByTestId('filter-value')).toHaveTextContent('all');
 
     fireEvent.click(screen.getByRole('button', { name: /Filter chat history/i }));
-    await waitFor(() => expect(screen.getByRole('menuitem', { name: /from-sdk/i })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('menuitem', { name: /From SDK/i })).toBeInTheDocument());
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('menuitem', { name: /from-sdk/i }));
+      fireEvent.click(screen.getByRole('menuitem', { name: /From SDK/i }));
     });
 
     expect(screen.getByTestId('filter-value')).toHaveTextContent('from-sdk');
@@ -126,6 +132,6 @@ describe('AgentHistoryFilterButton', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog', { name: /Filter agents/i })).toBeInTheDocument();
     });
-    await waitFor(() => expect(screen.getByRole('menuitem', { name: /from-sdk/i })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('menuitem', { name: /From SDK/i })).toBeInTheDocument());
   });
 });

--- a/packages/trueforge-ui-sdk/test/atoms/AgentsLibrary.test.tsx
+++ b/packages/trueforge-ui-sdk/test/atoms/AgentsLibrary.test.tsx
@@ -25,9 +25,9 @@ beforeAll(() => {
 function mockServer(
   agents: Array<{
     name: string;
-    agentId?: string;
+    agentId: string;
     agentSpec?: { model: { name: string }; skills?: Array<{ id: string; name: string }> };
-  }> = [{ name: 'alpha-agent' }],
+  }> = [{ name: 'alpha-agent', agentId: 'alpha-agent' }],
 ): AgentUIServer {
   return createMockAgentUIServer({
     searchAgents: vi.fn(async () => agents),
@@ -67,7 +67,10 @@ describe('CenteredModal', () => {
 
 describe('AgentsLibrary', () => {
   it('lists agents and selects a named agent (Try = immutable)', async () => {
-    const server = mockServer([{ name: 'alpha-agent' }, { name: 'beta-agent' }]);
+    const server = mockServer([
+      { name: 'alpha-agent', agentId: 'alpha-agent' },
+      { name: 'beta-agent', agentId: 'beta-agent' },
+    ]);
     const onSelectAgent = vi.fn();
     const onOpenChange = vi.fn();
 
@@ -98,7 +101,7 @@ describe('AgentsLibrary', () => {
         agentId: 'writer-id',
         agentSpec: { model: { name: 'openai-main/gpt-4.1' }, skills: [{ id: 's1', name: 'Skill' }] },
       },
-      { name: 'try-only' },
+      { name: 'try-only', agentId: 'try-only' },
     ]);
 
     render(
@@ -122,6 +125,7 @@ describe('AgentsLibrary', () => {
     const server = mockServer([
       {
         name: 'writer',
+        agentId: 'writer',
         agentSpec: { model: { name: 'openai-main/gpt-4.1' } },
       },
     ]);
@@ -145,7 +149,7 @@ describe('AgentsLibrary', () => {
 
 describe('AgentsLibraryButton', () => {
   it('opens the Agents Library dialog from the trigger', async () => {
-    const server = mockServer([{ name: 'alpha-agent' }]);
+    const server = mockServer([{ name: 'alpha-agent', agentId: 'alpha-agent' }]);
 
     render(
       <SlotsProvider>
@@ -167,8 +171,11 @@ describe('AgentsLibraryButton', () => {
   it('re-fetches the agent count when agentsListEpoch bumps', async () => {
     const searchAgents = vi
       .fn()
-      .mockResolvedValueOnce([{ name: 'alpha' }])
-      .mockResolvedValueOnce([{ name: 'alpha' }, { name: 'beta' }]);
+      .mockResolvedValueOnce([{ name: 'alpha', agentId: 'alpha' }])
+      .mockResolvedValueOnce([
+        { name: 'alpha', agentId: 'alpha' },
+        { name: 'beta', agentId: 'beta' },
+      ]);
     const server = { searchAgents } as unknown as AgentUIServer;
 
     function Invalidate() {

--- a/packages/trueforge-ui-sdk/test/atoms/ClearChatButton.test.tsx
+++ b/packages/trueforge-ui-sdk/test/atoms/ClearChatButton.test.tsx
@@ -11,7 +11,7 @@ import { createMockAgentUIServer } from '../server/mockServer.js';
 
 function mockServer() {
   return createMockAgentUIServer({
-    searchAgents: vi.fn(async () => [{ name: 'alpha' }]),
+    searchAgents: vi.fn(async () => [{ name: 'alpha', agentId: 'alpha' }]),
   });
 }
 

--- a/packages/trueforge-ui-sdk/test/server/createTrueFoundryServer.test.ts
+++ b/packages/trueforge-ui-sdk/test/server/createTrueFoundryServer.test.ts
@@ -21,7 +21,7 @@ describe('createTrueFoundryServer', () => {
     const getModels = vi.fn(async () => [{ name: 'm', provider: 'p', apiModel: 'p/m', modelId: 'm' }]);
     const getSkills = vi.fn(async () => []);
     const getMcp = vi.fn(async () => []);
-    const searchAgents = vi.fn(async () => [{ name: 'ask-ai-agent' }]);
+    const searchAgents = vi.fn(async () => [{ name: 'ask-ai-agent', agentId: 'ask-ai-agent' }]);
     const saveAgent = vi.fn(async () => ({ ok: true }));
 
     const server = createTrueFoundryServer({
@@ -38,7 +38,9 @@ describe('createTrueFoundryServer', () => {
     expect(server.catalog).toBeUndefined();
 
     await expect(server.getModels()).resolves.toHaveLength(1);
-    await expect(server.searchAgents({ query: 'ask' })).resolves.toEqual([{ name: 'ask-ai-agent' }]);
+    await expect(server.searchAgents({ query: 'ask' })).resolves.toEqual([
+      { name: 'ask-ai-agent', agentId: 'ask-ai-agent' },
+    ]);
     expect(searchAgents).toHaveBeenCalledWith({ query: 'ask' });
 
     await server.saveAgent({


### PR DESCRIPTION
- Updated  and  to utilize  instead of  for agent selection and filtering.
- Modified  function to return only .
- Adjusted  interface to require .
- Updated tests to reflect changes in agent data structure and ensure proper functionality with the new  usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking contract for `searchAgents` hosts that omitted `agentId`; behavior changes when display name and id differ (history filter and session binding).
> 
> **Overview**
> **`AgentLibraryEntry.agentId` is now required** and documented as the stable id for selection, history filters, and session binding. Hosts can no longer rely on `{ name }` alone from `searchAgents`.
> 
> **Library and history UI use `agentId` end-to-end:** the history filter compares and stores `agentId` (not display `name`), and Try/Edit in the Agents Library pass `agent.agentId` into `selectLibraryAgent` instead of going through a name fallback. **`libraryAgentId`** no longer falls back to `name`; it only returns `agent.agentId` (still exported for callers).
> 
> Tests and mocks were updated so every library row includes an `agentId`, including cases where id differs from display name (e.g. filter asserts `from-sdk` while the label is “From SDK”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f763afeca43354e6f41a6b8bcaed7fbe41d78562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->