### PR TITLE
Copy openapi spec for docs/ too

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,8 @@ dist/
 # Fern-generated: formatted by the generator, not by this repo's config.
 packages/sdk/
 .github/fern/openapi/
+# Ignore generated openapi.json in docs
+docs/openapi.json
 # Helm chart sources and downloaded Bitnami subcharts; not ours to reformat.
 charts/
 coverage/

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -228,13 +228,6 @@
             "minItems": 1,
             "type": "array"
           },
-          "name": {
-            "default": "alibaba",
-            "enum": [
-              "alibaba"
-            ],
-            "type": "string"
-          },
           "type": {
             "enum": [
               "alibaba"
@@ -268,13 +261,6 @@
             },
             "minItems": 1,
             "type": "array"
-          },
-          "name": {
-            "default": "anthropic",
-            "enum": [
-              "anthropic"
-            ],
-            "type": "string"
           },
           "type": {
             "enum": [
@@ -1015,13 +1001,6 @@
             "minItems": 1,
             "type": "array"
           },
-          "name": {
-            "default": "fireworks",
-            "enum": [
-              "fireworks"
-            ],
-            "type": "string"
-          },
           "type": {
             "enum": [
               "fireworks"
@@ -1237,13 +1216,6 @@
             },
             "minItems": 1,
             "type": "array"
-          },
-          "name": {
-            "default": "google-gemini",
-            "enum": [
-              "google-gemini"
-            ],
-            "type": "string"
           },
           "type": {
             "enum": [
@@ -2277,13 +2249,6 @@
             "minItems": 1,
             "type": "array"
           },
-          "name": {
-            "default": "moonshot",
-            "enum": [
-              "moonshot"
-            ],
-            "type": "string"
-          },
           "type": {
             "enum": [
               "moonshot"
@@ -2317,13 +2282,6 @@
             },
             "minItems": 1,
             "type": "array"
-          },
-          "name": {
-            "default": "openai",
-            "enum": [
-              "openai"
-            ],
-            "type": "string"
           },
           "type": {
             "enum": [
@@ -3236,13 +3194,6 @@
             "minItems": 1,
             "type": "array"
           },
-          "name": {
-            "default": "together",
-            "enum": [
-              "together"
-            ],
-            "type": "string"
-          },
           "type": {
             "enum": [
               "together"
@@ -4089,13 +4040,6 @@
             },
             "minItems": 1,
             "type": "array"
-          },
-          "name": {
-            "default": "zai",
-            "enum": [
-              "zai"
-            ],
-            "type": "string"
           },
           "type": {
             "enum": [
@@ -6379,7 +6323,7 @@
         "x-fern-sdk-method-name": "list"
       },
       "put": {
-        "description": "Full upsert keyed by `name`: creates the provider or replaces its entire configuration (models included). Every type but `custom` is named after itself, so each is limited to one configured provider and a repeat call replaces it; only `custom` providers are named, and numbered, by the caller.",
+        "description": "Full upsert: creates the provider or replaces its entire configuration (models included). The key is the returned `name`, which every type but `custom` takes from its own `type`, so each is limited to one configured provider and a repeat call replaces it; only `custom` providers are named by the caller.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6425,7 +6369,7 @@
     },
     "/api/v1/settings/model-providers/catalog": {
       "get": {
-        "description": "Provider and model presets shipped with the server (model-catalog.yaml). Discovery-only: copy an entry into PUT /settings/model-providers to configure it. Custom providers are not listed here.",
+        "description": "Provider and model presets shipped with the server (model-catalog.yaml). Discovery-only: an entry becomes a PUT /settings/model-providers body once the catalog-only `logo` and `name` are dropped and `auth` is added. Custom providers are not listed here.",
         "responses": {
           "200": {
             "content": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,1 +1,6771 @@
-../fern/openapi/openapi.json
+{
+  "components": {
+    "parameters": {},
+    "schemas": {
+      "ActionRequiredEvent": {
+        "discriminator": {
+          "mapping": {
+            "mcp.auth_required": "#/components/schemas/MCPAuthRequiredEvent",
+            "tool.approval_required": "#/components/schemas/ToolApprovalRequiredEvent",
+            "tool.response_required": "#/components/schemas/ToolResponseRequiredEvent"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ToolApprovalRequiredEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ToolResponseRequiredEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MCPAuthRequiredEvent"
+          }
+        ]
+      },
+      "Agent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentSpec"
+          },
+          {
+            "properties": {
+              "id": {
+                "description": "Immutable server-generated agent identifier.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "name": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ResourceName"
+                  },
+                  {
+                    "description": "Immutable unique agent name within the tenant."
+                  }
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ],
+            "type": "object"
+          }
+        ],
+        "description": "Complete agent definition used inline on a session or saved as a named agent."
+      },
+      "AgentInfo": {
+        "properties": {
+          "input": {
+            "description": "Input prompt passed to the subagent.",
+            "type": "string"
+          },
+          "model": {
+            "description": "Optional model override for the subagent.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "name": {
+            "description": "Display name of the dynamic subagent.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Subagent kind.",
+            "enum": [
+              "dynamic"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "input"
+        ],
+        "type": "object"
+      },
+      "AgentParent": {
+        "properties": {
+          "thread_id": {
+            "description": "Parent thread that spawned the child agent.",
+            "type": "string"
+          },
+          "tool_call_id": {
+            "description": "Tool call on the parent thread that created the child.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "thread_id",
+          "tool_call_id"
+        ],
+        "type": "object"
+      },
+      "AgentSpec": {
+        "description": "Complete agent definition used inline on a session or saved as a named agent.",
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/RuntimeConfig"
+          },
+          "instructions": {
+            "description": "Optional system prompt — the agent's role, behavior, and constraints.",
+            "type": "string"
+          },
+          "mcp_servers": {
+            "description": "Optional MCP servers attached by configured name.",
+            "items": {
+              "$ref": "#/components/schemas/MCPServer"
+            },
+            "type": "array"
+          },
+          "messages": {
+            "description": "Optional seed user messages injected at the start of every session.",
+            "items": {
+              "$ref": "#/components/schemas/AgentSpecUserMessage"
+            },
+            "type": "array"
+          },
+          "model": {
+            "$ref": "#/components/schemas/AgentSpecModel"
+          },
+          "response_format": {
+            "$ref": "#/components/schemas/ResponseFormat"
+          },
+          "skills": {
+            "description": "Optional name-only skill references. Requires `config.sandbox.enabled: true`.",
+            "items": {
+              "$ref": "#/components/schemas/SkillNameRef"
+            },
+            "type": "array"
+          },
+          "variables": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Optional string key–value map reserved for parameterizing agent definitions.",
+            "type": "object"
+          }
+        },
+        "required": [
+          "model"
+        ],
+        "type": "object"
+      },
+      "AgentSpecModel": {
+        "properties": {
+          "name": {
+            "description": "Model FQN: `provider/model`, e.g. `openai/gpt-5.2`.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "params": {
+            "$ref": "#/components/schemas/ModelParams"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "AgentSpecUserMessage": {
+        "properties": {
+          "content": {
+            "description": "Seed user message content injected at the start of every session.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "description": "Seed message type.",
+            "enum": [
+              "user.message"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content"
+        ],
+        "type": "object"
+      },
+      "AgentWriteRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentSpec"
+          },
+          {
+            "properties": {
+              "name": {
+                "$ref": "#/components/schemas/ResourceName"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ],
+        "description": "Complete agent definition used inline on a session or saved as a named agent."
+      },
+      "AlibabaModelProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/ModelProviderAuth"
+          },
+          "base_url": {
+            "default": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+            "description": "Override of the provider's default API base URL.",
+            "format": "uri",
+            "type": "string"
+          },
+          "models": {
+            "description": "Models exposed by this provider (at least one).",
+            "items": {
+              "$ref": "#/components/schemas/ModelEntry"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "default": "alibaba",
+            "enum": [
+              "alibaba"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "alibaba"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "auth",
+          "models",
+          "type"
+        ],
+        "type": "object"
+      },
+      "AnthropicModelProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/ModelProviderAuth"
+          },
+          "base_url": {
+            "default": "https://api.anthropic.com/v1",
+            "description": "Override of the provider's default API base URL.",
+            "format": "uri",
+            "type": "string"
+          },
+          "models": {
+            "description": "Models exposed by this provider (at least one).",
+            "items": {
+              "$ref": "#/components/schemas/ModelEntry"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "default": "anthropic",
+            "enum": [
+              "anthropic"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "anthropic"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "auth",
+          "models",
+          "type"
+        ],
+        "type": "object"
+      },
+      "ApprovalAllow": {
+        "properties": {
+          "status": {
+            "description": "Allow the pending tool call(s).",
+            "enum": [
+              "allow"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      },
+      "ApprovalDecision": {
+        "discriminator": {
+          "mapping": {
+            "allow": "#/components/schemas/ApprovalAllow",
+            "deny": "#/components/schemas/ApprovalDeny"
+          },
+          "propertyName": "status"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ApprovalAllow"
+          },
+          {
+            "$ref": "#/components/schemas/ApprovalDeny"
+          }
+        ]
+      },
+      "ApprovalDeny": {
+        "properties": {
+          "reason": {
+            "description": "Optional reason shown to the agent when denied.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Deny the pending tool call(s).",
+            "enum": [
+              "deny"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      },
+      "AskUserQuestionsConfig": {
+        "default": {
+          "enabled": true
+        },
+        "properties": {
+          "enabled": {
+            "default": true,
+            "description": "Enable the `ask_user_question` tool. Default: true.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "BaseMCPAuthRequiredEvent": {
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 event timestamp.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the event (monotonic ULID).",
+            "type": "string"
+          },
+          "thread_id": {
+            "description": "Always null — this is a run-level event.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "thread_id"
+        ],
+        "type": "object"
+      },
+      "BaseThreadDoneEvent": {
+        "properties": {
+          "parent": {
+            "$ref": "#/components/schemas/AgentParent"
+          },
+          "thread_id": {
+            "description": "Thread that finished.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Human-readable thread title.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "thread_id",
+          "title"
+        ],
+        "type": "object"
+      },
+      "CancelSessionRequest": {
+        "description": "Empty request body. Cancel identifies the session via the path only.",
+        "properties": {},
+        "type": "object"
+      },
+      "CancelSessionResponse": {
+        "description": "Empty success body. HTTP 200 means the cancel request was accepted (or nothing was running).",
+        "properties": {},
+        "type": "object"
+      },
+      "CatalogDaytonaSandboxProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "auto_archive_interval_in_minutes": {
+            "description": "Minutes before Daytona auto-archives the sandbox (0 disables).",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "auto_delete_interval_in_minutes": {
+            "description": "Minutes before Daytona auto-deletes the sandbox (0 disables).",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "auto_stop_interval_in_minutes": {
+            "description": "Minutes of idle time before Daytona auto-stops the sandbox (0 disables).",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "exec_timeout_ms": {
+            "description": "Default sandbox command exec timeout in milliseconds.",
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "snapshot_name": {
+            "description": "Daytona snapshot used when creating sandboxes.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "description": "Daytona sandbox provider.",
+            "enum": [
+              "daytona"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "snapshot_name",
+          "exec_timeout_ms",
+          "auto_stop_interval_in_minutes",
+          "auto_archive_interval_in_minutes",
+          "auto_delete_interval_in_minutes"
+        ],
+        "type": "object"
+      },
+      "CatalogMcpServer": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConfiguredMcpServerAuth"
+              },
+              {
+                "description": "Optional default auth settings for the preset."
+              }
+            ]
+          },
+          "logo": {
+            "description": "URL of the MCP server logo asset.",
+            "format": "uri",
+            "type": "string"
+          },
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "type": {
+            "$ref": "#/components/schemas/McpServerType"
+          },
+          "url": {
+            "description": "URL of the remote MCP server.",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "url"
+        ],
+        "type": "object"
+      },
+      "CatalogProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "logo": {
+            "description": "URL of the provider logo asset.",
+            "format": "uri",
+            "type": "string"
+          },
+          "models": {
+            "description": "Preset models for this catalog provider.",
+            "items": {
+              "$ref": "#/components/schemas/ModelEntry"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "type": {
+            "description": "Well-known provider type (catalog excludes `custom`).",
+            "enum": [
+              "openai",
+              "anthropic",
+              "google-gemini",
+              "fireworks",
+              "zai",
+              "moonshot",
+              "alibaba",
+              "together"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "models"
+        ],
+        "type": "object"
+      },
+      "CatalogSkill": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "Concise guidance for when the agent should use the skill.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "path": {
+            "description": "Path to the skill directory within the repository. Omit to use the repository root.",
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9._\\-/]+$",
+            "type": "string"
+          },
+          "ref": {
+            "description": "Git ref — branch name, tag, or commit SHA.",
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9._\\-/]+$",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/SkillType"
+          },
+          "url": {
+            "description": "Full HTTPS URL of a GitHub or GitLab repository.",
+            "minLength": 1,
+            "pattern": "^https:\\/\\/(github\\.com\\/[A-Za-z0-9._-]+\\/[A-Za-z0-9._-]+|gitlab\\.com\\/[A-Za-z0-9._-]+(?:\\/[A-Za-z0-9._-]+)+)(\\/|\\.git)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "url",
+          "ref",
+          "description"
+        ],
+        "type": "object"
+      },
+      "ChatCompletionChunkDeltaToolCall": {
+        "properties": {
+          "function": {
+            "properties": {
+              "arguments": {
+                "description": "Partial or complete JSON arguments string.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Partial or complete function name.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "description": "Tool call id (may arrive across multiple deltas).",
+            "type": "string"
+          },
+          "index": {
+            "description": "Index of this tool call in the streaming delta array.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": {
+            "description": "Tool call type when present on this delta.",
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "index"
+        ],
+        "type": "object"
+      },
+      "ChatCompletionContentPartRefusal": {
+        "properties": {
+          "refusal": {
+            "description": "Refusal message text.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Model refusal content part.",
+            "enum": [
+              "refusal"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "refusal"
+        ],
+        "type": "object"
+      },
+      "ChatCompletionContentPartText": {
+        "properties": {
+          "text": {
+            "description": "Plain-text content.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Text content part.",
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "ChatCompletionMessageToolCall": {
+        "properties": {
+          "function": {
+            "properties": {
+              "arguments": {
+                "description": "JSON-encoded function arguments string.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Function/tool name.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ],
+            "type": "object"
+          },
+          "id": {
+            "description": "Tool call id.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Tool call type.",
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "function"
+        ],
+        "type": "object"
+      },
+      "ConfiguredMcpServer": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/ConfiguredMcpServerAuth"
+          },
+          "auth_status": {
+            "$ref": "#/components/schemas/McpAuthStatus"
+          },
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "type": {
+            "$ref": "#/components/schemas/McpServerType"
+          },
+          "url": {
+            "description": "URL of the remote MCP server.",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "url",
+          "auth_status"
+        ],
+        "type": "object"
+      },
+      "ConfiguredMcpServerAuth": {
+        "description": "Optional auth settings. Omit when the server needs no credentials.",
+        "discriminator": {
+          "mapping": {
+            "dcr": "#/components/schemas/McpServerDcrAuth",
+            "header": "#/components/schemas/McpServerHeaderAuth"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/McpServerHeaderAuth"
+          },
+          {
+            "$ref": "#/components/schemas/McpServerDcrAuth"
+          }
+        ]
+      },
+      "ContextManagementConfig": {
+        "default": {
+          "compaction": {
+            "enabled": true
+          },
+          "large_tool_response": {
+            "enabled": true
+          }
+        },
+        "properties": {
+          "compaction": {
+            "default": {
+              "enabled": true
+            },
+            "properties": {
+              "compaction_threshold_tokens": {
+                "description": "Context size in tokens that triggers compaction. Default: 50000.",
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              },
+              "enabled": {
+                "default": true,
+                "description": "Summarize older history when context grows too large. Default: true.",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "large_tool_response": {
+            "$ref": "#/components/schemas/LargeToolResponseConfig"
+          }
+        },
+        "type": "object"
+      },
+      "CreateAgentResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Agent"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "CreateSessionAgent": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/SessionAgentNameRef"
+          },
+          {
+            "$ref": "#/components/schemas/SessionAgentSpecBody"
+          }
+        ]
+      },
+      "CreateSessionRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "$ref": "#/components/schemas/CreateSessionAgent"
+          }
+        },
+        "required": [
+          "agent"
+        ],
+        "type": "object"
+      },
+      "CreateTurnRequest": {
+        "properties": {
+          "input": {
+            "description": "Turn input items: user messages and/or approval/tool-response resumes. Do not mix user messages with approval or tool-response items.",
+            "items": {
+              "$ref": "#/components/schemas/TurnInputItem"
+            },
+            "type": "array"
+          },
+          "previous_turn_id": {
+            "$ref": "#/components/schemas/PreviousTurnIdInput"
+          },
+          "stream": {
+            "default": true,
+            "description": "When true (default), stream turn events as SSE. When false, return the running turn immediately.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "CustomModelProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/ModelProviderAuth"
+          },
+          "base_url": {
+            "description": "Base URL of the provider's API.",
+            "format": "uri",
+            "type": "string"
+          },
+          "models": {
+            "description": "Models exposed by this provider (at least one).",
+            "items": {
+              "$ref": "#/components/schemas/ModelEntry"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "type": {
+            "enum": [
+              "custom"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "auth",
+          "models",
+          "type",
+          "name",
+          "base_url"
+        ],
+        "type": "object"
+      },
+      "DaytonaSandboxProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/DaytonaSandboxProviderAuth"
+          },
+          "auto_archive_interval_in_minutes": {
+            "description": "Minutes before Daytona auto-archives the sandbox (0 disables).",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "auto_delete_interval_in_minutes": {
+            "description": "Minutes before Daytona auto-deletes the sandbox (0 disables).",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "auto_stop_interval_in_minutes": {
+            "description": "Minutes of idle time before Daytona auto-stops the sandbox (0 disables).",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "exec_timeout_ms": {
+            "description": "Default sandbox command exec timeout in milliseconds.",
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "snapshot_name": {
+            "description": "Daytona snapshot used when creating sandboxes.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "description": "Daytona sandbox provider.",
+            "enum": [
+              "daytona"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "snapshot_name",
+          "auth",
+          "exec_timeout_ms",
+          "auto_stop_interval_in_minutes",
+          "auto_archive_interval_in_minutes",
+          "auto_delete_interval_in_minutes"
+        ],
+        "type": "object"
+      },
+      "DaytonaSandboxProviderAuth": {
+        "additionalProperties": false,
+        "description": "Daytona authentication credentials.",
+        "properties": {
+          "api_key": {
+            "description": "Daytona API key.",
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "api_key"
+        ],
+        "type": "object"
+      },
+      "DynamicSubAgentsConfig": {
+        "default": {
+          "enabled": true
+        },
+        "properties": {
+          "enabled": {
+            "default": true,
+            "description": "Allow the agent to spawn dynamic subagents. Default: true.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "ExtendedChunkDeltaToolCall": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ChatCompletionChunkDeltaToolCall"
+          },
+          {
+            "properties": {
+              "provider_specific_fields": {
+                "additionalProperties": {},
+                "type": "object"
+              },
+              "tool_info": {
+                "$ref": "#/components/schemas/ToolInfo"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "FileContent": {
+        "properties": {
+          "data": {
+            "description": "Data URI: `data:<mime>;base64,<payload>`. MIME type is parsed from the URI.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Filename presented to the agent.",
+            "type": "string"
+          },
+          "type": {
+            "description": "File attachment content part.",
+            "enum": [
+              "file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "data"
+        ],
+        "type": "object"
+      },
+      "FinishReason": {
+        "description": "Why the model stopped generating.",
+        "enum": [
+          "stop",
+          "length",
+          "tool_calls",
+          "content_filter",
+          "function_call"
+        ],
+        "type": "string"
+      },
+      "FireworksModelProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/ModelProviderAuth"
+          },
+          "base_url": {
+            "default": "https://api.fireworks.ai/inference/v1",
+            "description": "Override of the provider's default API base URL.",
+            "format": "uri",
+            "type": "string"
+          },
+          "models": {
+            "description": "Models exposed by this provider (at least one).",
+            "items": {
+              "$ref": "#/components/schemas/ModelEntry"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "default": "fireworks",
+            "enum": [
+              "fireworks"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "fireworks"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "auth",
+          "models",
+          "type"
+        ],
+        "type": "object"
+      },
+      "GenerativeUIConfig": {
+        "default": {
+          "enabled": true
+        },
+        "properties": {
+          "enabled": {
+            "default": true,
+            "description": "Enable Generative UI (OpenUI blocks). Default: true.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "GetAgentResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Agent"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetCapabilitiesResponse": {
+        "properties": {
+          "data": {
+            "properties": {
+              "sandbox": {
+                "properties": {
+                  "enabled": {
+                    "description": "Whether a sandbox provider is configured for this tenant.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "enabled"
+                ],
+                "type": "object"
+              },
+              "settings": {
+                "properties": {
+                  "enabled": {
+                    "description": "Whether the settings UI/API is enabled.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "enabled"
+                ],
+                "type": "object"
+              },
+              "skill": {
+                "properties": {
+                  "enabled": {
+                    "description": "Whether skills are available. False when sandbox is not enabled (skills require a sandbox).",
+                    "type": "boolean"
+                  },
+                  "reason": {
+                    "description": "Present when skills are disabled. Explains why.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "enabled"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "sandbox",
+              "skill",
+              "settings"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetMcpServerCatalogResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/CatalogMcpServer"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetMcpServerResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ConfiguredMcpServer"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetModelProviderCatalogResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/CatalogProvider"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetSandboxProviderCatalogResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/CatalogDaytonaSandboxProvider"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetSandboxProviderResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DaytonaSandboxProvider"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetSessionResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Session"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetSkillCatalogResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/CatalogSkill"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GetTurnResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Turn"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "GoogleGeminiModelProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/ModelProviderAuth"
+          },
+          "base_url": {
+            "default": "https://generativelanguage.googleapis.com/v1beta",
+            "description": "Override of the provider's default API base URL.",
+            "format": "uri",
+            "type": "string"
+          },
+          "models": {
+            "description": "Models exposed by this provider (at least one).",
+            "items": {
+              "$ref": "#/components/schemas/ModelEntry"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "default": "google-gemini",
+            "enum": [
+              "google-gemini"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "google-gemini"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "auth",
+          "models",
+          "type"
+        ],
+        "type": "object"
+      },
+      "LargeToolResponseConfig": {
+        "default": {
+          "enabled": true
+        },
+        "properties": {
+          "enabled": {
+            "default": true,
+            "description": "Offload oversized tool responses to a sandbox file. Default: true.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "ListAgentsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Agent"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ListAvailableMcpServersResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/McpServerReadEntry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ListAvailableSkillsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SkillReadEntry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ListConfiguredSkillsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SkillManifest"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ListMcpServerToolsResponse": {
+        "properties": {
+          "data": {
+            "description": "MCP `tools/list` entries, passed through verbatim from the MCP server.",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ListMcpServersResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ConfiguredMcpServer"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ListModelProvidersResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ModelProvider"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ListModelsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Model"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ListSessionEventsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SessionEventItem"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/TokenPagination"
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ],
+        "type": "object"
+      },
+      "ListSessionsOrder": {
+        "default": "desc",
+        "description": "Sort sessions by creation time. Defaults to \"desc\".",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "ListSessionsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Session"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/TokenPagination"
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ],
+        "type": "object"
+      },
+      "ListTurnEventsOrder": {
+        "default": "asc",
+        "description": "Sort events by insertion order. Defaults to \"asc\".",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "ListTurnEventsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SessionEvent"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/TokenPagination"
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ],
+        "type": "object"
+      },
+      "ListTurnsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Turn"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/TokenPagination"
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ],
+        "type": "object"
+      },
+      "MCPAuthRequiredEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseMCPAuthRequiredEvent"
+          },
+          {
+            "properties": {
+              "mcp_servers": {
+                "description": "Servers that need authorization, each with an auth_url.",
+                "items": {
+                  "$ref": "#/components/schemas/MCPServerAuthInfo"
+                },
+                "type": "array"
+              },
+              "type": {
+                "description": "One or more MCP servers need OAuth before tools can run.",
+                "enum": [
+                  "mcp.auth_required"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "mcp_servers"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "MCPInitializeEvent": {
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 event timestamp.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the event (monotonic ULID).",
+            "type": "string"
+          },
+          "mcp_servers": {
+            "description": "Servers that were initialized.",
+            "items": {
+              "$ref": "#/components/schemas/MCPServerInitInfo"
+            },
+            "type": "array"
+          },
+          "thread_id": {
+            "description": "Thread that triggered initialization.",
+            "type": "string"
+          },
+          "type": {
+            "description": "MCP server(s) initialized for this turn.",
+            "enum": [
+              "mcp.initialize"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "created_at",
+          "thread_id",
+          "mcp_servers"
+        ],
+        "type": "object"
+      },
+      "MCPServer": {
+        "properties": {
+          "disable_tools": {
+            "default": [],
+            "description": "Tools subtracted from the enabled set. Default: none.",
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "@all",
+                    "@read-only"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "enable_tools": {
+            "default": [
+              "@all"
+            ],
+            "description": "Tools exposed to the agent: `@all`, `@read-only`, or literal tool names. Default: `[\"@all\"]`.",
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "@all",
+                    "@read-only"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "Name of a configured MCP server (Settings → Connectors).",
+            "minLength": 1,
+            "type": "string"
+          },
+          "preload": {
+            "default": false,
+            "description": "When true, load all tool schemas upfront. Default: false (deferred discovery).",
+            "type": "boolean"
+          },
+          "preload_tools": {
+            "default": [],
+            "description": "Tools loaded eagerly into context while the rest stay deferred. A non-empty list implies `preload: false`.",
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "@all",
+                    "@read-only"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "require_approval_for_tools": {
+            "default": [
+              "@write",
+              "@destructive"
+            ],
+            "description": "Tools that pause for human approval: `@all`, `@write`, `@destructive`, or literal names. Default: `[\"@write\", \"@destructive\"]`.",
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "@all",
+                    "@write",
+                    "@destructive"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "MCPServerAuthInfo": {
+        "properties": {
+          "auth_url": {
+            "description": "URL the user must visit to complete OAuth for this server.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Internal MCP server id.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Configured MCP server name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "auth_url"
+        ],
+        "type": "object"
+      },
+      "MCPServerInitInfo": {
+        "properties": {
+          "id": {
+            "description": "Internal MCP server id.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Configured MCP server name.",
+            "type": "string"
+          },
+          "session_id": {
+            "description": "Optional MCP session id from the transport.",
+            "type": "string"
+          },
+          "transport_type": {
+            "description": "Transport used to connect to the MCP server.",
+            "enum": [
+              "streamable-http",
+              "sse"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "MCPToolInfo": {
+        "properties": {
+          "name": {
+            "description": "Tool name on the MCP server.",
+            "type": "string"
+          },
+          "server_id": {
+            "description": "Internal MCP server id.",
+            "type": "string"
+          },
+          "server_name": {
+            "description": "Configured MCP server name.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Tool hosted on an MCP server.",
+            "enum": [
+              "mcp"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "server_id",
+          "server_name",
+          "name"
+        ],
+        "type": "object"
+      },
+      "McpAuthStatus": {
+        "additionalProperties": false,
+        "properties": {
+          "authorization_url": {
+            "description": "When auth is required, this contains the URL to redirect the user to for authorization.",
+            "format": "uri",
+            "type": "string"
+          },
+          "status": {
+            "description": "Current auth state for this MCP server.",
+            "enum": [
+              "authenticated",
+              "auth_required",
+              "not_required"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      },
+      "McpServerDcrAuth": {
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "description": "Authenticate via OAuth Dynamic Client Registration.",
+            "enum": [
+              "dcr"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "McpServerHeaderAuth": {
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "additionalProperties": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": "HTTP headers sent on each request to this MCP server.",
+            "type": "object"
+          },
+          "type": {
+            "description": "Authenticate with static HTTP headers.",
+            "enum": [
+              "header"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "headers"
+        ],
+        "type": "object"
+      },
+      "McpServerManifest": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/ConfiguredMcpServerAuth"
+          },
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "type": {
+            "$ref": "#/components/schemas/McpServerType"
+          },
+          "url": {
+            "description": "URL of the remote MCP server.",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "url"
+        ],
+        "type": "object"
+      },
+      "McpServerReadEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "url": {
+            "description": "URL of the remote MCP server.",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "url"
+        ],
+        "type": "object"
+      },
+      "McpServerType": {
+        "description": "MCP server kind (`remote` today).",
+        "enum": [
+          "remote"
+        ],
+        "type": "string"
+      },
+      "MeResponse": {
+        "properties": {
+          "email": {
+            "description": "User email from the ID token when connected; `\"default\"` when anonymous.",
+            "type": "string"
+          },
+          "role": {
+            "description": "Caller role.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Session kind: `default` when no valid OIDC session; `oidc-connected` after a successful browser login.",
+            "enum": [
+              "default",
+              "oidc-connected"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "email",
+          "role"
+        ],
+        "type": "object"
+      },
+      "Model": {
+        "additionalProperties": false,
+        "properties": {
+          "model_id": {
+            "description": "Upstream, provider-specific identifier sent to the provider API.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Fully qualified name `provider_name/model_name`, e.g. \"openai/gpt-5-6-sol\". Unique within a tenant.",
+            "type": "string"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/ModelProperties"
+          }
+        },
+        "required": [
+          "name",
+          "model_id",
+          "properties"
+        ],
+        "type": "object"
+      },
+      "ModelEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "model_id": {
+            "description": "Upstream, provider-specific identifier sent to the provider API.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceName"
+              },
+              {
+                "description": "Internal identifier; forms the fully qualified name `name/model_name`."
+              }
+            ]
+          },
+          "properties": {
+            "$ref": "#/components/schemas/ModelProperties"
+          }
+        },
+        "required": [
+          "model_id",
+          "name",
+          "properties"
+        ],
+        "type": "object"
+      },
+      "ModelMessageDeltaEvent": {
+        "properties": {
+          "content": {
+            "description": "Incremental assistant text content.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "description": "Optional ISO 8601 event timestamp.",
+            "type": "string"
+          },
+          "finish_reason": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FinishReason"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Finish reason when this delta completes the stream."
+          },
+          "id": {
+            "description": "Unique identifier for the event (monotonic ULID).",
+            "type": "string"
+          },
+          "reasoning_content": {
+            "type": "string"
+          },
+          "refusal": {
+            "description": "Incremental refusal text when present.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "thread_id": {
+            "description": "Thread that emitted this delta.",
+            "type": "string"
+          },
+          "tool_calls": {
+            "items": {
+              "$ref": "#/components/schemas/ExtendedChunkDeltaToolCall"
+            },
+            "type": "array"
+          },
+          "type": {
+            "description": "Streaming delta for a model.message.",
+            "enum": [
+              "model.message.delta"
+            ],
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/ModelMessageUsage"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "thread_id"
+        ],
+        "type": "object"
+      },
+      "ModelMessageEvent": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ChatCompletionContentPartText"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ChatCompletionContentPartRefusal"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Assistant message content as text or content parts."
+          },
+          "created_at": {
+            "description": "ISO 8601 event timestamp.",
+            "type": "string"
+          },
+          "finish_reason": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FinishReason"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Model finish reason; null when the provider omitted it."
+          },
+          "id": {
+            "description": "Unique identifier for the event (monotonic ULID).",
+            "type": "string"
+          },
+          "name": {
+            "description": "Optional participant name.",
+            "type": "string"
+          },
+          "reasoning_content": {
+            "type": "string"
+          },
+          "refusal": {
+            "description": "Optional refusal text.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "thread_id": {
+            "description": "Thread that emitted this message (`main` for the root agent).",
+            "type": "string"
+          },
+          "tool_calls": {
+            "items": {
+              "$ref": "#/components/schemas/ToolCall"
+            },
+            "type": "array"
+          },
+          "type": {
+            "description": "Complete assistant model message.",
+            "enum": [
+              "model.message"
+            ],
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/ModelMessageUsage"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "thread_id",
+          "created_at"
+        ],
+        "type": "object"
+      },
+      "ModelMessageUsage": {
+        "properties": {
+          "cache_read_tokens": {
+            "description": "Optional cache-read tokens.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "cache_write_tokens": {
+            "description": "Optional cache-write tokens.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "input_tokens": {
+            "description": "Input tokens for this model call.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "input_tokens_breakdown": {
+            "properties": {
+              "harness": {
+                "description": "Tokens attributed to harness system framing.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "instructions": {
+                "description": "Tokens attributed to agent instructions.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "messages": {
+                "description": "Tokens attributed to conversation messages.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "skills": {
+                "description": "Tokens attributed to skill instructions.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "tool_definitions": {
+                "description": "Tokens attributed to tool schemas.",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "harness",
+              "skills",
+              "instructions",
+              "tool_definitions",
+              "messages"
+            ],
+            "type": "object"
+          },
+          "output_tokens": {
+            "description": "Output tokens for this model call.",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "input_tokens",
+          "output_tokens",
+          "input_tokens_breakdown"
+        ],
+        "type": "object"
+      },
+      "ModelParams": {
+        "additionalProperties": {},
+        "description": "Model call parameters passed through to the provider. Known keys are documented; extra keys are allowed and forwarded as-is.",
+        "properties": {
+          "max_tokens": {
+            "description": "Maximum tokens to generate in the model response.",
+            "type": "number"
+          },
+          "parallel_tool_calls": {
+            "description": "Whether the model may emit multiple tool calls in one response.",
+            "type": "boolean"
+          },
+          "reasoning_effort": {
+            "description": "Provider-specific reasoning effort (e.g. low/medium/high).",
+            "type": "string"
+          },
+          "temperature": {
+            "description": "Sampling temperature; higher values increase randomness.",
+            "type": "number"
+          },
+          "top_k": {
+            "description": "Top-k sampling; keep only the k highest-probability tokens.",
+            "type": "number"
+          },
+          "top_p": {
+            "description": "Nucleus sampling probability mass.",
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "ModelProperties": {
+        "additionalProperties": false,
+        "description": "Optional model capability metadata.",
+        "properties": {
+          "context_length": {
+            "description": "Maximum context window size in tokens.",
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "max_output_tokens": {
+            "description": "Maximum output tokens the model can generate.",
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "reasoning_efforts": {
+            "description": "Supported reasoning-effort values for this model.",
+            "items": {
+              "$ref": "#/components/schemas/ReasoningEffort"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ModelProvider": {
+        "discriminator": {
+          "mapping": {
+            "alibaba": "#/components/schemas/AlibabaModelProvider",
+            "anthropic": "#/components/schemas/AnthropicModelProvider",
+            "custom": "#/components/schemas/CustomModelProvider",
+            "fireworks": "#/components/schemas/FireworksModelProvider",
+            "google-gemini": "#/components/schemas/GoogleGeminiModelProvider",
+            "moonshot": "#/components/schemas/MoonshotModelProvider",
+            "openai": "#/components/schemas/OpenAIModelProvider",
+            "together": "#/components/schemas/TogetherAIModelProvider",
+            "zai": "#/components/schemas/ZaiModelProvider"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/OpenAIModelProvider"
+          },
+          {
+            "$ref": "#/components/schemas/AnthropicModelProvider"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleGeminiModelProvider"
+          },
+          {
+            "$ref": "#/components/schemas/FireworksModelProvider"
+          },
+          {
+            "$ref": "#/components/schemas/ZaiModelProvider"
+          },
+          {
+            "$ref": "#/components/schemas/MoonshotModelProvider"
+          },
+          {
+            "$ref": "#/components/schemas/TogetherAIModelProvider"
+          },
+          {
+            "$ref": "#/components/schemas/AlibabaModelProvider"
+          },
+          {
+            "$ref": "#/components/schemas/CustomModelProvider"
+          }
+        ]
+      },
+      "ModelProviderAuth": {
+        "additionalProperties": false,
+        "description": "Provider authentication credentials.",
+        "properties": {
+          "api_key": {
+            "description": "API key used to authenticate with the provider.",
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "api_key"
+        ],
+        "type": "object"
+      },
+      "MoonshotModelProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/ModelProviderAuth"
+          },
+          "base_url": {
+            "default": "https://api.moonshot.ai/v1",
+            "description": "Override of the provider's default API base URL.",
+            "format": "uri",
+            "type": "string"
+          },
+          "models": {
+            "description": "Models exposed by this provider (at least one).",
+            "items": {
+              "$ref": "#/components/schemas/ModelEntry"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "default": "moonshot",
+            "enum": [
+              "moonshot"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "moonshot"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "auth",
+          "models",
+          "type"
+        ],
+        "type": "object"
+      },
+      "OpenAIModelProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/ModelProviderAuth"
+          },
+          "base_url": {
+            "default": "https://api.openai.com/v1",
+            "description": "Override of the provider's default API base URL.",
+            "format": "uri",
+            "type": "string"
+          },
+          "models": {
+            "description": "Models exposed by this provider (at least one).",
+            "items": {
+              "$ref": "#/components/schemas/ModelEntry"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "default": "openai",
+            "enum": [
+              "openai"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "openai"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "auth",
+          "models",
+          "type"
+        ],
+        "type": "object"
+      },
+      "PreviousTurnIdInput": {
+        "anyOf": [
+          {
+            "enum": [
+              "auto"
+            ],
+            "type": "string"
+          },
+          {
+            "enum": [
+              "none"
+            ],
+            "type": "string"
+          },
+          {
+            "minLength": 1,
+            "type": "string"
+          }
+        ],
+        "default": "auto",
+        "description": "Defaults to 'auto' (chain to session last turn). Use 'none' for a new root turn."
+      },
+      "PutAgentResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Agent"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "PutMcpServerResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ConfiguredMcpServer"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "PutModelProviderResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ModelProvider"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "PutSandboxProviderResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DaytonaSandboxProvider"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "PutSkillResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SkillManifest"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "RawToolCall": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ChatCompletionMessageToolCall"
+          },
+          {
+            "properties": {
+              "provider_specific_fields": {
+                "additionalProperties": {},
+                "type": "object"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "ReasoningEffort": {
+        "enum": [
+          "none",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "type": "string"
+      },
+      "RequestErrorResponse": {
+        "properties": {
+          "error": {
+            "properties": {
+              "code": {
+                "description": "Optional machine-readable error code; null when not applicable.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "message": {
+                "description": "Human-readable explanation of the failure.",
+                "type": "string"
+              },
+              "param": {
+                "description": "Optional request field that caused the error; null when not field-specific.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "Optional error category (e.g. validation vs conflict).",
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "ResourceName": {
+        "description": "Fully qualified name. Unique within a tenant.",
+        "maxLength": 64,
+        "minLength": 2,
+        "pattern": "^[a-z](?:[a-z0-9._-]{0,62}[a-z0-9])$",
+        "type": "string"
+      },
+      "ResponseFormat": {
+        "discriminator": {
+          "mapping": {
+            "json_object": "#/components/schemas/ResponseFormatJsonObject",
+            "json_schema": "#/components/schemas/ResponseFormatJsonSchema",
+            "text": "#/components/schemas/ResponseFormatText"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ResponseFormatText"
+          },
+          {
+            "$ref": "#/components/schemas/ResponseFormatJsonObject"
+          },
+          {
+            "$ref": "#/components/schemas/ResponseFormatJsonSchema"
+          }
+        ]
+      },
+      "ResponseFormatJsonObject": {
+        "additionalProperties": {},
+        "description": "JSON object response format. Extra provider fields are allowed.",
+        "properties": {
+          "type": {
+            "description": "Model must return a JSON object.",
+            "enum": [
+              "json_object"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ResponseFormatJsonSchema": {
+        "additionalProperties": {},
+        "description": "JSON Schema response format. Extra provider fields are allowed.",
+        "properties": {
+          "json_schema": {
+            "additionalProperties": {},
+            "description": "JSON Schema payload. Extra provider fields are allowed.",
+            "properties": {
+              "description": {
+                "description": "Optional schema description for the model.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Schema name sent to the provider.",
+                "type": "string"
+              },
+              "schema": {
+                "additionalProperties": {},
+                "description": "JSON Schema object for the response.",
+                "type": "object"
+              },
+              "strict": {
+                "description": "When true, ask the provider to enforce the schema strictly.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "description": "Model must return JSON matching a schema.",
+            "enum": [
+              "json_schema"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "json_schema"
+        ],
+        "type": "object"
+      },
+      "ResponseFormatText": {
+        "additionalProperties": {},
+        "description": "Default text response format. Extra provider fields are allowed.",
+        "properties": {
+          "type": {
+            "description": "Unconstrained text output.",
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "RuntimeConfig": {
+        "default": {
+          "ask_user_questions": {
+            "enabled": true
+          },
+          "context_management": {
+            "compaction": {
+              "enabled": true
+            },
+            "large_tool_response": {
+              "enabled": true
+            }
+          },
+          "dynamic_sub_agents": {
+            "enabled": true
+          },
+          "generative_ui": {
+            "enabled": true
+          },
+          "iteration_limit": 100,
+          "sandbox": {
+            "enabled": false,
+            "file_downloads": true
+          }
+        },
+        "properties": {
+          "ask_user_questions": {
+            "$ref": "#/components/schemas/AskUserQuestionsConfig"
+          },
+          "context_management": {
+            "$ref": "#/components/schemas/ContextManagementConfig"
+          },
+          "dynamic_sub_agents": {
+            "$ref": "#/components/schemas/DynamicSubAgentsConfig"
+          },
+          "generative_ui": {
+            "$ref": "#/components/schemas/GenerativeUIConfig"
+          },
+          "iteration_limit": {
+            "default": 100,
+            "description": "Max agent-loop iterations per turn (1–1024). Default: 100.",
+            "exclusiveMinimum": 0,
+            "maximum": 1024,
+            "type": "integer"
+          },
+          "sandbox": {
+            "$ref": "#/components/schemas/SandboxConfig"
+          }
+        },
+        "type": "object"
+      },
+      "SandboxConfig": {
+        "default": {
+          "enabled": false,
+          "file_downloads": true
+        },
+        "properties": {
+          "enabled": {
+            "description": "Give the agent a sandbox. Required for skills and Code Mode.",
+            "type": "boolean"
+          },
+          "file_downloads": {
+            "default": true,
+            "description": "Allow downloading agent-produced files via the turn download endpoint. Default: true.",
+            "type": "boolean"
+          },
+          "network_policy": {
+            "$ref": "#/components/schemas/SandboxNetworkPolicy"
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "type": "object"
+      },
+      "SandboxCreatedEvent": {
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 event timestamp.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the event (monotonic ULID).",
+            "type": "string"
+          },
+          "sandbox_id": {
+            "description": "Provider sandbox id.",
+            "type": "string"
+          },
+          "thread_id": {
+            "description": "Always null — sandbox is session-scoped.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": {
+            "description": "A sandbox was created for this session.",
+            "enum": [
+              "sandbox.created"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "created_at",
+          "sandbox_id",
+          "thread_id"
+        ],
+        "type": "object"
+      },
+      "SandboxNetworkPolicy": {
+        "properties": {
+          "auth_inject": {
+            "description": "Up to one rule injecting git basic-auth credentials for exact hosts.",
+            "items": {
+              "properties": {
+                "auth_data": {
+                  "properties": {
+                    "password": {
+                      "description": "Basic-auth password.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Basic auth credential type.",
+                      "enum": [
+                        "basic"
+                      ],
+                      "type": "string"
+                    },
+                    "username": {
+                      "description": "Basic-auth username (no whitespace).",
+                      "pattern": "^\\S+$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "username",
+                    "password"
+                  ],
+                  "type": "object"
+                },
+                "match": {
+                  "properties": {
+                    "hosts": {
+                      "description": "Hostnames that receive injected credentials.",
+                      "items": {
+                        "description": "Exact hostname to match (no wildcards).",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "hosts"
+                  ],
+                  "type": "object"
+                },
+                "type": {
+                  "description": "Inject credentials for git HTTPS clones.",
+                  "enum": [
+                    "git"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "match",
+                "auth_data"
+              ],
+              "type": "object"
+            },
+            "maxItems": 1,
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Session": {
+        "properties": {
+          "agent": {
+            "$ref": "#/components/schemas/SessionAgent"
+          },
+          "created_at": {
+            "description": "ISO 8601 creation timestamp.",
+            "type": "string"
+          },
+          "created_by": {
+            "description": "Caller identity that created the session (immutable).",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique session id.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Optional human-readable title; null until set.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updated_at": {
+            "description": "ISO 8601 last-update timestamp.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "agent",
+          "title",
+          "created_by",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "SessionAgent": {
+        "discriminator": {
+          "mapping": {
+            "inline": "#/components/schemas/SessionAgentInline",
+            "reference": "#/components/schemas/SessionAgentReference"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SessionAgentReference"
+          },
+          {
+            "$ref": "#/components/schemas/SessionAgentInline"
+          }
+        ]
+      },
+      "SessionAgentInline": {
+        "additionalProperties": false,
+        "properties": {
+          "spec": {
+            "$ref": "#/components/schemas/AgentSpec"
+          },
+          "type": {
+            "description": "Bind the session to an inline AgentSpec (not a registry id).",
+            "enum": [
+              "inline"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "spec"
+        ],
+        "type": "object"
+      },
+      "SessionAgentNameRef": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SessionAgentReference": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "Registry agent id.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "name": {
+            "description": "Create-time snapshot of the registry agent name; null for legacy or orphan rows.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": {
+            "description": "Bind the session to a named registry agent.",
+            "enum": [
+              "reference"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "SessionAgentSpecBody": {
+        "additionalProperties": false,
+        "properties": {
+          "spec": {
+            "$ref": "#/components/schemas/AgentSpec"
+          }
+        },
+        "required": [
+          "spec"
+        ],
+        "type": "object"
+      },
+      "SessionEvent": {
+        "discriminator": {
+          "mapping": {
+            "mcp.auth_required": "#/components/schemas/MCPAuthRequiredEvent",
+            "mcp.initialize": "#/components/schemas/MCPInitializeEvent",
+            "model.message": "#/components/schemas/ModelMessageEvent",
+            "sandbox.created": "#/components/schemas/SandboxCreatedEvent",
+            "thread.created": "#/components/schemas/ThreadCreatedEvent",
+            "thread.done": "#/components/schemas/ThreadDoneEvent",
+            "tool.approval_required": "#/components/schemas/ToolApprovalRequiredEvent",
+            "tool.response": "#/components/schemas/ToolResponseEvent",
+            "tool.response_required": "#/components/schemas/ToolResponseRequiredEvent",
+            "turn.created": "#/components/schemas/TurnCreatedEvent",
+            "turn.done": "#/components/schemas/TurnDoneEvent"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/TurnCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/TurnDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ModelMessageEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ToolResponseEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MCPAuthRequiredEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MCPInitializeEvent"
+          },
+          {
+            "$ref": "#/components/schemas/SandboxCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ToolApprovalRequiredEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ToolResponseRequiredEvent"
+          }
+        ]
+      },
+      "SessionEventItem": {
+        "properties": {
+          "event": {
+            "$ref": "#/components/schemas/SessionEvent"
+          },
+          "turn_id": {
+            "description": "Turn that emitted this event.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "turn_id",
+          "event"
+        ],
+        "type": "object"
+      },
+      "SkillManifest": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "Concise guidance for when the agent should use the skill.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "path": {
+            "description": "Path to the skill directory within the repository. Omit to use the repository root.",
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9._\\-/]+$",
+            "type": "string"
+          },
+          "ref": {
+            "description": "Git ref — branch name, tag, or commit SHA.",
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9._\\-/]+$",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/SkillType"
+          },
+          "url": {
+            "description": "Full HTTPS URL of a GitHub or GitLab repository.",
+            "minLength": 1,
+            "pattern": "^https:\\/\\/(github\\.com\\/[A-Za-z0-9._-]+\\/[A-Za-z0-9._-]+|gitlab\\.com\\/[A-Za-z0-9._-]+(?:\\/[A-Za-z0-9._-]+)+)(\\/|\\.git)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "url",
+          "ref",
+          "description"
+        ],
+        "type": "object"
+      },
+      "SkillNameRef": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "Name of a configured skill (also used as the skill directory name in the sandbox).",
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9._-]+$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SkillReadEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "Concise guidance for when the agent should use the skill.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "type": "object"
+      },
+      "SkillType": {
+        "enum": [
+          "git"
+        ],
+        "type": "string"
+      },
+      "TextContent": {
+        "properties": {
+          "text": {
+            "description": "Plain-text content.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Text content part.",
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "ThreadCreatedEvent": {
+        "properties": {
+          "agent_info": {
+            "$ref": "#/components/schemas/AgentInfo"
+          },
+          "created_at": {
+            "description": "ISO 8601 event timestamp.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the event (monotonic ULID).",
+            "type": "string"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/AgentParent"
+          },
+          "thread_id": {
+            "description": "Id of the new thread.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Human-readable thread title.",
+            "type": "string"
+          },
+          "type": {
+            "description": "A dynamic subagent thread was created.",
+            "enum": [
+              "thread.created"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "agent_info",
+          "created_at",
+          "parent",
+          "thread_id",
+          "title"
+        ],
+        "type": "object"
+      },
+      "ThreadDoneEvent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseThreadDoneEvent"
+          },
+          {
+            "properties": {
+              "created_at": {
+                "description": "ISO 8601 event timestamp.",
+                "type": "string"
+              },
+              "id": {
+                "description": "Unique identifier for the event (monotonic ULID).",
+                "type": "string"
+              },
+              "state": {
+                "$ref": "#/components/schemas/ThreadState"
+              },
+              "type": {
+                "description": "A thread reached a terminal state.",
+                "enum": [
+                  "thread.done"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "id",
+              "created_at",
+              "state"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ThreadState": {
+        "discriminator": {
+          "mapping": {
+            "done": "#/components/schemas/ThreadStateDone",
+            "error": "#/components/schemas/ThreadStateError"
+          },
+          "propertyName": "status"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ThreadStateDone"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadStateError"
+          }
+        ]
+      },
+      "ThreadStateDone": {
+        "properties": {
+          "output": {
+            "$ref": "#/components/schemas/ModelMessageEvent"
+          },
+          "status": {
+            "description": "Thread completed successfully.",
+            "enum": [
+              "done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "output"
+        ],
+        "type": "object"
+      },
+      "ThreadStateError": {
+        "properties": {
+          "error": {
+            "description": "Human-readable error message.",
+            "type": "string"
+          },
+          "output": {
+            "$ref": "#/components/schemas/ModelMessageEvent"
+          },
+          "status": {
+            "description": "Thread ended with an error.",
+            "enum": [
+              "error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "error"
+        ],
+        "type": "object"
+      },
+      "TogetherAIModelProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/ModelProviderAuth"
+          },
+          "base_url": {
+            "default": "https://api.together.xyz/v1",
+            "description": "Override of the provider's default API base URL.",
+            "format": "uri",
+            "type": "string"
+          },
+          "models": {
+            "description": "Models exposed by this provider (at least one).",
+            "items": {
+              "$ref": "#/components/schemas/ModelEntry"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "default": "together",
+            "enum": [
+              "together"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "together"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "auth",
+          "models",
+          "type"
+        ],
+        "type": "object"
+      },
+      "TokenPagination": {
+        "properties": {
+          "limit": {
+            "description": "Page size used for this response.",
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "next_page_token": {
+            "description": "Opaque token for the next page. Omit or absent when there is no next page.",
+            "type": "string"
+          },
+          "previous_page_token": {
+            "description": "Opaque token for the previous page. Omit or absent when there is no previous page.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "limit"
+        ],
+        "type": "object"
+      },
+      "ToolApprovalRequiredEvent": {
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 event timestamp.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the event (monotonic ULID).",
+            "type": "string"
+          },
+          "thread_id": {
+            "description": "Thread that owns the pending tool calls.",
+            "type": "string"
+          },
+          "tool_calls": {
+            "description": "Tool calls waiting for approval.",
+            "items": {
+              "$ref": "#/components/schemas/ToolCallRef"
+            },
+            "type": "array"
+          },
+          "type": {
+            "description": "One or more tool calls need human approval.",
+            "enum": [
+              "tool.approval_required"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "created_at",
+          "thread_id",
+          "tool_calls"
+        ],
+        "type": "object"
+      },
+      "ToolCall": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RawToolCall"
+          },
+          {
+            "properties": {
+              "tool_info": {
+                "$ref": "#/components/schemas/ToolInfo"
+              }
+            },
+            "required": [
+              "tool_info"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ToolCallRef": {
+        "properties": {
+          "id": {
+            "description": "Tool call id awaiting action.",
+            "type": "string"
+          },
+          "source_event_id": {
+            "description": "Event id of the model.message that requested the tool call.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "source_event_id"
+        ],
+        "type": "object"
+      },
+      "ToolInfo": {
+        "discriminator": {
+          "mapping": {
+            "mcp": "#/components/schemas/MCPToolInfo",
+            "truefoundry-system": "#/components/schemas/TrueFoundrySystemToolInfo"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/TrueFoundrySystemToolInfo"
+          },
+          {
+            "$ref": "#/components/schemas/MCPToolInfo"
+          }
+        ]
+      },
+      "ToolResponseEvent": {
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 event timestamp.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the event (monotonic ULID).",
+            "type": "string"
+          },
+          "thread_id": {
+            "description": "Thread that owns the tool call.",
+            "type": "string"
+          },
+          "tool_call_id": {
+            "description": "Id of the tool call this message responds to.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Result of a tool execution.",
+            "enum": [
+              "tool.response"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool_call_id",
+          "content",
+          "type",
+          "id",
+          "thread_id",
+          "created_at"
+        ],
+        "type": "object"
+      },
+      "ToolResponseRequiredEvent": {
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 event timestamp.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the event (monotonic ULID).",
+            "type": "string"
+          },
+          "thread_id": {
+            "description": "Thread that owns the pending tool calls.",
+            "type": "string"
+          },
+          "tool_calls": {
+            "description": "Tool calls waiting for a client response.",
+            "items": {
+              "$ref": "#/components/schemas/ToolCallRef"
+            },
+            "type": "array"
+          },
+          "type": {
+            "description": "One or more client-side tool calls need a user/tool response.",
+            "enum": [
+              "tool.response_required"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "created_at",
+          "thread_id",
+          "tool_calls"
+        ],
+        "type": "object"
+      },
+      "TrueFoundrySystemToolInfo": {
+        "properties": {
+          "name": {
+            "description": "System tool name.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Built-in harness system tool.",
+            "enum": [
+              "truefoundry-system"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name"
+        ],
+        "type": "object"
+      },
+      "Turn": {
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 creation timestamp.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique turn id.",
+            "type": "string"
+          },
+          "input": {
+            "description": "Input items supplied when the turn was created.",
+            "items": {
+              "$ref": "#/components/schemas/TurnInputItem"
+            },
+            "type": "array"
+          },
+          "previous_turn_id": {
+            "description": "Prior turn this turn chains from; null for a root turn.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "session_id": {
+            "description": "Session that owns this turn.",
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/components/schemas/TurnState"
+          }
+        },
+        "required": [
+          "id",
+          "session_id",
+          "previous_turn_id",
+          "state",
+          "created_at"
+        ],
+        "type": "object"
+      },
+      "TurnCreatedEvent": {
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 event timestamp.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the event (monotonic ULID).",
+            "type": "string"
+          },
+          "input": {
+            "description": "Input items supplied when the turn was created.",
+            "items": {
+              "$ref": "#/components/schemas/TurnInputItem"
+            },
+            "type": "array"
+          },
+          "previous_turn_id": {
+            "description": "Prior turn this turn chains from; null for a root turn.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "$ref": "#/components/schemas/TurnStateRunning"
+          },
+          "thread_id": {
+            "description": "Thread that owns the event; null for turn-level lifecycle events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "turn_id": {
+            "description": "Id of the newly created turn.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Emitted when a turn starts.",
+            "enum": [
+              "turn.created"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "turn_id",
+          "previous_turn_id",
+          "state",
+          "created_at",
+          "thread_id"
+        ],
+        "type": "object"
+      },
+      "TurnDoneEvent": {
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 event timestamp.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the event (monotonic ULID).",
+            "type": "string"
+          },
+          "state": {
+            "description": "Terminal turn state (done, cancelled, or error).",
+            "discriminator": {
+              "mapping": {
+                "cancelled": "#/components/schemas/TurnStateCancelled",
+                "done": "#/components/schemas/TurnStateDone",
+                "error": "#/components/schemas/TurnStateError"
+              },
+              "propertyName": "status"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TurnStateDone"
+              },
+              {
+                "$ref": "#/components/schemas/TurnStateCancelled"
+              },
+              {
+                "$ref": "#/components/schemas/TurnStateError"
+              }
+            ]
+          },
+          "thread_id": {
+            "description": "Thread that owns the event; null for turn-level lifecycle events.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": {
+            "description": "Emitted when a turn reaches a terminal state.",
+            "enum": [
+              "turn.done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "state",
+          "created_at",
+          "thread_id"
+        ],
+        "type": "object"
+      },
+      "TurnInputItem": {
+        "discriminator": {
+          "mapping": {
+            "user.message": "#/components/schemas/UserMessage",
+            "user.tool_approval": "#/components/schemas/UserToolApprovalEvent",
+            "user.tool_response": "#/components/schemas/UserToolResponseEvent"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/UserMessage"
+          },
+          {
+            "$ref": "#/components/schemas/UserToolApprovalEvent"
+          },
+          {
+            "$ref": "#/components/schemas/UserToolResponseEvent"
+          }
+        ]
+      },
+      "TurnMetrics": {
+        "description": "Optional billable aggregate for the whole turn.",
+        "properties": {
+          "total_cache_read_tokens": {
+            "description": "Total cache-read tokens across model calls in this turn.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total_cache_write_tokens": {
+            "description": "Total cache-write tokens across model calls in this turn.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total_cost_in_usd": {
+            "description": "Estimated total cost in USD for this turn.",
+            "minimum": 0,
+            "type": "number"
+          },
+          "total_input_tokens": {
+            "description": "Total input tokens across model calls in this turn.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total_output_tokens": {
+            "description": "Total output tokens across model calls in this turn.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total_reasoning_tokens": {
+            "description": "Total reasoning tokens across model calls in this turn.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total_tokens": {
+            "description": "Total tokens (input + output) across model calls in this turn.",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "TurnState": {
+        "discriminator": {
+          "mapping": {
+            "cancelled": "#/components/schemas/TurnStateCancelled",
+            "done": "#/components/schemas/TurnStateDone",
+            "error": "#/components/schemas/TurnStateError",
+            "running": "#/components/schemas/TurnStateRunning"
+          },
+          "propertyName": "status"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/TurnStateRunning"
+          },
+          {
+            "$ref": "#/components/schemas/TurnStateDone"
+          },
+          {
+            "$ref": "#/components/schemas/TurnStateCancelled"
+          },
+          {
+            "$ref": "#/components/schemas/TurnStateError"
+          }
+        ]
+      },
+      "TurnStateCancelled": {
+        "properties": {
+          "completed_at": {
+            "description": "ISO 8601 time when cancellation completed.",
+            "type": "string"
+          },
+          "metrics": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TurnMetrics"
+              },
+              {
+                "description": "Optional billable aggregate for work done before cancel."
+              }
+            ]
+          },
+          "reason": {
+            "$ref": "#/components/schemas/TurnStateCancelledReason"
+          },
+          "status": {
+            "description": "Turn was cancelled before completion.",
+            "enum": [
+              "cancelled"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "reason",
+          "completed_at"
+        ],
+        "type": "object"
+      },
+      "TurnStateCancelledReason": {
+        "description": "Reason for the cancellation.",
+        "enum": [
+          "server-execution-timeout",
+          "client-cancelled",
+          "cancelled-for-next-turn",
+          "abandoned"
+        ],
+        "type": "string"
+      },
+      "TurnStateDone": {
+        "properties": {
+          "completed_at": {
+            "description": "ISO 8601 time when the turn reached a terminal state.",
+            "type": "string"
+          },
+          "metrics": {
+            "$ref": "#/components/schemas/TurnMetrics"
+          },
+          "output": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ModelMessageEvent"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Final `model.message` for the turn, or null when the turn ended paused without a final message."
+          },
+          "required_actions": {
+            "description": "Pending actions (`tool.approval_required`, `tool.response_required`, `mcp.auth_required`); empty when none.",
+            "items": {
+              "$ref": "#/components/schemas/ActionRequiredEvent"
+            },
+            "type": "array"
+          },
+          "status": {
+            "description": "Turn finished (possibly paused for required actions).",
+            "enum": [
+              "done"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "output",
+          "required_actions",
+          "completed_at"
+        ],
+        "type": "object"
+      },
+      "TurnStateError": {
+        "properties": {
+          "completed_at": {
+            "description": "ISO 8601 time when the error state was recorded.",
+            "type": "string"
+          },
+          "message": {
+            "description": "Human-readable error message.",
+            "type": "string"
+          },
+          "metrics": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TurnMetrics"
+              },
+              {
+                "description": "Optional billable aggregate for work done before the error."
+              }
+            ]
+          },
+          "status": {
+            "description": "Turn ended with an error.",
+            "enum": [
+              "error"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "message",
+          "completed_at"
+        ],
+        "type": "object"
+      },
+      "TurnStateRunning": {
+        "properties": {
+          "status": {
+            "description": "Turn is still executing.",
+            "enum": [
+              "running"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      },
+      "TurnStreamingEvent": {
+        "discriminator": {
+          "mapping": {
+            "mcp.auth_required": "#/components/schemas/MCPAuthRequiredEvent",
+            "mcp.initialize": "#/components/schemas/MCPInitializeEvent",
+            "model.message": "#/components/schemas/ModelMessageEvent",
+            "model.message.delta": "#/components/schemas/ModelMessageDeltaEvent",
+            "sandbox.created": "#/components/schemas/SandboxCreatedEvent",
+            "thread.created": "#/components/schemas/ThreadCreatedEvent",
+            "thread.done": "#/components/schemas/ThreadDoneEvent",
+            "tool.approval_required": "#/components/schemas/ToolApprovalRequiredEvent",
+            "tool.response": "#/components/schemas/ToolResponseEvent",
+            "tool.response_required": "#/components/schemas/ToolResponseRequiredEvent",
+            "turn.created": "#/components/schemas/TurnCreatedEvent",
+            "turn.done": "#/components/schemas/TurnDoneEvent"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ModelMessageEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ModelMessageDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ToolResponseEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MCPAuthRequiredEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MCPInitializeEvent"
+          },
+          {
+            "$ref": "#/components/schemas/SandboxCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ToolApprovalRequiredEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ToolResponseRequiredEvent"
+          },
+          {
+            "$ref": "#/components/schemas/TurnCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/TurnDoneEvent"
+          }
+        ]
+      },
+      "UpdateAgentRequest": {
+        "description": "Complete agent definition used inline on a session or saved as a named agent.",
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/RuntimeConfig"
+          },
+          "instructions": {
+            "description": "Optional system prompt — the agent's role, behavior, and constraints.",
+            "type": "string"
+          },
+          "mcp_servers": {
+            "description": "Optional MCP servers attached by configured name.",
+            "items": {
+              "$ref": "#/components/schemas/MCPServer"
+            },
+            "type": "array"
+          },
+          "messages": {
+            "description": "Optional seed user messages injected at the start of every session.",
+            "items": {
+              "$ref": "#/components/schemas/AgentSpecUserMessage"
+            },
+            "type": "array"
+          },
+          "model": {
+            "$ref": "#/components/schemas/AgentSpecModel"
+          },
+          "response_format": {
+            "$ref": "#/components/schemas/ResponseFormat"
+          },
+          "skills": {
+            "description": "Optional name-only skill references. Requires `config.sandbox.enabled: true`.",
+            "items": {
+              "$ref": "#/components/schemas/SkillNameRef"
+            },
+            "type": "array"
+          },
+          "variables": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Optional string key–value map reserved for parameterizing agent definitions.",
+            "type": "object"
+          }
+        },
+        "required": [
+          "model"
+        ],
+        "type": "object"
+      },
+      "UpdateSessionRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "$ref": "#/components/schemas/SessionAgentSpecBody"
+          }
+        },
+        "type": "object"
+      },
+      "UserMessage": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UserMessageContentItem"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Plain string or structured text/file content parts."
+          },
+          "type": {
+            "description": "User message input item.",
+            "enum": [
+              "user.message"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content"
+        ],
+        "type": "object"
+      },
+      "UserMessageContentItem": {
+        "discriminator": {
+          "mapping": {
+            "file": "#/components/schemas/FileContent",
+            "text": "#/components/schemas/TextContent"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/TextContent"
+          },
+          {
+            "$ref": "#/components/schemas/FileContent"
+          }
+        ]
+      },
+      "UserToolApprovalEvent": {
+        "properties": {
+          "approval": {
+            "$ref": "#/components/schemas/ApprovalDecision"
+          },
+          "thread_id": {
+            "description": "Thread that owns the pending tool call.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "tool_call_id": {
+            "description": "Tool call id being approved or denied.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "description": "Client resume after tool.approval_required.",
+            "enum": [
+              "user.tool_approval"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "thread_id",
+          "tool_call_id",
+          "approval"
+        ],
+        "type": "object"
+      },
+      "UserToolResponseEvent": {
+        "properties": {
+          "content": {
+            "description": "Client-side tool result content.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "thread_id": {
+            "description": "Thread that owns the pending tool call.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "tool_call_id": {
+            "description": "Tool call id receiving the client response.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "description": "Client resume after tool.response_required.",
+            "enum": [
+              "user.tool_response"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "thread_id",
+          "tool_call_id",
+          "content"
+        ],
+        "type": "object"
+      },
+      "ZaiModelProvider": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/ModelProviderAuth"
+          },
+          "base_url": {
+            "default": "https://api.z.ai/api/paas/v4",
+            "description": "Override of the provider's default API base URL.",
+            "format": "uri",
+            "type": "string"
+          },
+          "models": {
+            "description": "Models exposed by this provider (at least one).",
+            "items": {
+              "$ref": "#/components/schemas/ModelEntry"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "default": "zai",
+            "enum": [
+              "zai"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "zai"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "auth",
+          "models",
+          "type"
+        ],
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "description": "HTTP API for the TrueForge agent server (`/api/v1`). Interactive docs are served at `/api/v1/docs` (OpenAPI JSON at `/api/v1/openapi.json`).\n\n**Authentication:** Standalone deployments (no OIDC) accept requests without credentials — middleware stamps a local default user. When OIDC is configured, browser login sets an httpOnly `id_token` cookie; protected routes read that cookie (not `Authorization: Bearer`). There is no built-in API-key scheme; pass custom headers only if your reverse proxy or IdP layer requires them.\n\nCovers DB-backed sessions, the agent registry, settings catalogs, and model/MCP/skill/sandbox providers.",
+    "title": "TrueForge API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/v1/agents": {
+      "get": {
+        "description": "All configured agents for the tenant.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAgentsResponse"
+                }
+              }
+            },
+            "description": "All configured agents."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          }
+        },
+        "summary": "List agents",
+        "tags": [
+          "Agents"
+        ],
+        "x-fern-sdk-group-name": [
+          "agents"
+        ],
+        "x-fern-sdk-method-name": "list"
+      },
+      "post": {
+        "description": "Creates an agent and allocates an immutable id. Fails if `name` is already taken. Name cannot be changed later.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentWriteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateAgentResponse"
+                }
+              }
+            },
+            "description": "The created agent."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request body or unknown model/MCP/skill refs."
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "An agent with this name already exists."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "The agent spec is valid but requires a capability this server does not provide (e.g. sandbox or skills)."
+          }
+        },
+        "summary": "Create an agent",
+        "tags": [
+          "Agents"
+        ],
+        "x-fern-sdk-group-name": [
+          "agents"
+        ],
+        "x-fern-sdk-method-name": "create"
+      }
+    },
+    "/api/v1/agents/{agent_id}": {
+      "delete": {
+        "description": "Delete a configured agent by immutable id. Idempotent if already gone.",
+        "parameters": [
+          {
+            "description": "Immutable agent identifier.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "description": "Immutable agent identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Agent deleted."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          }
+        },
+        "summary": "Delete an agent",
+        "tags": [
+          "Agents"
+        ],
+        "x-fern-sdk-group-name": [
+          "agents"
+        ],
+        "x-fern-sdk-method-name": "delete"
+      },
+      "get": {
+        "description": "Fetch a configured agent by immutable id.",
+        "parameters": [
+          {
+            "description": "Immutable agent identifier.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "description": "Immutable agent identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAgentResponse"
+                }
+              }
+            },
+            "description": "The agent."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Agent not found."
+          }
+        },
+        "summary": "Get an agent",
+        "tags": [
+          "Agents"
+        ],
+        "x-fern-sdk-group-name": [
+          "agents"
+        ],
+        "x-fern-sdk-method-name": "get"
+      }
+    },
+    "/api/v1/agents/{name}": {
+      "put": {
+        "description": "Replaces the AgentSpec for an existing agent keyed by immutable `name`.",
+        "parameters": [
+          {
+            "description": "Immutable unique agent name within the tenant.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ResourceName"
+                },
+                {
+                  "description": "Immutable unique agent name within the tenant."
+                }
+              ]
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAgentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutAgentResponse"
+                }
+              }
+            },
+            "description": "The saved agent."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request body or unknown model/MCP/skill refs."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Agent not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "The agent spec is valid but requires a capability this server does not provide (e.g. sandbox or skills)."
+          }
+        },
+        "summary": "Update an agent",
+        "tags": [
+          "Agents"
+        ],
+        "x-fern-sdk-group-name": [
+          "agents"
+        ],
+        "x-fern-sdk-method-name": "update"
+      }
+    },
+    "/api/v1/auth/callback": {
+      "get": {
+        "description": "Browser-redirect target hit by the identity provider after login, never called directly by SDK consumers. In local/single-binary mode, redirects straight back into the app.",
+        "parameters": [
+          {
+            "description": "Authorization code, present when the user granted consent.",
+            "in": "query",
+            "name": "code",
+            "required": false,
+            "schema": {
+              "description": "Authorization code, present when the user granted consent.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Opaque token; correlates this callback to its pending login. Always present, success or error.",
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "schema": {
+              "description": "Opaque token; correlates this callback to its pending login. Always present, success or error.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Error code from the identity provider, present instead of `code` if the user denied consent.",
+            "in": "query",
+            "name": "error",
+            "required": false,
+            "schema": {
+              "description": "Error code from the identity provider, present instead of `code` if the user denied consent.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Human-readable error detail from the identity provider when `error` is set.",
+            "in": "query",
+            "name": "error_description",
+            "required": false,
+            "schema": {
+              "description": "Human-readable error detail from the identity provider when `error` is set.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect back into the app on success, or to /?error=<reason> on failure."
+          }
+        },
+        "summary": "Login callback",
+        "tags": [
+          "Auth"
+        ],
+        "x-fern-ignore": true
+      }
+    },
+    "/api/v1/auth/login": {
+      "get": {
+        "description": "Redirects the browser to the configured identity provider. In local/single-binary mode, redirects straight back into the app — there is nothing to log into.",
+        "parameters": [
+          {
+            "description": "Path to return to after login. Must be a same-origin relative path; anything else falls back to \"/\".",
+            "in": "query",
+            "name": "return_to",
+            "required": false,
+            "schema": {
+              "description": "Path to return to after login. Must be a same-origin relative path; anything else falls back to \"/\".",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to the IdP authorization endpoint."
+          }
+        },
+        "summary": "Start the login flow",
+        "tags": [
+          "Auth"
+        ],
+        "x-fern-ignore": true
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "description": "Ends the local harness session only — does not hit the IdP end-session endpoint. A no-op in local/single-binary mode, since there is no real session to clear.",
+        "responses": {
+          "204": {
+            "description": "Session cookie cleared."
+          }
+        },
+        "summary": "Clear the local session",
+        "tags": [
+          "Auth"
+        ],
+        "x-fern-sdk-group-name": [
+          "auth"
+        ],
+        "x-fern-sdk-method-name": "logout"
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "description": "Returns the authenticated caller identity. When OIDC is configured this requires a valid session cookie (401 otherwise). Without OIDC, returns the default anonymous identity.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "Session type and identity for the current request."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          }
+        },
+        "summary": "Current session",
+        "tags": [
+          "Auth"
+        ],
+        "x-fern-sdk-group-name": [
+          "auth"
+        ],
+        "x-fern-sdk-method-name": "me"
+      }
+    },
+    "/api/v1/capabilities": {
+      "get": {
+        "description": "Report optional runtime capabilities available for this tenant.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCapabilitiesResponse"
+                }
+              }
+            },
+            "description": "Server capabilities."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          }
+        },
+        "summary": "Get server capabilities",
+        "tags": [
+          "Capabilities"
+        ],
+        "x-fern-sdk-group-name": [
+          "server"
+        ],
+        "x-fern-sdk-method-name": "get_capabilities"
+      }
+    },
+    "/api/v1/mcp-servers": {
+      "get": {
+        "description": "MCP servers as a slim name/url list for the composer. No auth or auth_status.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAvailableMcpServersResponse"
+                }
+              }
+            },
+            "description": "All MCP servers (chat projection)."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          }
+        },
+        "summary": "List MCP servers for chat",
+        "tags": [
+          "MCP Servers"
+        ],
+        "x-fern-sdk-group-name": [
+          "mcpServers"
+        ],
+        "x-fern-sdk-method-name": "list"
+      }
+    },
+    "/api/v1/mcp-servers/oauth/callback": {
+      "get": {
+        "description": "Browser redirect target for MCP server OAuth. The authorization server redirects here with `code`/`state` (or `error`). Exchanges the code for tokens, then either returns JSON or redirects to the `redirect_url` supplied at authorize time. Not called by the SDK — browsers hit this URL directly.",
+        "parameters": [
+          {
+            "description": "Authorization code, present when the user granted consent.",
+            "in": "query",
+            "name": "code",
+            "required": false,
+            "schema": {
+              "description": "Authorization code, present when the user granted consent.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Opaque token; correlates this callback to its pending login. Always present, success or error.",
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "schema": {
+              "description": "Opaque token; correlates this callback to its pending login. Always present, success or error.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Error code from the identity provider, present instead of `code` if the user denied consent.",
+            "in": "query",
+            "name": "error",
+            "required": false,
+            "schema": {
+              "description": "Error code from the identity provider, present instead of `code` if the user denied consent.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Human-readable error detail from the identity provider when `error` is set.",
+            "in": "query",
+            "name": "error_description",
+            "required": false,
+            "schema": {
+              "description": "Human-readable error detail from the identity provider when `error` is set.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "success": {
+                      "description": "Present when the OAuth callback completed without a redirect_url.",
+                      "enum": [
+                        true
+                      ],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token exchanged successfully and no `redirect_url` was given at authorize time."
+          },
+          "302": {
+            "description": "Redirect to the `redirect_url` given at authorize time, with `isSuccess` (and `reason` when it failed) appended to its existing query params."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "IdP `error`, unknown/expired `state`, token exchange failure, or `code`/`error` both missing."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Unexpected failure during token exchange."
+          }
+        },
+        "summary": "OAuth callback for MCP authorization",
+        "tags": [
+          "MCP OAuth"
+        ],
+        "x-fern-ignore": true
+      }
+    },
+    "/api/v1/mcp-servers/{name}/authorize": {
+      "delete": {
+        "description": "For auth.type dcr, deletes the stored OAuth token and returns the server with auth_status auth_required, keeping the dynamically registered OAuth client so the next authorize can reuse it. No-op for header or no-auth servers (returns the server unchanged).",
+        "parameters": [
+          {
+            "description": "MCP server name.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "MCP server name.",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutMcpServerResponse"
+                }
+              }
+            },
+            "description": "The MCP server after disconnect (auth_required for dcr)."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "MCP server not found."
+          }
+        },
+        "summary": "Disconnect OAuth for an MCP server",
+        "tags": [
+          "MCP Servers"
+        ],
+        "x-fern-sdk-group-name": [
+          "mcpServers"
+        ],
+        "x-fern-sdk-method-name": "delete_authorize"
+      },
+      "get": {
+        "description": "For servers without auth returns not_required, and for header credentials returns authenticated (no browser flow). For auth.type dcr, returns authenticated when a usable (or refreshable) token exists; otherwise runs DCR if needed and returns auth_required with an authorization URL. Optional redirect_url is where the OAuth callback then redirects the browser; without it the callback returns JSON.",
+        "parameters": [
+          {
+            "description": "MCP server name.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "MCP server name.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional FE landing URL the OAuth callback redirects to, with `isSuccess`/`reason` appended.",
+            "in": "query",
+            "name": "redirect_url",
+            "required": false,
+            "schema": {
+              "description": "Optional FE landing URL the OAuth callback redirects to, with `isSuccess`/`reason` appended.",
+              "format": "uri",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpAuthStatus"
+                }
+              }
+            },
+            "description": "Either already authenticated, or an authorization URL to redirect to."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid redirect_url."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "MCP server not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "DCR could not be completed for this server (e.g. it lacks a registration_endpoint)."
+          },
+          "424": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "The authorization server failed dynamic client registration or authorization startup."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Server misconfiguration (e.g. PUBLIC_BASE_URL unset)."
+          }
+        },
+        "summary": "Start (or short-circuit) the auth flow for an MCP server",
+        "tags": [
+          "MCP Servers"
+        ],
+        "x-fern-sdk-group-name": [
+          "mcpServers"
+        ],
+        "x-fern-sdk-method-name": "authorize"
+      }
+    },
+    "/api/v1/models": {
+      "get": {
+        "description": "Models across all configured model providers, addressed by fully qualified name `name/model_name`.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListModelsResponse"
+                }
+              }
+            },
+            "description": "All models of all configured providers."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          }
+        },
+        "summary": "List models",
+        "tags": [
+          "Models"
+        ],
+        "x-fern-sdk-group-name": [
+          "models"
+        ],
+        "x-fern-sdk-method-name": "list"
+      }
+    },
+    "/api/v1/sessions": {
+      "get": {
+        "description": "List the caller's sessions (newest first by default), token-paginated. Results are scoped to the authenticated identity via the session store's `created_by` filter (not a client query param). Optional `agent_id` filters to sessions bound to that named agent. Pass `page_token` to fetch the next page, keeping the other query params constant.",
+        "parameters": [
+          {
+            "description": "Page size. Defaults to 10, max 100.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Page size. Defaults to 10, max 100.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort sessions by creation time. Defaults to \"desc\".",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ListSessionsOrder"
+            }
+          },
+          {
+            "description": "Opaque token from a previous response `next_page_token`.",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "description": "Opaque token from a previous response `next_page_token`.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive lower bound on `created_at` (ISO-8601 / RFC 3339).",
+            "in": "query",
+            "name": "start_timestamp",
+            "required": false,
+            "schema": {
+              "description": "Inclusive lower bound on `created_at` (ISO-8601 / RFC 3339).",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive upper bound on `created_at` (ISO-8601 / RFC 3339).",
+            "in": "query",
+            "name": "end_timestamp",
+            "required": false,
+            "schema": {
+              "description": "Inclusive upper bound on `created_at` (ISO-8601 / RFC 3339).",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "When set, only sessions bound to this agent id are returned.",
+            "in": "query",
+            "name": "agent_id",
+            "required": false,
+            "schema": {
+              "description": "When set, only sessions bound to this agent id are returned.",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSessionsResponse"
+                }
+              }
+            },
+            "description": "Paginated sessions."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid query parameters or page token."
+          }
+        },
+        "summary": "List sessions",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-pagination": {
+          "cursor": "$request.page_token",
+          "next_cursor": "$response.pagination.next_page_token",
+          "results": "$response.data"
+        },
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "list"
+      },
+      "post": {
+        "description": "Create a session with `agent` as either `{ name }` (named registry binding) or `{ spec: AgentSpec }` (inline). Named sessions snapshot the agent name at create and resolve the live agent on each turn. Responses use `{ type: \"reference\", name, id }` or `{ type: \"inline\", spec }`.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSessionResponse"
+                }
+              }
+            },
+            "description": "Session created."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request body."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Named agent not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "The agent spec is valid but references a resource this server does not provide (e.g. model, MCP server, skill, or sandbox)."
+          }
+        },
+        "summary": "Create a session",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "create"
+      }
+    },
+    "/api/v1/sessions/{session_id}": {
+      "delete": {
+        "description": "Delete a session and all related turns, events, and internal state. Only the session creator (`created_by`) may delete it. Idempotent if already gone.",
+        "parameters": [
+          {
+            "description": "Session identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "description": "Session identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Session and all related data deleted."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Caller is not the session creator."
+          }
+        },
+        "summary": "Delete a session",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "delete"
+      },
+      "get": {
+        "description": "Fetch a session by ID. Only the session creator (`created_by`) may fetch it.",
+        "parameters": [
+          {
+            "description": "Session identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "description": "Session identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSessionResponse"
+                }
+              }
+            },
+            "description": "Session data."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Caller is not the session creator."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Session not found."
+          }
+        },
+        "summary": "Get a session",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "get"
+      },
+      "patch": {
+        "description": "Update a session by replacing `agent` with `{ spec: AgentSpec }`. Named (reference) sessions reject agent updates. An empty body is a valid no-op that refreshes `updated_at`. Only the session creator (`created_by`) may update it.",
+        "parameters": [
+          {
+            "description": "Session identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "description": "Session identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSessionResponse"
+                }
+              }
+            },
+            "description": "Session updated."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request body."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Caller is not the session creator."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Session not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Named session rejected an agent update, or the agent spec references a resource this server does not provide (e.g. model, MCP server, skill, or sandbox)."
+          }
+        },
+        "summary": "Update a session",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "update"
+      }
+    },
+    "/api/v1/sessions/{session_id}/cancel": {
+      "post": {
+        "description": "Cancel the running last turn for a session. Only the session creator (`created_by`) may cancel.",
+        "parameters": [
+          {
+            "description": "Session identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "description": "Session identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CancelSessionRequest"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelSessionResponse"
+                }
+              }
+            },
+            "description": "Turn cancelled."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Caller is not the session creator."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Session not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Requested action cannot be performed on the session because it is no longer usable, or the executor owning the running turn is unreachable."
+          }
+        },
+        "summary": "Cancel a running turn in a session",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "cancel"
+      }
+    },
+    "/api/v1/sessions/{session_id}/events": {
+      "get": {
+        "description": "List session events as `{ turn_id, event }` across the active turn branch (newest first), including persisted events from a running tip. Each turn contributes turn.created, content events (model.message, tool.call, …), and turn.done when terminal; streaming deltas are not included. Use `page_token` to paginate backward toward older events while retaining the original branch anchor. Only the session creator (`created_by`) may list events.",
+        "parameters": [
+          {
+            "description": "Session identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "description": "Session identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Pagination cursor from `pagination.next_page_token`. It retains the branch anchor turn and returns older events toward the session start.",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "description": "Pagination cursor from `pagination.next_page_token`. It retains the branch anchor turn and returns older events toward the session start.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Newest turn in the listing window (initial load only; ignored when `page_token` is set). Lists that turn and its ancestors, newest events first. Omit to use the session last turn.",
+            "in": "query",
+            "name": "last_turn_id",
+            "required": false,
+            "schema": {
+              "description": "Newest turn in the listing window (initial load only; ignored when `page_token` is set). Lists that turn and its ancestors, newest events first. Omit to use the session last turn.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max events per response. Default 100, max 100.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Max events per response. Default 100, max 100.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSessionEventsResponse"
+                }
+              }
+            },
+            "description": "Paginated session events."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid page token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Caller is not the session creator."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Session not found."
+          }
+        },
+        "summary": "List session events",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-pagination": {
+          "cursor": "$request.page_token",
+          "next_cursor": "$response.pagination.next_page_token",
+          "results": "$response.data"
+        },
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "list_events"
+      }
+    },
+    "/api/v1/sessions/{session_id}/turns": {
+      "get": {
+        "description": "List turns for a session (newest first by default), token-paginated. Only the session creator (`created_by`) may list turns.",
+        "parameters": [
+          {
+            "description": "Session identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "description": "Session identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size. Defaults to 10, max 100.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Page size. Defaults to 10, max 100.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque token from a previous response `next_page_token`.",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "description": "Opaque token from a previous response `next_page_token`.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTurnsResponse"
+                }
+              }
+            },
+            "description": "Paginated turns."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid page token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Caller is not the session creator."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Session not found."
+          }
+        },
+        "summary": "List turns in a session",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-pagination": {
+          "cursor": "$request.page_token",
+          "next_cursor": "$response.pagination.next_page_token",
+          "results": "$response.data"
+        },
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "list_turns"
+      },
+      "post": {
+        "description": "Create a turn within a session and execute it.\nOnly the session creator (`created_by`) may create turns.\nWhen `stream` is true (default), respond with a Server-Sent Events stream of turn events.\nWhen `stream` is false, return the turn immediately with `state.status: \"running\"` while execution continues in the background; use get turn or subscribe to observe completion.\nUse `previous_turn_id` to chain to the session's last turn (defaults to `auto`); use `none` for a new root.",
+        "parameters": [
+          {
+            "description": "Session identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "description": "Session identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTurnRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetTurnResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/TurnStreamingEvent"
+                }
+              }
+            },
+            "description": "When stream is false: the running turn. When stream is true: Server-Sent Events stream of turn events."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request body."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Caller is not the session creator."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Session or prior turn not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Requested action cannot be performed on the session because it is no longer usable."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "The request is well-formed but cannot be processed: a referenced resource is missing (named agent, model, MCP server, skill, or sandbox provider), sandbox is required but unavailable (e.g. file uploads), or the turn input conflicts with current state (e.g. unresolved tool calls or approvals, tool name collision)."
+          }
+        },
+        "summary": "Create and execute a turn in a session",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "create_turn",
+        "x-fern-streaming": {
+          "format": "sse",
+          "response": {
+            "$ref": "#/components/schemas/GetTurnResponse"
+          },
+          "response-stream": {
+            "$ref": "#/components/schemas/TurnStreamingEvent"
+          },
+          "resumable": false,
+          "stream-condition": "$request.stream"
+        }
+      }
+    },
+    "/api/v1/sessions/{session_id}/turns/{turn_id}": {
+      "get": {
+        "description": "Fetch a single turn by ID. Only the session creator (`created_by`) may fetch it.",
+        "parameters": [
+          {
+            "description": "Session identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "description": "Session identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Turn identifier.",
+            "in": "path",
+            "name": "turn_id",
+            "required": true,
+            "schema": {
+              "description": "Turn identifier.",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetTurnResponse"
+                }
+              }
+            },
+            "description": "Turn data."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Caller is not the session creator."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Session or turn not found."
+          }
+        },
+        "summary": "Get a turn",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "get_turn"
+      }
+    },
+    "/api/v1/sessions/{session_id}/turns/{turn_id}/download": {
+      "get": {
+        "description": "Download a file from the sandbox this turn ran in. Paths come from the assistant's `sandbox_artifacts` block. Only the session creator (`created_by`) may download.",
+        "parameters": [
+          {
+            "description": "Session identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "description": "Session identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Turn identifier.",
+            "in": "path",
+            "name": "turn_id",
+            "required": true,
+            "schema": {
+              "description": "Turn identifier.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Absolute path of the file inside the sandbox, as listed in the assistant's `sandbox_artifacts` block.",
+            "in": "query",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "description": "Absolute path of the file inside the sandbox, as listed in the assistant's `sandbox_artifacts` block.",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "File contents."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid path, or the path is a directory."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Caller is not the session creator, or sandbox belongs to another tenant."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Session, turn, or file not found."
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Sandbox no longer exists."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Turn has no sandbox, or no sandbox provider is configured."
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "File exceeds the maximum download size."
+          },
+          "424": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Sandbox infrastructure error."
+          }
+        },
+        "summary": "Download a file from the turn sandbox",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "download_sandbox_file"
+      }
+    },
+    "/api/v1/sessions/{session_id}/turns/{turn_id}/events": {
+      "get": {
+        "description": "Paginated persisted events for a turn (insertion order by default). Only the session creator (`created_by`) may list events.",
+        "parameters": [
+          {
+            "description": "Session identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "description": "Session identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Turn identifier.",
+            "in": "path",
+            "name": "turn_id",
+            "required": true,
+            "schema": {
+              "description": "Turn identifier.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max events per response. Default 25, max 100.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "description": "Max events per response. Default 25, max 100.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque token from a previous response `next_page_token`.",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "description": "Opaque token from a previous response `next_page_token`.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort events by insertion order. Defaults to \"asc\".",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ListTurnEventsOrder"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTurnEventsResponse"
+                }
+              }
+            },
+            "description": "Paginated turn events."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid page token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Caller is not the session creator."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Session or turn not found."
+          }
+        },
+        "summary": "List turn events",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-pagination": {
+          "cursor": "$request.page_token",
+          "next_cursor": "$response.pagination.next_page_token",
+          "results": "$response.data"
+        },
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "list_turn_events"
+      }
+    },
+    "/api/v1/sessions/{session_id}/turns/{turn_id}/subscribe": {
+      "get": {
+        "description": "Subscribe to the live SSE stream for a turn. Only the session creator (`created_by`) may subscribe. Pass `after_sequence_number` to resume after a disconnect (exclusive — events after this sequence number are replayed).",
+        "parameters": [
+          {
+            "description": "Session identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "description": "Session identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Turn identifier.",
+            "in": "path",
+            "name": "turn_id",
+            "required": true,
+            "schema": {
+              "description": "Turn identifier.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exclusive resume cursor: replay only events with a sequence number greater than this value. Omit to start from the beginning of the live buffer.",
+            "in": "query",
+            "name": "after_sequence_number",
+            "required": false,
+            "schema": {
+              "description": "Exclusive resume cursor: replay only events with a sequence number greater than this value. Omit to start from the beginning of the live buffer.",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/TurnStreamingEvent"
+                }
+              }
+            },
+            "description": "Server-Sent Events stream of turn events (deltas and lifecycle)."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid query parameters."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Caller is not the session creator."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Turn not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Cannot subscribe — the live stream no longer exists."
+          }
+        },
+        "summary": "Subscribe to a running turn",
+        "tags": [
+          "Sessions"
+        ],
+        "x-fern-sdk-group-name": [
+          "sessions"
+        ],
+        "x-fern-sdk-method-name": "subscribe_to_turn",
+        "x-fern-streaming": {
+          "format": "sse",
+          "resumable": true
+        }
+      }
+    },
+    "/api/v1/settings/mcp-servers": {
+      "get": {
+        "description": "All MCP servers with nested auth_status (settings / admin projection).",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListMcpServersResponse"
+                }
+              }
+            },
+            "description": "All MCP servers."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the caller is authenticated but not an admin."
+          }
+        },
+        "summary": "List MCP servers",
+        "tags": [
+          "MCP Servers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "mcpServers"
+        ],
+        "x-fern-sdk-method-name": "list"
+      },
+      "put": {
+        "description": "Full upsert keyed by `name`: creates the server or replaces its manifest. Does not start DCR or modify stored oauth_server / oauth_client columns.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/McpServerManifest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutMcpServerResponse"
+                }
+              }
+            },
+            "description": "The saved MCP server with stub auth_status."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request body."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "The server cannot satisfy `auth.type: dcr` (e.g. it advertises no registration_endpoint)."
+          }
+        },
+        "summary": "Create or replace an MCP server",
+        "tags": [
+          "MCP Servers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "mcpServers"
+        ],
+        "x-fern-sdk-method-name": "upsert"
+      }
+    },
+    "/api/v1/settings/mcp-servers/catalog": {
+      "get": {
+        "description": "MCP server presets shipped with the server (mcp-catalog.yaml). Discovery-only: copy an entry into PUT /settings/mcp-servers to configure it.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetMcpServerCatalogResponse"
+                }
+              }
+            },
+            "description": "The shipped catalog, verbatim."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the caller is authenticated but not an admin."
+          }
+        },
+        "summary": "Get the MCP catalog",
+        "tags": [
+          "MCP Servers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "mcpServers"
+        ],
+        "x-fern-sdk-method-name": "catalog"
+      }
+    },
+    "/api/v1/settings/mcp-servers/{name}": {
+      "get": {
+        "description": "A single MCP server by name, with nested auth_status (settings / admin projection).",
+        "parameters": [
+          {
+            "description": "MCP server name.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "MCP server name.",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetMcpServerResponse"
+                }
+              }
+            },
+            "description": "The MCP server."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "MCP server not found."
+          }
+        },
+        "summary": "Get a single MCP server by name",
+        "tags": [
+          "MCP Servers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "mcpServers"
+        ],
+        "x-fern-sdk-method-name": "get"
+      }
+    },
+    "/api/v1/settings/mcp-servers/{name}/tools": {
+      "get": {
+        "description": "All tools exposed by the given MCP server (non-paginated), as returned by the MCP `tools/list` call.",
+        "parameters": [
+          {
+            "description": "MCP server name.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "MCP server name.",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListMcpServerToolsResponse"
+                }
+              }
+            },
+            "description": "All tools of the MCP server."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Harness session login required."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "MCP server not found."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "The MCP server requires authentication (does not trigger browser OIDC login)."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "The MCP server could not be reached or returned an error."
+          }
+        },
+        "summary": "List tools of an MCP server",
+        "tags": [
+          "MCP Servers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "mcpServers"
+        ],
+        "x-fern-sdk-method-name": "list_tools"
+      }
+    },
+    "/api/v1/settings/model-providers": {
+      "get": {
+        "description": "All configured providers with their models.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListModelProvidersResponse"
+                }
+              }
+            },
+            "description": "All configured model providers."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the caller is authenticated but not an admin."
+          }
+        },
+        "summary": "List configured model providers",
+        "tags": [
+          "Model Providers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "modelProviders"
+        ],
+        "x-fern-sdk-method-name": "list"
+      },
+      "put": {
+        "description": "Full upsert keyed by `name`: creates the provider or replaces its entire configuration (models included). Every type but `custom` is named after itself, so each is limited to one configured provider and a repeat call replaces it; only `custom` providers are named, and numbered, by the caller.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModelProvider"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutModelProviderResponse"
+                }
+              }
+            },
+            "description": "The saved provider."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request body."
+          }
+        },
+        "summary": "Create or replace a model provider",
+        "tags": [
+          "Model Providers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "modelProviders"
+        ],
+        "x-fern-sdk-method-name": "upsert"
+      }
+    },
+    "/api/v1/settings/model-providers/catalog": {
+      "get": {
+        "description": "Provider and model presets shipped with the server (model-catalog.yaml). Discovery-only: copy an entry into PUT /settings/model-providers to configure it. Custom providers are not listed here.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetModelProviderCatalogResponse"
+                }
+              }
+            },
+            "description": "The shipped catalog, verbatim."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the caller is authenticated but not an admin."
+          }
+        },
+        "summary": "Get the model catalog",
+        "tags": [
+          "Model Providers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "modelProviders"
+        ],
+        "x-fern-sdk-method-name": "catalog"
+      }
+    },
+    "/api/v1/settings/sandbox-providers": {
+      "get": {
+        "description": "The single configured sandbox provider for this tenant.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSandboxProviderResponse"
+                }
+              }
+            },
+            "description": "The configured sandbox provider."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "No sandbox provider configured."
+          }
+        },
+        "summary": "Get the configured sandbox provider",
+        "tags": [
+          "Sandbox Providers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "sandboxProviders"
+        ],
+        "x-fern-sdk-method-name": "get"
+      },
+      "put": {
+        "description": "Upserts the single sandbox provider for this tenant: creates it or replaces its entire configuration.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DaytonaSandboxProvider"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutSandboxProviderResponse"
+                }
+              }
+            },
+            "description": "The saved sandbox provider."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request body."
+          }
+        },
+        "summary": "Create or replace the sandbox provider",
+        "tags": [
+          "Sandbox Providers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "sandboxProviders"
+        ],
+        "x-fern-sdk-method-name": "upsert"
+      }
+    },
+    "/api/v1/settings/sandbox-providers/catalog": {
+      "get": {
+        "description": "Sandbox provider presets shipped with the server (sandbox-catalog.yaml). Discovery-only: copy an entry into PUT /settings/sandbox-providers to configure it.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSandboxProviderCatalogResponse"
+                }
+              }
+            },
+            "description": "The shipped catalog, verbatim."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the caller is authenticated but not an admin."
+          }
+        },
+        "summary": "Get the sandbox provider catalog",
+        "tags": [
+          "Sandbox Providers"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "sandboxProviders"
+        ],
+        "x-fern-sdk-method-name": "catalog"
+      }
+    },
+    "/api/v1/settings/skills": {
+      "get": {
+        "description": "All configured skills with full manifests (settings / admin projection).",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListConfiguredSkillsResponse"
+                }
+              }
+            },
+            "description": "All configured skills."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the caller is authenticated but not an admin."
+          }
+        },
+        "summary": "List configured skills",
+        "tags": [
+          "Skills"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "skills"
+        ],
+        "x-fern-sdk-method-name": "list"
+      },
+      "put": {
+        "description": "Full upsert keyed by `name`: creates the skill or replaces its entire manifest.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkillManifest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutSkillResponse"
+                }
+              }
+            },
+            "description": "The saved skill."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request body."
+          }
+        },
+        "summary": "Create or replace a skill",
+        "tags": [
+          "Skills"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "skills"
+        ],
+        "x-fern-sdk-method-name": "upsert"
+      }
+    },
+    "/api/v1/settings/skills/catalog": {
+      "get": {
+        "description": "Skill presets shipped with the server (skill-catalog.yaml). Discovery-only: copy an entry into PUT /settings/skills to configure it.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSkillCatalogResponse"
+                }
+              }
+            },
+            "description": "The shipped catalog, verbatim."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the caller is authenticated but not an admin."
+          }
+        },
+        "summary": "Get the skill catalog",
+        "tags": [
+          "Skills"
+        ],
+        "x-fern-sdk-group-name": [
+          "settings",
+          "skills"
+        ],
+        "x-fern-sdk-method-name": "catalog"
+      }
+    },
+    "/api/v1/skills": {
+      "get": {
+        "description": "Configured skills as a slim name/description list for the composer.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAvailableSkillsResponse"
+                }
+              }
+            },
+            "description": "All configured skills (chat projection)."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "OIDC is configured and the request has no valid session cookie."
+          }
+        },
+        "summary": "List skills for chat",
+        "tags": [
+          "Skills"
+        ],
+        "x-fern-sdk-group-name": [
+          "skills"
+        ],
+        "x-fern-sdk-method-name": "list"
+      }
+    }
+  },
+  "webhooks": {}
+}

