### PR TITLE
docs: embed interactive demos in capability pages

### DIFF
--- a/docs/mcp-servers.mdx
+++ b/docs/mcp-servers.mdx
@@ -30,6 +30,17 @@ An MCP server is configured with a small manifest:
 
 Register it with `PUT /api/v1/settings/mcp-servers` (or through the UI). A catalog of popular servers is available at `GET /api/v1/settings/mcp-servers/catalog`, and you can verify connectivity with `GET /api/v1/settings/mcp-servers/{name}/tools`, which lists the server's live tools.
 
+<div style={{ position: "relative", boxSizing: "content-box", width: "100%", aspectRatio: "1.75", padding: "40px 0" }}>
+  <iframe
+    src="https://app.supademo.com/embed/cmsk7ca2801l91t0jwyiwj78i?embed_v=2&utm_source=embed"
+    loading="lazy"
+    title="Register a remote MCP server in TrueForge"
+    allow="clipboard-write"
+    allowFullScreen
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+  />
+</div>
+
 ### Authentication options
 
 - **No auth** — public or network-trusted servers.

--- a/docs/models.mdx
+++ b/docs/models.mdx
@@ -26,7 +26,7 @@ The shipped catalog (`GET /api/v1/settings/model-providers/catalog`) contains re
 
 <Tabs>
   <Tab title="UI">
-    Open **Settings → Model Providers**, pick a provider from the catalog, and paste your API key. Models from that provider become available immediately in the model selector.
+    Open **Settings → Models**, pick a provider from the catalog, and paste your API key. Models from that provider become available immediately in the model selector.
   </Tab>
   <Tab title="API">
     Fetch a template from the catalog, fill in the credentials, and upsert it:
@@ -42,6 +42,17 @@ The shipped catalog (`GET /api/v1/settings/model-providers/catalog`) contains re
 
   </Tab>
 </Tabs>
+
+<div style={{ position: "relative", boxSizing: "content-box", width: "100%", aspectRatio: "1.75", padding: "40px 0" }}>
+  <iframe
+    src="https://app.supademo.com/embed/cmsk7202v01l51t0jkq022fjk?embed_v=2&utm_source=embed"
+    loading="lazy"
+    title="Configure a model provider in TrueForge"
+    allow="clipboard-write"
+    allowFullScreen
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+  />
+</div>
 
 ## Referencing a model in an agent
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -70,7 +70,7 @@ description: 'Run TrueForge with one command, configure a model provider, and ha
 TrueForge ships with a catalog of model providers. Configure one before your first chat:
 
 <Steps>
-  <Step title="Open Settings">In the UI, open **Settings → Model Providers**.</Step>
+  <Step title="Open Settings">In the UI, open **Settings → Models**.</Step>
   <Step title="Pick a provider">
     Choose a provider from the catalog — OpenAI, Anthropic, Google Gemini, or an OpenAI-compatible endpoint — and paste
     your API key.
@@ -82,6 +82,17 @@ TrueForge ships with a catalog of model providers. Configure one before your fir
 
 Everything you can do in Settings is also available through the API — see `GET /api/v1/settings/model-providers/catalog` and `PUT /api/v1/settings/model-providers` in the interactive API docs at `/api/v1/docs`.
 
+<div style={{ position: "relative", boxSizing: "content-box", width: "100%", aspectRatio: "1.75", padding: "40px 0" }}>
+  <iframe
+    src="https://app.supademo.com/embed/cmsk7202v01l51t0jkq022fjk?embed_v=2&utm_source=embed"
+    loading="lazy"
+    title="Configure a model provider in TrueForge"
+    allow="clipboard-write"
+    allowFullScreen
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+  />
+</div>
+
 ## Start chatting
 
 Send your first message. Out of the box the agent supports multi-turn conversations with streaming. To give it more capabilities:
