### PR TITLE
Update platforms to only include linux/amd64 in image publish

### DIFF
--- a/.github/workflows/release-image-and-chart.yml
+++ b/.github/workflows/release-image-and-chart.yml
@@ -52,7 +52,7 @@ jobs:
       image_tag: ${{ github.sha }}
       image_context: .
       dockerfile_path: Dockerfile
-      platforms: linux/amd64,linux/arm64
+      platforms: linux/amd64
       # The chart pulls the server image from JFrog (values.yaml image.repository),
       # so JFrog is the only publish target; public ECR stays off.
       enable_jfrog: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dropping arm64 from the release image means ARM64 Kubernetes nodes cannot pull a native image unless another build path exists; release CI behavior changes but not runtime app code.
> 
> **Overview**
> The **release image and Helm chart** workflow no longer publishes a **multi-arch** `truefoundry-utils` image. The reusable build job’s `platforms` input is narrowed from `linux/amd64,linux/arm64` to **`linux/amd64` only**, so release builds skip the **arm64** variant while JFrog publishing and chart packaging stay the same.
> 
> This aligns the release path with workflows like **push-sandbox-image**, which already target amd64 only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f9a2de1c1c58b0d4bbeaeda82514aa7ee9d0d6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->