--- a/packages/server/scripts/write-openapi.ts
+++ b/packages/server/scripts/write-openapi.ts
@@ -70,7 +70,14 @@ const app = createServerApp({
 });
 
 const document = buildOpenApiDocument(app);
-const outputPath = path.join(import.meta.dirname, '../../../.github/fern/openapi/openapi.json');
-mkdirSync(path.dirname(outputPath), { recursive: true });
-writeFileSync(outputPath, `${JSON.stringify(canonicalise(document), null, 2)}\n`);
-console.log(`Wrote ${String(Object.keys(document.paths ?? {}).length)} paths to ${outputPath}`);
+const sdkOutputPath = path.join(import.meta.dirname, '../../../.github/fern/openapi/openapi.json');
+mkdirSync(path.dirname(sdkOutputPath), { recursive: true });
+writeFileSync(sdkOutputPath, `${JSON.stringify(canonicalise(document), null, 2)}\n`);
+console.log(`Wrote ${String(Object.keys(document.paths ?? {}).length)} paths to ${sdkOutputPath}`);
+
+// we are replicating it here because we need to use it in the docs
+// TODO (chiragjn): We tried symlinking but that did not work, revisit it later
+const docsOutputPath = path.join(import.meta.dirname, '../../../docs/openapi.json');
+mkdirSync(path.dirname(docsOutputPath), { recursive: true });
+writeFileSync(docsOutputPath, `${JSON.stringify(canonicalise(document), null, 2)}\n`);
+console.log(`Wrote ${String(Object.keys(document.paths ?? {}).length)} paths to ${docsOutputPath}`);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs and formatting config only; no runtime or API behavior changes.
> 
> **Overview**
> Docs now ship a **real** `docs/openapi.json` produced by `pnpm openapi:write` (same canonical JSON as `.github/fern/openapi/openapi.json`), replacing the previous symlink to the Fern path that did not work in this setup.
> 
> **`.prettierignore`** adds `docs/openapi.json` so Prettier skips that generated file, consistent with other Fern-generated artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccf3e4434b2a6e4f8765adc63794e54f8ea6d47a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->