### PR TITLE
fix(ui): rename "Save as agent" button to "Save agent"

### DIFF
--- a/packages/trueforge-ui-sdk/README.md
+++ b/packages/trueforge-ui-sdk/README.md
@@ -267,7 +267,7 @@ See [docs/theming.md](./docs/theming.md) for presets, controlled vs uncontrolled
 | `AgentLibrary`                         | Agents Library only (no draft)  | Empty until pick; no New Chat; Clear Chat after selection |
 | `AgentComposer`                        | Draft builder only (no library) | Always draft; New Chat / Clear Chat = fresh draft         |
 
-In library modes, picking an agent from the Agents Library switches to a named chat for that agent **and remounts the runtime** so the new agent starts from a clean conversation. Draft chats can be promoted via **Save as agent** (`server.saveAgent` on the resolved `AgentUIServer`). **Clear Chat** (thread header) resets the current named or draft session.
+In library modes, picking an agent from the Agents Library switches to a named chat for that agent **and remounts the runtime** so the new agent starts from a clean conversation. Draft chats can be promoted via **Save agent** (`server.saveAgent` on the resolved `AgentUIServer`). **Clear Chat** (thread header) resets the current named or draft session.
 
 ```tsx
 {

--- a/packages/trueforge-ui-sdk/src/atoms/SaveAgentButton.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/SaveAgentButton.tsx
@@ -80,8 +80,8 @@ export function SaveAgentButton() {
     }
   };
 
-  const triggerLabel = isUpdate ? 'Update Agent' : 'Save as agent';
-  const modalTitle = isUpdate ? 'Update Agent' : 'Save as agent';
+  const triggerLabel = isUpdate ? 'Update Agent' : 'Save agent';
+  const modalTitle = isUpdate ? 'Update Agent' : 'Save agent';
   const modalDescription = isUpdate
     ? 'Save changes to this agent in the Agents library'
     : 'Reuse this setup later from the Agents library';

--- a/packages/trueforge-ui-sdk/test/atoms/SaveAgentButton.test.tsx
+++ b/packages/trueforge-ui-sdk/test/atoms/SaveAgentButton.test.tsx
@@ -52,7 +52,7 @@ describe('SaveAgentButton', () => {
       </SlotsProvider>,
     );
 
-    expect(screen.queryByRole('button', { name: 'Save as agent' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save agent' })).not.toBeInTheDocument();
   });
 
   it('opens a modal with name + system instructions and saves them on agentSpec', async () => {
@@ -68,8 +68,8 @@ describe('SaveAgentButton', () => {
       </SlotsProvider>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Save as agent' }));
-    const dialog = screen.getByRole('dialog', { name: 'Save as agent' });
+    fireEvent.click(screen.getByRole('button', { name: 'Save agent' }));
+    const dialog = screen.getByRole('dialog', { name: 'Save agent' });
     expect(dialog).toBeInTheDocument();
     expect(dialog.className).toContain('h-auto');
     expect(dialog.className).toContain('md:max-w-md');
@@ -94,7 +94,7 @@ describe('SaveAgentButton', () => {
       });
     });
     await waitFor(() => {
-      expect(screen.queryByRole('dialog', { name: 'Save as agent' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog', { name: 'Save agent' })).not.toBeInTheDocument();
     });
     // Bound as mutable Edit with saved identity + spec; chrome flips to Update Agent.
     expect(screen.getByRole('button', { name: 'Update Agent' })).toBeInTheDocument();
@@ -124,8 +124,8 @@ describe('SaveAgentButton', () => {
     const epochBefore = shellSnap.agentsListEpoch;
     const runtimeKeyBefore = shellSnap.runtimeKey;
 
-    fireEvent.click(screen.getByRole('button', { name: 'Save as agent' }));
-    const dialog = screen.getByRole('dialog', { name: 'Save as agent' });
+    fireEvent.click(screen.getByRole('button', { name: 'Save agent' }));
+    const dialog = screen.getByRole('dialog', { name: 'Save agent' });
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'saved-agent' } });
     fireEvent.change(screen.getByLabelText('System instructions'), {
       target: { value: 'Be helpful.' },
@@ -169,15 +169,15 @@ describe('SaveAgentButton', () => {
       </SlotsProvider>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Save as agent' }));
-    const dialog = screen.getByRole('dialog', { name: 'Save as agent' });
+    fireEvent.click(screen.getByRole('button', { name: 'Save agent' }));
+    const dialog = screen.getByRole('dialog', { name: 'Save agent' });
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'dup' } });
     fireEvent.click(getSubmitButton(dialog));
 
     await waitFor(() => {
       expect(screen.getByText('Name taken')).toBeInTheDocument();
     });
-    expect(screen.getByRole('dialog', { name: 'Save as agent' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Save agent' })).toBeInTheDocument();
   });
 
   it('shows Update Agent and prefills name when editing a library agent', async () => {


### PR DESCRIPTION
## What

Renames the draft-chat save action label from **"Save as agent"** to **"Save agent"** — shorter and cleaner.

- Trigger button + modal title in [`SaveAgentButton.tsx`](packages/trueforge-ui-sdk/src/atoms/SaveAgentButton.tsx)
- Tests that query those by accessible name
- The UI-SDK README reference

The **"Update Agent"** label (edit-existing case) is left as-is.

## Verified
- `trueforge-ui-sdk` typecheck clean
- `SaveAgentButton` suite: 5/5 pass
- No remaining "Save as agent" anywhere in `packages/` or `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only label change with no behavior or API impact.
> 
> **Overview**
> Renames the draft save action copy from **"Save as agent"** to **"Save agent"** for the trigger button and modal title in `SaveAgentButton`.
> 
> Tests that assert accessible names and the UI-SDK README agent-modes section are updated to match. **Update Agent** labels for the edit-existing flow are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4fee327152310ebce8ba4eb47a996ae83669bf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->