### PR TITLE
fix(auth): clarify admin route descriptions and set user context for local admin

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -92,7 +92,7 @@ function withAuth(router: OpenAPIHono): OpenAPIHono {
   return shell;
 }
 
-/** Admin-only routes: standalone passes through; with OIDC requires an authenticated admin. */
+/** Admin-only routes: local admin when auth is disabled; with OIDC requires an authenticated admin. */
 function withAdminAuth(router: OpenAPIHono): OpenAPIHono {
   const shell = new OpenAPIHono();
   shell.use('*', adminAuthMiddleware);

--- a/packages/server/src/auth/middleware.ts
+++ b/packages/server/src/auth/middleware.ts
@@ -91,9 +91,10 @@ export const authMiddleware: MiddlewareHandler = async (c, next) => {
   return next();
 };
 
-/** Admin gate: no-op when auth is disabled; when auth is enabled requires an authenticated admin. */
+/** Admin gate: local admin when auth is disabled; when auth is enabled requires an authenticated admin. */
 export const adminAuthMiddleware: MiddlewareHandler = async (c, next) => {
   if (!getOidcVerify()) {
+    c.set('user_context', LOCAL_USER_CONTEXT);
     return next();
   }
 

--- a/packages/server/tests/unit/auth/middleware.test.ts
+++ b/packages/server/tests/unit/auth/middleware.test.ts
@@ -62,7 +62,7 @@ describe('authMiddleware', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       ok: true,
-      user: undefined,
+      user: { userRef: 'trueforge-default', role: 'admin' },
     });
   });
 


### PR DESCRIPTION
…

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/sdk`, `.github/fern/openapi/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small standalone-mode consistency fix; no change to OIDC-enforced admin checks.
> 
> **Overview**
> When OIDC is off, **`adminAuthMiddleware`** now stamps **`LOCAL_USER_CONTEXT`** on the request (same as **`authMiddleware`**), so admin routes like **`/api/v1/settings`** expose the local default admin in **`user_context`** instead of leaving it unset.
> 
> Comments on **`withAdminAuth`** and the admin middleware are updated to describe this as a **local admin** path rather than a no-op pass-through. Unit tests expect **`{ userRef: 'trueforge-default', role: 'admin' }`** on settings when auth is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8440c97edd22644cef5f9761e416d121df9ed14a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->