### PR TITLE
fix(ui): valid agent-name example in Save agent placeholder

### DIFF
--- a/packages/trueforge-ui-sdk/src/atoms/SaveAgentButton.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/SaveAgentButton.tsx
@@ -115,7 +115,7 @@ export function SaveAgentButton() {
               type="text"
               value={name}
               onChange={e => setName(e.target.value)}
-              placeholder="Release notes writer"
+              placeholder="release-notes-writer"
               autoFocus={!isUpdate}
               autoComplete="off"
               disabled={saving || isUpdate}


### PR DESCRIPTION
The **Save agent** Name field enforces `/^[a-z](?:[a-z0-9._-]{0,62}[a-z0-9])$/` (2–64 lowercase chars, start with a letter, end alphanumeric, `. _ -` allowed between). The placeholder was `Release notes writer` — spaces + capitals, so it **violates the field's own rule** and misleads users into invalid names.

Changed the placeholder to **`release-notes-writer`**, a valid example. (System-instructions placeholder unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only placeholder change in the Save agent UI with no behavior or validation impact.
> 
> **Overview**
> The **Save agent** modal’s **Name** input placeholder is changed from `Release notes writer` to **`release-notes-writer`**.
> 
> That aligns the hint with the enforced agent name format (lowercase, no spaces, valid separators), so users aren’t nudged toward invalid names. No validation, submit flow, or other placeholders are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f017a19d9ae600e8dbeb86fbfbe68b86151b56de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->