### PR TITLE
Fix sdk package name

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -41,7 +41,7 @@ groups:
           path: ../packages/sdk
         config:
           packageJson:
-            name: trueforge
+            name: trueforge-sdk
           allowExtraFields: true
           allowCustomFetcher: true
           enableInlineTypes: false

--- a/packages/sdk/.fern/metadata.json
+++ b/packages/sdk/.fern/metadata.json
@@ -4,7 +4,7 @@
     "generatorVersion": "3.87.1",
     "generatorConfig": {
         "packageJson": {
-            "name": "trueforge"
+            "name": "trueforge-sdk"
         },
         "allowExtraFields": true,
         "allowCustomFetcher": true,
@@ -27,8 +27,8 @@
         "streamType": "web",
         "useDefaultRequestParameterValues": true
     },
-    "originGitCommit": "90fe41de61c43396f77efc7a6a1b4c5504a494a7",
-    "originGitCommitIsDirty": true,
+    "originGitCommit": "60032ffbb02cf4a302dfaadcd1b27ee63115db92",
+    "originGitCommitIsDirty": false,
     "invokedBy": "ci",
     "requestedVersion": "0.0.0",
     "ciProvider": "github",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,7 +1,7 @@
 # Truefoundry TypeScript Library
 
 [![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Truefoundry%2FTypeScript)
-[![npm shield](https://img.shields.io/npm/v/trueforge)](https://www.npmjs.com/package/trueforge)
+[![npm shield](https://img.shields.io/npm/v/trueforge-sdk)](https://www.npmjs.com/package/trueforge-sdk)
 
 TypeScript client for the TrueFoundry agent harness server: a self-hosted runtime that executes agent turns and streams them over Server-Sent Events.
 
@@ -34,7 +34,7 @@ The harness server has no built-in authentication, so point the client at your o
 ## Installation
 
 ```sh
-npm i -s trueforge
+npm i -s trueforge-sdk
 ```
 
 ## Reference
@@ -46,7 +46,7 @@ A full reference for this library is available [here](./reference.md).
 Instantiate and use the client with the following:
 
 ```typescript
-import { TrueForge } from "trueforge";
+import { TrueForge } from "trueforge-sdk";
 
 const client = new TrueForge({ baseUrl: "YOUR_BASE_URL" });
 const response = await client.sessions.createTurnStream("session_id", {});
@@ -61,7 +61,7 @@ The SDK exports all request and response types as TypeScript interfaces. Simply 
 following namespace:
 
 ```typescript
-import { TrueForge } from "trueforge";
+import { TrueForge } from "trueforge-sdk";
 
 const request: TrueForge.AgentWriteRequest = {
     ...
@@ -74,7 +74,7 @@ When the API returns a non-success status code (4xx or 5xx response), a subclass
 will be thrown.
 
 ```typescript
-import { TrueForgeError } from "trueforge";
+import { TrueForgeError } from "trueforge-sdk";
 
 try {
     await client.sessions.createTurnStream(...);
@@ -94,7 +94,7 @@ Some endpoints return streaming responses instead of returning the full response
 The SDK uses async iterators, so you can consume the responses using a `for await...of` loop.
 
 ```typescript
-import { TrueForge } from "trueforge";
+import { TrueForge } from "trueforge-sdk";
 
 const client = new TrueForge({ baseUrl: "YOUR_BASE_URL" });
 const response = await client.sessions.createTurnStream("session_id", {});
@@ -499,7 +499,7 @@ const text = new TextDecoder().decode(bytes);
 This SDK supports direct imports of subpackage clients, which allows JavaScript bundlers to tree-shake and include only the imported subpackage code. This results in much smaller bundle sizes.
 
 ```typescript
-import { AgentsClient } from 'trueforge/agents';
+import { AgentsClient } from 'trueforge-sdk/agents';
 
 const client = new AgentsClient({...});
 ```
@@ -509,7 +509,7 @@ const client = new AgentsClient({...});
 If you would like to send additional headers as part of the request, use the `headers` request option.
 
 ```typescript
-import { TrueForge } from "trueforge";
+import { TrueForge } from "trueforge-sdk";
 
 const client = new TrueForge({
     ...
@@ -604,7 +604,7 @@ console.log(rawResponse.headers['X-My-Header']);
 The SDK supports logging. You can configure the logger by passing in a `logging` object to the client options.
 
 ```typescript
-import { TrueForge, logging } from "trueforge";
+import { TrueForge, logging } from "trueforge-sdk";
 
 const client = new TrueForge({
     ...
@@ -688,7 +688,7 @@ The SDK provides a way for you to customize the underlying HTTP client / Fetch f
 unsupported environment, this provides a way for you to break glass and ensure the SDK works.
 
 ```typescript
-import { TrueForge } from "trueforge";
+import { TrueForge } from "trueforge-sdk";
 
 const client = new TrueForge({
     ...

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "trueforge",
+    "name": "trueforge-sdk",
     "version": "0.0.0",
     "private": false,
     "type": "commonjs",

--- a/packages/sdk/pnpm-lock.yaml
+++ b/packages/sdk/pnpm-lock.yaml
@@ -686,8 +686,8 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1518,7 +1518,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   neo-async@2.6.2: {}
 
@@ -1538,7 +1538,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/packages/sdk/src/BaseClient.ts
+++ b/packages/sdk/src/BaseClient.ts
@@ -49,9 +49,9 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     const headers = mergeHeaders(
         {
             "X-Fern-Language": "JavaScript",
-            "X-Fern-SDK-Name": "trueforge",
+            "X-Fern-SDK-Name": "trueforge-sdk",
             "X-Fern-SDK-Version": "0.0.0",
-            "User-Agent": "trueforge/0.0.0",
+            "User-Agent": "trueforge-sdk/0.0.0",
             "X-Fern-Runtime": core.RUNTIME.type,
             "X-Fern-Runtime-Version": core.RUNTIME.version,
         },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This is a breaking change for anyone already installing or importing `trueforge`; consumers must update package names and import paths.
> 
> **Overview**
> Renames the published TypeScript SDK from **`trueforge`** to **`trueforge-sdk`** so install and import paths match the intended npm package name.
> 
> The Fern generator config (`fern/generators.yml`) now sets `packageJson.name` to `trueforge-sdk`, which flows through generated **`packages/sdk/package.json`**, **README** examples (install, imports, subpath exports), and **`BaseClient`** default headers (`X-Fern-SDK-Name`, `User-Agent`). Fern metadata and **`pnpm-lock.yaml`** reflect regeneration (including a `nanoid` patch bump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc133301486f760a70262331985e3a486d7bc2e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->