@@ -89,6 +100,17 @@ Send your first message. Out of the box the agent supports multi-turn conversati
 - **Connect tools** — add [MCP servers](/mcp-servers) under **Settings → MCP Servers**.
 - **Enable the sandbox** — configure a [sandbox provider](/sandbox) so the agent can run code and use [skills](/skills).
 - **Add skills** — register [git-backed skills](/skills) under **Settings → Skills**.
+
+<div style={{ position: "relative", boxSizing: "content-box", width: "100%", aspectRatio: "1.46", padding: "40px 0" }}>
+  <iframe
+    src="https://app.supademo.com/embed/cmsk13xio00k81p0j1wj6amj6?embed_v=2&utm_source=embed"
+    loading="lazy"
+    title="Chat with an agent in TrueForge"
+    allow="clipboard-write"
+    allowFullScreen
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+  />
+</div>
 
 ## Call the API
 

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -55,6 +55,17 @@ TrueForge delegates sandbox compute to a provider. Configure it once — in the 
 
 A template with defaults is available at `GET /api/v1/settings/sandbox-providers/catalog`. Whether a provider is configured is reported by `GET /api/v1/capabilities`.
 
+<div style={{ position: "relative", boxSizing: "content-box", width: "100%", aspectRatio: "1.75", padding: "40px 0" }}>
+  <iframe
+    src="https://app.supademo.com/embed/cmsk7vatl00pz0n0jme1d96w5?embed_v=2&utm_source=embed"
+    loading="lazy"
+    title="Configure a sandbox provider in TrueForge"
+    allow="clipboard-write"
+    allowFullScreen
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+  />
+</div>
+
 ## Enabling the sandbox on an agent
 
 The sandbox is **off by default** per agent. Enable it in the agent spec:

--- a/docs/skills.mdx
+++ b/docs/skills.mdx
@@ -54,6 +54,17 @@ Register it with `PUT /api/v1/settings/skills` (or through the UI). Starter skil
   tag or SHA, test changes on a branch, and roll back by changing the ref.
 </Tip>
 
+<div style={{ position: "relative", boxSizing: "content-box", width: "100%", aspectRatio: "1.75", padding: "40px 0" }}>
+  <iframe
+    src="https://app.supademo.com/embed/cmsk7of5d00eezq0jjcap0qxp?embed_v=2&utm_source=embed"
+    loading="lazy"
+    title="Register a skill in TrueForge"
+    allow="clipboard-write"
+    allowFullScreen
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+  />
+</div>
+
 ## Attaching skills to an agent
 
 Agents reference skills by name only:


### PR DESCRIPTION
## What

Adds step-by-step Supademo walkthroughs to the main Documentation, each placed directly under its relevant section.

| Page | Section | Demo |
|---|---|---|
| `quickstart` | Configure a model provider | Configure a model provider |
| `quickstart` | Start chatting | Compose/chat with an agent |
| `models` | Configuring a provider | Configure a model provider |
| `mcp-servers` | Registering an MCP server | Register a remote MCP server |
| `skills` | Registering a skill | Register a skill |
| `sandbox` | Configuring a sandbox provider | Configure a sandbox provider |

Also fixes two stale **"Settings → Model Providers"** references to the actual tab name **"Settings → Models"** (quickstart, models).

## Notes

- Demos are `<iframe>` embeds (JSX-safe `style={{…}}`), consistent with the UI SDK docs. They render in the hosted docs / Mintlify PR preview but **not** in offline/PDF exports.
- Please eyeball the **Mintlify preview** for this PR to confirm all six embeds render in place (couldn't run `mint dev` locally — Mintlify's CLI doesn't support Node 25+, and this machine is on Node 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (third-party embeds and copy); no runtime or application code affected.
> 
> **Overview**
> Adds **Supademo** walkthroughs as responsive `<iframe>` blocks on six capability docs, placed right after the section they illustrate: model setup on `quickstart` and `models`, chat on `quickstart`, MCP registration, skill registration, and sandbox provider setup.
> 
> Also renames the documented Settings path from **Settings → Model Providers** to **Settings → Models** in the quickstart steps and the models UI tab so it matches the current UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fec82c23dc161aacf491fb914b869190f24d6b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->