### PR TITLE
fix: handle failsafe for toast element mounting

### DIFF
--- a/packages/trueforge-ui-sdk/src/atoms/Toast.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/Toast.tsx
@@ -80,9 +80,14 @@ export type ToastStackProps = {
 };
 
 const openToastStack = (element: HTMLDivElement | null): void => {
-  if (element === null || typeof element.showPopover !== 'function') return;
-  if (element.matches(':popover-open')) element.hidePopover();
-  element.showPopover();
+  if (element === null) return;
+  try {
+    if (typeof element.showPopover !== 'function') return;
+    if (element.matches(':popover-open')) element.hidePopover();
+    element.showPopover();
+  } catch {
+    // Popover APIs can reject during attachment; the fixed stack remains usable.
+  }
 };
 
 export function ToastStack({ children, duration: _duration = Number.POSITIVE_INFINITY }: ToastStackProps) {


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/sdk`, `fern/openapi/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in UI toast mounting with no auth, data, or API behavior changes.
> 
> **Overview**
> **`ToastStack`** still opens its manual popover via the ref callback `openToastStack`, but that path is now wrapped in **try/catch** so `showPopover` / `hidePopover` / `:popover-open` checks cannot throw during attachment (e.g. when the element is not fully connected).
> 
> If popover APIs are missing or reject, the callback exits quietly and the fixed-position toast stack continues to render as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c5ca24fe1b15ff19d8125d653ca4c76f2b5d907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->