### PR TITLE
Allow disabling tool approvals entirely or enabling it on specific tools

### DIFF
--- a/packages/harness/src/core/mcp/ToolSelectorPolicy.ts
+++ b/packages/harness/src/core/mcp/ToolSelectorPolicy.ts
@@ -104,14 +104,11 @@ export class ToolSelectorPolicy {
   }
 
   /**
-   * Approvals are always enabled. Required if the agent's own selectors match OR the tool is
-   * write/destructive — the default set is a floor the per-agent selectors can widen but never
-   * drop below.
+   * Whether the tool requires human approval. Honors `requireApprovalForTools` exactly: omit /
+   * undefined defaults to write+destructive (constructor); an explicit list — including empty —
+   * is exact.
    */
   requiresApproval(toolName: string, annotations: ToolAnnotations | undefined): boolean {
-    return (
-      toolRequiresApproval(toolName, annotations, this.requireApprovalForTools) ||
-      toolRequiresApproval(toolName, annotations, DEFAULT_REQUIRE_APPROVAL_FOR_TOOLS)
-    );
+    return toolRequiresApproval(toolName, annotations, this.requireApprovalForTools);
   }
 }

--- a/packages/harness/tests/core/mcp/remoteMcpServer.test.ts
+++ b/packages/harness/tests/core/mcp/remoteMcpServer.test.ts
@@ -222,17 +222,39 @@ describe('RemoteMCP + ToolSet', () => {
     expect(state.callToolCalls).toBe(0);
   });
 
-  it('enforces the write/destructive approval floor even when the agent narrows require_approval_for_tools', async () => {
+  it('honors an empty require_approval_for_tools list (no approvals)', async () => {
     const state = installFakeConnection();
-    // Agent explicitly clears its approval selectors; the write/destructive floor must still apply.
     const server = makeServer({
       selectors: { enableTools: ['@all'], disableTools: [], preloadTools: [], requireApprovalForTools: [] },
     });
     await server.listTools();
 
     const res = await server.callTool({ name: 'write_thing', arguments: {} });
-    expect(isApprovalRequiredResponse(res)).toBe(true);
+    if (!isCallToolResponseResult(res)) throw new Error('expected result response');
+    expect(res.result.isError).toBeFalsy();
+    expect(state.callToolCalls).toBe(1);
+  });
+
+  it('honors literal require_approval_for_tools without gating other write tools', async () => {
+    const state = installFakeConnection();
+    const server = makeServer({
+      selectors: {
+        enableTools: ['@all'],
+        disableTools: [],
+        preloadTools: [],
+        requireApprovalForTools: ['write_thing'],
+      },
+    });
+    await server.listTools();
+
+    const gated = await server.callTool({ name: 'write_thing', arguments: {} });
+    expect(isApprovalRequiredResponse(gated)).toBe(true);
     expect(state.callToolCalls).toBe(0);
+
+    const ungated = await server.callTool({ name: 'read_thing', arguments: {} });
+    if (!isCallToolResponseResult(ungated)) throw new Error('expected result response');
+    expect(ungated.result.isError).toBeFalsy();
+    expect(state.callToolCalls).toBe(1);
   });
 
   it('short-circuits a denied tool call without hitting the transport', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes human-in-the-loop safety behavior: agents can now fully disable approvals or narrow them to named tools instead of always inheriting a write/destructive minimum.
> 
> **Overview**
> **Tool approval gating** no longer unions agent `require_approval_for_tools` with the default `@write` / `@destructive` set. `ToolSelectorPolicy.requiresApproval` now evaluates only the resolved selector list: omitted/undefined still defaults to write+destructive in the constructor, but an **explicit empty list disables all approvals**, and a **literal list gates only those tools** (other write tools run without approval).
> 
> Remote MCP integration tests were updated to match: empty selectors allow `write_thing` through to the transport, and listing only `write_thing` still requires approval while `read_thing` does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253a19e83cc16223edbfbce81cc1d62a0dbcf89d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->