### PR TITLE
fix: switching models with reasoning enabled

### DIFF
--- a/packages/harness/src/core/llm/LLMTypes.ts
+++ b/packages/harness/src/core/llm/LLMTypes.ts
@@ -78,6 +78,12 @@ export const EnrichedToolCallSchema = RawToolCallSchema.extend({
   tool_info: ToolInfoSchema,
 }).openapi('ToolCall');
 
+/** Which configured provider/model minted an assistant message (replay provenance; not on the wire). */
+export const AssistantMessageSourceSchema = z.object({
+  provider_name: z.string().describe('Configured model-provider name.'),
+  model_name: z.string().describe('Configured model name.'),
+});
+
 export const RawAssistantMessageSchema = ChatCompletionAssistantMessageParamSchema.omit({
   tool_calls: true,
   audio: true,
@@ -88,6 +94,8 @@ export const RawAssistantMessageSchema = ChatCompletionAssistantMessageParamSche
     thinking_blocks: z.array(ThinkingBlockUnionSchema).optional(),
     /** Plain-text thinking content streamed incrementally for frontend display; redundant with thinking_blocks[].thinking. */
     reasoning_content: z.string().optional(),
+    /** Provider/model that produced this message; used to gate reasoning-signature replay. */
+    source: AssistantMessageSourceSchema.optional(),
   })
   .openapi('RawAssistantMessage');
 
@@ -97,10 +105,11 @@ export const InternalEnrichedAssistantMessageSchema = RawAssistantMessageSchema.
   tool_calls: z.array(InternalEnrichedToolCallSchema).optional(),
 });
 
-// `thinking_blocks` omitted: kept on the internal message for Redis replay, hidden from the client event.
+// `thinking_blocks` / `source` omitted: kept on the internal message for context replay, hidden from the client event.
 export const EnrichedAssistantMessageSchema = RawAssistantMessageSchema.omit({
   tool_calls: true,
   thinking_blocks: true,
+  source: true,
 })
   .extend({
     tool_calls: z.array(EnrichedToolCallSchema).optional(),
@@ -156,6 +165,7 @@ export type MCPToolInfo = z.infer<typeof MCPToolInfoSchema>;
 export type ToolInfo = z.infer<typeof ToolInfoSchema>;
 export type InternalEnrichedToolCall = z.infer<typeof InternalEnrichedToolCallSchema>;
 export type EnrichedToolCall = z.infer<typeof EnrichedToolCallSchema>;
+export type AssistantMessageSource = z.infer<typeof AssistantMessageSourceSchema>;
 export type RawAssistantMessage = z.infer<typeof RawAssistantMessageSchema>;
 export type InternalEnrichedAssistantMessage = z.infer<typeof InternalEnrichedAssistantMessageSchema>;
 export type EnrichedAssistantMessage = z.infer<typeof EnrichedAssistantMessageSchema>;

--- a/packages/harness/src/core/llm/LLMTypes.ts
+++ b/packages/harness/src/core/llm/LLMTypes.ts
@@ -88,7 +88,7 @@ export const RawAssistantMessageSchema = ChatCompletionAssistantMessageParamSche
     thinking_blocks: z.array(ThinkingBlockUnionSchema).optional(),
     /** Plain-text thinking content streamed incrementally for frontend display; redundant with thinking_blocks[].thinking. */
     reasoning_content: z.string().optional(),
-    /**Provenance for reasoning-signature replay: `provider_type/provider_name/model_name`.*/
+    /** Source of the message: which provider/model sent it (`provider_type/provider_name/model_name`). */
     source: z.string().optional(),
   })
   .openapi('RawAssistantMessage');

--- a/packages/harness/src/core/llm/LLMTypes.ts
+++ b/packages/harness/src/core/llm/LLMTypes.ts
@@ -78,12 +78,6 @@ export const EnrichedToolCallSchema = RawToolCallSchema.extend({
   tool_info: ToolInfoSchema,
 }).openapi('ToolCall');
 
-/** Which configured provider/model minted an assistant message (replay provenance; not on the wire). */
-export const AssistantMessageSourceSchema = z.object({
-  provider_name: z.string().describe('Configured model-provider name.'),
-  model_name: z.string().describe('Configured model name.'),
-});
-
 export const RawAssistantMessageSchema = ChatCompletionAssistantMessageParamSchema.omit({
   tool_calls: true,
   audio: true,
@@ -94,8 +88,8 @@ export const RawAssistantMessageSchema = ChatCompletionAssistantMessageParamSche
     thinking_blocks: z.array(ThinkingBlockUnionSchema).optional(),
     /** Plain-text thinking content streamed incrementally for frontend display; redundant with thinking_blocks[].thinking. */
     reasoning_content: z.string().optional(),
-    /** Provider/model that produced this message; used to gate reasoning-signature replay. */
-    source: AssistantMessageSourceSchema.optional(),
+    /**Provenance for reasoning-signature replay: `provider_type/provider_name/model_name`.*/
+    source: z.string().optional(),
   })
   .openapi('RawAssistantMessage');
 
@@ -165,7 +159,6 @@ export type MCPToolInfo = z.infer<typeof MCPToolInfoSchema>;
 export type ToolInfo = z.infer<typeof ToolInfoSchema>;
 export type InternalEnrichedToolCall = z.infer<typeof InternalEnrichedToolCallSchema>;
 export type EnrichedToolCall = z.infer<typeof EnrichedToolCallSchema>;
-export type AssistantMessageSource = z.infer<typeof AssistantMessageSourceSchema>;
 export type RawAssistantMessage = z.infer<typeof RawAssistantMessageSchema>;
 export type InternalEnrichedAssistantMessage = z.infer<typeof InternalEnrichedAssistantMessageSchema>;
 export type EnrichedAssistantMessage = z.infer<typeof EnrichedAssistantMessageSchema>;

--- a/packages/harness/src/core/llm/VercelAILLM.ts
+++ b/packages/harness/src/core/llm/VercelAILLM.ts
@@ -615,8 +615,8 @@ export function toUserContent(content: string | ChatCompletionContentPart[]): Us
  * - `'google-gemini'` → per-tool-call `google.thoughtSignature`, no standalone reasoning block
  * - `'custom'`        → OpenAI-compatible ignores providerOptions, so the token has nowhere to go
  *
- * Signatures attach when `source` (`type/name/model`) matches: same provider type, or for
- * `custom` the same provider name. Missing/foreign source → reasoning text only.
+ * Signatures attach when `source` (`type/name/model`) matches both provider type and
+ * provider name. Missing/foreign source → reasoning text only.
  */
 export function toAssistantModelMessage({
   msg,
@@ -625,7 +625,7 @@ export function toAssistantModelMessage({
 }: {
   msg: Extract<ChatCompletionMessageParam, { role: 'assistant' }>;
   provider: VercelAIProviderName;
-  /** Configured provider resource name (FQN prefix); used when `provider` is `custom`. */
+  /** Configured provider resource name (FQN prefix). */
   providerName: string;
 }): ModelMessage {
   const parts: AssistantContent = [];
@@ -736,7 +736,7 @@ function parseAssistantMessageSource(
   return { providerType, providerName, modelName };
 }
 
-/** Same adapter type keeps signatures; `custom` also requires the same configured provider name. */
+/** Attach when both provider type and configured provider name match `source`. */
 export function shouldAttachReasoningSignature({
   source,
   provider,
@@ -750,10 +750,7 @@ export function shouldAttachReasoningSignature({
   if (parsed === undefined) {
     return false;
   }
-  if (provider === 'custom') {
-    return parsed.providerType === 'custom' && parsed.providerName === providerName;
-  }
-  return parsed.providerType === provider;
+  return parsed.providerType === provider && parsed.providerName === providerName;
 }
 
 export interface ConvertedMessages {

--- a/packages/harness/src/core/llm/VercelAILLM.ts
+++ b/packages/harness/src/core/llm/VercelAILLM.ts
@@ -1282,6 +1282,18 @@ export async function* mapStreamToChunks({
   return { usage: finalUsage, output, finish_reason: finalFinishReason };
 }
 
+/** Split `provider/model` FQN. Returns undefined when the shape is not exactly one slash. */
+function parseModelFqn(name: string): { providerName: string; modelName: string } | undefined {
+  const slash = name.indexOf('/');
+  if (slash <= 0 || slash === name.length - 1) {
+    return undefined;
+  }
+  if (name.includes('/', slash + 1)) {
+    return undefined;
+  }
+  return { providerName: name.slice(0, slash), modelName: name.slice(slash + 1) };
+}
+
 // ---------------------------------------------------------------------------
 // VercelAILLM
 // ---------------------------------------------------------------------------
@@ -1383,7 +1395,16 @@ export class VercelAILLM implements ILLM {
     };
 
     try {
-      return yield* mapStreamToChunks({ stream: streamResult.stream, chunkMeta });
+      const result = yield* mapStreamToChunks({ stream: streamResult.stream, chunkMeta });
+      // Stamp provenance for reasoning-signature replay; omit when name is not a provider/model FQN.
+      const parsed = parseModelFqn(providerConfig.name);
+      if (parsed) {
+        result.output.source = {
+          provider_name: parsed.providerName,
+          model_name: parsed.modelName,
+        };
+      }
+      return result;
     } catch (error) {
       if (this.signal?.aborted) {
         this.logger.debug('LLM stream aborted', extractErrorLogFields(error));

--- a/packages/harness/src/core/llm/VercelAILLM.ts
+++ b/packages/harness/src/core/llm/VercelAILLM.ts
@@ -615,8 +615,8 @@ export function toUserContent(content: string | ChatCompletionContentPart[]): Us
  * - `'google-gemini'` → per-tool-call `google.thoughtSignature`, no standalone reasoning block
  * - `'custom'`        → OpenAI-compatible ignores providerOptions, so the token has nowhere to go
  *
- * Signatures are attached only when `source.provider_name` matches the current `providerName`.
- * Missing or foreign source → reasoning text without providerOptions.
+ * Signatures attach when `source` (`type/name/model`) matches: same provider type, or for
+ * `custom` the same provider name. Missing/foreign source → reasoning text only.
  */
 export function toAssistantModelMessage({
   msg,
@@ -625,14 +625,18 @@ export function toAssistantModelMessage({
 }: {
   msg: Extract<ChatCompletionMessageParam, { role: 'assistant' }>;
   provider: VercelAIProviderName;
+  /** Configured provider resource name (FQN prefix); used when `provider` is `custom`. */
   providerName: string;
 }): ModelMessage {
   const parts: AssistantContent = [];
 
   // `thinking_blocks` / `source` are attached at runtime by AgentThread and absent from the OpenAI SDK type.
   const rawThinking: unknown = Reflect.get(msg, 'thinking_blocks');
-  const messageSource = readAssistantMessageSource(msg);
-  const attachSignature = messageSource?.provider_name === providerName;
+  const attachSignature = shouldAttachReasoningSignature({
+    source: Reflect.get(msg, 'source'),
+    provider,
+    providerName,
+  });
   // Alibaba appends replayed thinking to the visible answer, and Qwen signs nothing to preserve.
   if (Array.isArray(rawThinking) && provider !== 'alibaba') {
     // Widen any[] → unknown[] so the in-guards below narrow safely.
@@ -718,18 +722,38 @@ export function toAssistantModelMessage({
   };
 }
 
-/** Reads optional `source` stamped on an assistant message for signature replay gating. */
-function readAssistantMessageSource(msg: object): { provider_name: string; model_name: string } | undefined {
-  const rawSource: unknown = Reflect.get(msg, 'source');
-  if (!isPlainObject(rawSource)) {
+/** Parse `provider_type/provider_name/model_name`. */
+function parseAssistantMessageSource(
+  source: unknown,
+): { providerType: string; providerName: string; modelName: string } | undefined {
+  if (typeof source !== 'string') {
     return undefined;
   }
-  const provider_name = rawSource['provider_name'];
-  const model_name = rawSource['model_name'];
-  if (typeof provider_name !== 'string' || typeof model_name !== 'string') {
+  const [providerType, providerName, modelName, ...rest] = source.split('/');
+  if (rest.length > 0 || !providerType || !providerName || !modelName) {
     return undefined;
   }
-  return { provider_name, model_name };
+  return { providerType, providerName, modelName };
+}
+
+/** Same adapter type keeps signatures; `custom` also requires the same configured provider name. */
+export function shouldAttachReasoningSignature({
+  source,
+  provider,
+  providerName,
+}: {
+  source: unknown;
+  provider: VercelAIProviderName;
+  providerName: string;
+}): boolean {
+  const parsed = parseAssistantMessageSource(source);
+  if (parsed === undefined) {
+    return false;
+  }
+  if (provider === 'custom') {
+    return parsed.providerType === 'custom' && parsed.providerName === providerName;
+  }
+  return parsed.providerType === provider;
 }
 
 export interface ConvertedMessages {
@@ -1426,10 +1450,7 @@ export class VercelAILLM implements ILLM {
     try {
       const result = yield* mapStreamToChunks({ stream: streamResult.stream, chunkMeta });
       if (parsedFqn) {
-        result.output.source = {
-          provider_name: parsedFqn.providerName,
-          model_name: parsedFqn.modelName,
-        };
+        result.output.source = `${providerConfig.provider}/${parsedFqn.providerName}/${parsedFqn.modelName}`;
       }
       return result;
     } catch (error) {

--- a/packages/harness/src/core/llm/VercelAILLM.ts
+++ b/packages/harness/src/core/llm/VercelAILLM.ts
@@ -73,7 +73,7 @@ export type VercelAIProviderName = (typeof VERCEL_AI_PROVIDER_NAMES)[number];
  */
 export interface VercelAIProviderConfig {
   provider: VercelAIProviderName;
-  /** Display name / alias, used for logs and errors. Often provider-qualified, so never sent. */
+  /** Display name / alias, used for logs and errors. Often a provider/model FQN when set by the host. */
   name: string;
   /** Provider-facing model identifier. */
   modelId: string;
@@ -614,18 +614,25 @@ export function toUserContent(content: string | ChatCompletionContentPart[]): Us
  * - `'anthropic'`     → `anthropic.signature`
  * - `'google-gemini'` → per-tool-call `google.thoughtSignature`, no standalone reasoning block
  * - `'custom'`        → OpenAI-compatible ignores providerOptions, so the token has nowhere to go
+ *
+ * Signatures are attached only when `source.provider_name` matches the current `providerName`.
+ * Missing or foreign source → reasoning text without providerOptions.
  */
 export function toAssistantModelMessage({
   msg,
   provider,
+  providerName,
 }: {
   msg: Extract<ChatCompletionMessageParam, { role: 'assistant' }>;
   provider: VercelAIProviderName;
+  providerName: string;
 }): ModelMessage {
   const parts: AssistantContent = [];
 
-  // `thinking_blocks` is attached at runtime by AgentThread and absent from the OpenAI SDK type.
+  // `thinking_blocks` / `source` are attached at runtime by AgentThread and absent from the OpenAI SDK type.
   const rawThinking: unknown = Reflect.get(msg, 'thinking_blocks');
+  const messageSource = readAssistantMessageSource(msg);
+  const attachSignature = messageSource?.provider_name === providerName;
   // Alibaba appends replayed thinking to the visible answer, and Qwen signs nothing to preserve.
   if (Array.isArray(rawThinking) && provider !== 'alibaba') {
     // Widen any[] → unknown[] so the in-guards below narrow safely.
@@ -641,7 +648,7 @@ export function toAssistantModelMessage({
       ) {
         const signature = 'signature' in tb && typeof tb.signature === 'string' ? tb.signature : undefined;
         let reasoningProviderOptions: ProviderOptions | undefined;
-        if (signature !== undefined) {
+        if (signature !== undefined && attachSignature) {
           if (provider === 'openai') {
             reasoningProviderOptions = { openai: { reasoningEncryptedContent: signature } };
           } else if (provider === 'anthropic') {
@@ -711,6 +718,20 @@ export function toAssistantModelMessage({
   };
 }
 
+/** Reads optional `source` stamped on an assistant message for signature replay gating. */
+function readAssistantMessageSource(msg: object): { provider_name: string; model_name: string } | undefined {
+  const rawSource: unknown = Reflect.get(msg, 'source');
+  if (!isPlainObject(rawSource)) {
+    return undefined;
+  }
+  const provider_name = rawSource['provider_name'];
+  const model_name = rawSource['model_name'];
+  if (typeof provider_name !== 'string' || typeof model_name !== 'string') {
+    return undefined;
+  }
+  return { provider_name, model_name };
+}
+
 export interface ConvertedMessages {
   instructions: string | undefined;
   messages: ModelMessage[];
@@ -724,9 +745,11 @@ export interface ConvertedMessages {
 export function convertMessages({
   messages,
   provider,
+  providerName,
 }: {
   messages: ChatCompletionMessageParam[];
   provider: VercelAIProviderName;
+  providerName: string;
 }): ConvertedMessages {
   const toolNameById = new Map<string, string>();
   for (const msg of messages) {
@@ -753,7 +776,7 @@ export function convertMessages({
       continue;
     }
     if (msg.role === 'assistant') {
-      result.push(toAssistantModelMessage({ msg, provider }));
+      result.push(toAssistantModelMessage({ msg, provider, providerName }));
       continue;
     }
     if (msg.role === 'tool') {
@@ -1315,8 +1338,14 @@ export class VercelAILLM implements ILLM {
   ): AsyncGenerator<ExtendedChatCompletionChunk, RawAssistantMessageWithUsage, unknown> {
     const { providerConfig } = this.config;
     const model = buildLanguageModel(providerConfig);
+    const parsedFqn = parseModelFqn(providerConfig.name);
+    const providerName = parsedFqn?.providerName ?? providerConfig.provider;
 
-    const { instructions, messages } = convertMessages({ messages: body.messages, provider: providerConfig.provider });
+    const { instructions, messages } = convertMessages({
+      messages: body.messages,
+      provider: providerConfig.provider,
+      providerName,
+    });
     const tools = convertTools(body.tools ?? undefined);
     const structuredOutputSpec = toStructuredOutputSpec(body.response_format);
     const output = buildOutput(structuredOutputSpec);
@@ -1396,12 +1425,10 @@ export class VercelAILLM implements ILLM {
 
     try {
       const result = yield* mapStreamToChunks({ stream: streamResult.stream, chunkMeta });
-      // Stamp provenance for reasoning-signature replay; omit when name is not a provider/model FQN.
-      const parsed = parseModelFqn(providerConfig.name);
-      if (parsed) {
+      if (parsedFqn) {
         result.output.source = {
-          provider_name: parsed.providerName,
-          model_name: parsed.modelName,
+          provider_name: parsedFqn.providerName,
+          model_name: parsedFqn.modelName,
         };
       }
       return result;

--- a/packages/harness/src/core/llm/VercelAILLM.ts
+++ b/packages/harness/src/core/llm/VercelAILLM.ts
@@ -622,19 +622,24 @@ export function toAssistantModelMessage({
   msg,
   provider,
   providerName,
+  logger,
 }: {
   msg: Extract<ChatCompletionMessageParam, { role: 'assistant' }>;
   provider: VercelAIProviderName;
   /** Configured provider resource name (FQN prefix). */
   providerName: string;
+  logger?: Logger | undefined;
 }): ModelMessage {
   const parts: AssistantContent = [];
 
   // `thinking_blocks` / `source` are attached at runtime by AgentThread and absent from the OpenAI SDK type.
   const rawThinking: unknown = Reflect.get(msg, 'thinking_blocks');
-  const rawSource: unknown = Reflect.get(msg, 'source');
-  const source = typeof rawSource === 'string' ? rawSource : undefined;
-  const attachSignature = shouldAttachReasoningSignature({ source, provider, providerName });
+  const attachSignature = shouldAttachReasoningSignature({
+    source: Reflect.get(msg, 'source'),
+    provider,
+    providerName,
+    logger,
+  });
   // Alibaba appends replayed thinking to the visible answer, and Qwen signs nothing to preserve.
   if (Array.isArray(rawThinking) && provider !== 'alibaba') {
     // Widen any[] → unknown[] so the in-guards below narrow safely.
@@ -736,16 +741,23 @@ export function shouldAttachReasoningSignature({
   source,
   provider,
   providerName,
+  logger,
 }: {
-  source: string | undefined;
+  source: unknown;
   provider: VercelAIProviderName;
   providerName: string;
+  logger?: Logger | undefined;
 }): boolean {
   if (source === undefined) {
     return false;
   }
+  if (typeof source !== 'string') {
+    logger?.warn('Ignoring non-string assistant message source; skipping reasoning signature replay', { source });
+    return false;
+  }
   const parsed = parseAssistantMessageSource(source);
   if (parsed === undefined) {
+    logger?.warn('Ignoring malformed assistant message source; skipping reasoning signature replay', { source });
     return false;
   }
   return parsed.providerType === provider && parsed.providerName === providerName;
@@ -765,10 +777,12 @@ export function convertMessages({
   messages,
   provider,
   providerName,
+  logger,
 }: {
   messages: ChatCompletionMessageParam[];
   provider: VercelAIProviderName;
   providerName: string;
+  logger?: Logger | undefined;
 }): ConvertedMessages {
   const toolNameById = new Map<string, string>();
   for (const msg of messages) {
@@ -795,7 +809,7 @@ export function convertMessages({
       continue;
     }
     if (msg.role === 'assistant') {
-      result.push(toAssistantModelMessage({ msg, provider, providerName }));
+      result.push(toAssistantModelMessage({ msg, provider, providerName, logger }));
       continue;
     }
     if (msg.role === 'tool') {
@@ -1364,6 +1378,7 @@ export class VercelAILLM implements ILLM {
       messages: body.messages,
       provider: providerConfig.provider,
       providerName,
+      logger: this.logger,
     });
     const tools = convertTools(body.tools ?? undefined);
     const structuredOutputSpec = toStructuredOutputSpec(body.response_format);

--- a/packages/harness/src/core/llm/VercelAILLM.ts
+++ b/packages/harness/src/core/llm/VercelAILLM.ts
@@ -632,11 +632,9 @@ export function toAssistantModelMessage({
 
   // `thinking_blocks` / `source` are attached at runtime by AgentThread and absent from the OpenAI SDK type.
   const rawThinking: unknown = Reflect.get(msg, 'thinking_blocks');
-  const attachSignature = shouldAttachReasoningSignature({
-    source: Reflect.get(msg, 'source'),
-    provider,
-    providerName,
-  });
+  const rawSource: unknown = Reflect.get(msg, 'source');
+  const source = typeof rawSource === 'string' ? rawSource : undefined;
+  const attachSignature = shouldAttachReasoningSignature({ source, provider, providerName });
   // Alibaba appends replayed thinking to the visible answer, and Qwen signs nothing to preserve.
   if (Array.isArray(rawThinking) && provider !== 'alibaba') {
     // Widen any[] → unknown[] so the in-guards below narrow safely.
@@ -724,11 +722,8 @@ export function toAssistantModelMessage({
 
 /** Parse `provider_type/provider_name/model_name`. */
 function parseAssistantMessageSource(
-  source: unknown,
+  source: string,
 ): { providerType: string; providerName: string; modelName: string } | undefined {
-  if (typeof source !== 'string') {
-    return undefined;
-  }
   const [providerType, providerName, modelName, ...rest] = source.split('/');
   if (rest.length > 0 || !providerType || !providerName || !modelName) {
     return undefined;
@@ -742,10 +737,13 @@ export function shouldAttachReasoningSignature({
   provider,
   providerName,
 }: {
-  source: unknown;
+  source: string | undefined;
   provider: VercelAIProviderName;
   providerName: string;
 }): boolean {
+  if (source === undefined) {
+    return false;
+  }
   const parsed = parseAssistantMessageSource(source);
   if (parsed === undefined) {
     return false;

--- a/packages/harness/src/core/runtime/AgentThread.ts
+++ b/packages/harness/src/core/runtime/AgentThread.ts
@@ -227,10 +227,11 @@ function buildModelMessageEvent({
   usage: ModelMessageUsage | undefined;
   id: string;
 }): ModelMessageEvent {
-  // `thinking_blocks` is persisted to the Redis context for replay; strip it from the client event.
-  const { role, tool_calls, thinking_blocks, ...rest } = assistantMessage;
+  // `thinking_blocks` / `source` stay on the context message for replay; strip them from the client event.
+  const { role, tool_calls, thinking_blocks, source, ...rest } = assistantMessage;
   void role;
   void thinking_blocks;
+  void source;
   const event: ModelMessageEvent = {
     ...rest,
     tool_calls: tool_calls?.map(toEnrichedToolCall),

--- a/packages/harness/tests/core/llm/VercelAILLM.messages.test.ts
+++ b/packages/harness/tests/core/llm/VercelAILLM.messages.test.ts
@@ -264,6 +264,50 @@ describe('toAssistantModelMessage', () => {
     const toolCallPart = (result.content as Array<{ type: string }>).find(p => p.type === 'tool-call');
     expect(toolCallPart).not.toHaveProperty('providerOptions');
   });
+
+  it('attaches signature when source.provider_name matches, ignoring model_name', () => {
+    const msg: Extract<ChatCompletionMessageParam, { role: 'assistant' }> = {
+      role: 'assistant',
+      content: null,
+    };
+    Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'step', signature: 'sig' }]);
+    Reflect.set(msg, 'source', { provider_name: 'openai', model_name: 'old-model' });
+
+    const result = toAssistantModelMessage({ msg: msg, provider: 'openai', providerName: 'openai' });
+    const reasoningPart = (result.content as Array<{ type: string; providerOptions?: unknown }>).find(
+      p => p.type === 'reasoning',
+    );
+    expect(reasoningPart?.providerOptions).toEqual({ openai: { reasoningEncryptedContent: 'sig' } });
+  });
+
+  it('omits signature providerOptions when source.provider_name differs from current provider', () => {
+    const msg: Extract<ChatCompletionMessageParam, { role: 'assistant' }> = {
+      role: 'assistant',
+      content: null,
+    };
+    Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'step', signature: 'ant-sig' }]);
+    Reflect.set(msg, 'source', { provider_name: 'anthropic', model_name: 'opus' });
+
+    const result = toAssistantModelMessage({ msg: msg, provider: 'openai', providerName: 'openai' });
+    const reasoningPart = (result.content as Array<{ type: string; text?: string; providerOptions?: unknown }>).find(
+      p => p.type === 'reasoning',
+    );
+    expect(reasoningPart?.text).toBe('step');
+    expect(reasoningPart).not.toHaveProperty('providerOptions');
+  });
+
+  it('omits signature providerOptions when source is missing', () => {
+    const msg: Extract<ChatCompletionMessageParam, { role: 'assistant' }> = {
+      role: 'assistant',
+      content: null,
+    };
+    Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'step', signature: 'sig' }]);
+
+    const result = toAssistantModelMessage({ msg: msg, provider: 'openai', providerName: 'openai' });
+    const reasoningPart = (result.content as Array<{ type: string; text?: string }>).find(p => p.type === 'reasoning');
+    expect(reasoningPart?.text).toBe('step');
+    expect(reasoningPart).not.toHaveProperty('providerOptions');
+  });
 });
 
 // ─────────── convertMessages ───────────

--- a/packages/harness/tests/core/llm/VercelAILLM.messages.test.ts
+++ b/packages/harness/tests/core/llm/VercelAILLM.messages.test.ts
@@ -8,6 +8,7 @@ import {
   convertMessages,
   convertTools,
   parseMimeFromDataUri,
+  shouldAttachReasoningSignature,
   toAssistantModelMessage,
   toFilePart,
   toUserContent,
@@ -180,7 +181,7 @@ describe('toAssistantModelMessage', () => {
       content: null,
     };
     Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'step one', signature: 'sig-openai' }]);
-    Reflect.set(msg, 'source', { provider_name: 'openai', model_name: 'test' });
+    Reflect.set(msg, 'source', 'openai/openai/test');
 
     const result = toAssistantModelMessage({ msg: msg, provider: 'openai', providerName: 'openai' });
     const reasoningPart = (result.content as Array<{ type: string; text?: string; providerOptions?: unknown }>).find(
@@ -197,7 +198,7 @@ describe('toAssistantModelMessage', () => {
       content: null,
     };
     Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'step two', signature: 'sig-ant' }]);
-    Reflect.set(msg, 'source', { provider_name: 'anthropic', model_name: 'test' });
+    Reflect.set(msg, 'source', 'anthropic/anthropic/test');
 
     const result = toAssistantModelMessage({ msg: msg, provider: 'anthropic', providerName: 'anthropic' });
     const reasoningPart = (result.content as Array<{ type: string; providerOptions?: unknown }>).find(
@@ -265,13 +266,13 @@ describe('toAssistantModelMessage', () => {
     expect(toolCallPart).not.toHaveProperty('providerOptions');
   });
 
-  it('attaches signature when source.provider_name matches, ignoring model_name', () => {
+  it('attaches signature when source provider type matches, ignoring model_name', () => {
     const msg: Extract<ChatCompletionMessageParam, { role: 'assistant' }> = {
       role: 'assistant',
       content: null,
     };
     Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'step', signature: 'sig' }]);
-    Reflect.set(msg, 'source', { provider_name: 'openai', model_name: 'old-model' });
+    Reflect.set(msg, 'source', 'openai/openai/old-model');
 
     const result = toAssistantModelMessage({ msg: msg, provider: 'openai', providerName: 'openai' });
     const reasoningPart = (result.content as Array<{ type: string; providerOptions?: unknown }>).find(
@@ -280,13 +281,13 @@ describe('toAssistantModelMessage', () => {
     expect(reasoningPart?.providerOptions).toEqual({ openai: { reasoningEncryptedContent: 'sig' } });
   });
 
-  it('omits signature providerOptions when source.provider_name differs from current provider', () => {
+  it('omits signature providerOptions when source provider type differs', () => {
     const msg: Extract<ChatCompletionMessageParam, { role: 'assistant' }> = {
       role: 'assistant',
       content: null,
     };
     Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'step', signature: 'ant-sig' }]);
-    Reflect.set(msg, 'source', { provider_name: 'anthropic', model_name: 'opus' });
+    Reflect.set(msg, 'source', 'anthropic/anthropic/opus');
 
     const result = toAssistantModelMessage({ msg: msg, provider: 'openai', providerName: 'openai' });
     const reasoningPart = (result.content as Array<{ type: string; text?: string; providerOptions?: unknown }>).find(
@@ -294,6 +295,23 @@ describe('toAssistantModelMessage', () => {
     );
     expect(reasoningPart?.text).toBe('step');
     expect(reasoningPart).not.toHaveProperty('providerOptions');
+  });
+
+  it('for custom providers, requires matching provider name (not only type)', () => {
+    expect(
+      shouldAttachReasoningSignature({
+        source: 'custom/gateway-a/model',
+        provider: 'custom',
+        providerName: 'gateway-a',
+      }),
+    ).toBe(true);
+    expect(
+      shouldAttachReasoningSignature({
+        source: 'custom/gateway-a/model',
+        provider: 'custom',
+        providerName: 'gateway-b',
+      }),
+    ).toBe(false);
   });
 
   it('omits signature providerOptions when source is missing', () => {
@@ -405,7 +423,7 @@ describe('convertMessages', () => {
   it('threads the provider into assistant message reasoning parts', () => {
     const msg: ChatCompletionMessageParam = { role: 'assistant', content: null };
     Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'thought', signature: 'sig' }]);
-    Reflect.set(msg, 'source', { provider_name: 'anthropic', model_name: 'test' });
+    Reflect.set(msg, 'source', 'anthropic/anthropic/test');
 
     const { messages: result } = convertMessages({ messages: [msg], provider: 'anthropic', providerName: 'anthropic' });
     const assistantMsg = result.find(m => m.role === 'assistant');

--- a/packages/harness/tests/core/llm/VercelAILLM.messages.test.ts
+++ b/packages/harness/tests/core/llm/VercelAILLM.messages.test.ts
@@ -314,6 +314,17 @@ describe('toAssistantModelMessage', () => {
     ).toBe(false);
   });
 
+  // Defensive: well-known gate is type-only; a shared name must not override a type mismatch.
+  it('does not attach when provider type differs even if provider_name matches', () => {
+    expect(
+      shouldAttachReasoningSignature({
+        source: 'openai/shared/model',
+        provider: 'anthropic',
+        providerName: 'shared',
+      }),
+    ).toBe(false);
+  });
+
   it('omits signature providerOptions when source is missing', () => {
     const msg: Extract<ChatCompletionMessageParam, { role: 'assistant' }> = {
       role: 'assistant',

--- a/packages/harness/tests/core/llm/VercelAILLM.messages.test.ts
+++ b/packages/harness/tests/core/llm/VercelAILLM.messages.test.ts
@@ -121,7 +121,7 @@ describe('toAssistantModelMessage', () => {
       role: 'assistant',
       content: 'hello',
     };
-    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini' });
+    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini', providerName: 'google-gemini' });
     expect(result.role).toBe('assistant');
     expect(result.content).toEqual([{ type: 'text', text: 'hello' }]);
   });
@@ -134,7 +134,7 @@ describe('toAssistantModelMessage', () => {
         { type: 'text', text: 'b' },
       ],
     };
-    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini' });
+    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini', providerName: 'google-gemini' });
     expect(result.content).toEqual([{ type: 'text', text: 'ab' }]);
   });
 
@@ -143,7 +143,7 @@ describe('toAssistantModelMessage', () => {
       role: 'assistant',
       content: null,
     };
-    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini' });
+    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini', providerName: 'google-gemini' });
     expect(result.content).toEqual([{ type: 'text', text: '' }]);
   });
 
@@ -153,7 +153,7 @@ describe('toAssistantModelMessage', () => {
       content: null,
       tool_calls: [{ id: 'call-1', type: 'function', function: { name: 'my_tool', arguments: '{"x":1}' } }],
     };
-    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini' });
+    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini', providerName: 'google-gemini' });
     const toolCallPart = (result.content as Array<{ type: string }>).find(p => p.type === 'tool-call');
     expect(toolCallPart).toMatchObject({
       type: 'tool-call',
@@ -169,7 +169,7 @@ describe('toAssistantModelMessage', () => {
       content: null,
       tool_calls: [{ id: 'call-2', type: 'function', function: { name: 'bad', arguments: 'not-json' } }],
     };
-    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini' });
+    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini', providerName: 'google-gemini' });
     const toolCallPart = (result.content as Array<{ type: string; input?: unknown }>).find(p => p.type === 'tool-call');
     expect(toolCallPart?.input).toEqual({});
   });
@@ -180,8 +180,9 @@ describe('toAssistantModelMessage', () => {
       content: null,
     };
     Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'step one', signature: 'sig-openai' }]);
+    Reflect.set(msg, 'source', { provider_name: 'openai', model_name: 'test' });
 
-    const result = toAssistantModelMessage({ msg: msg, provider: 'openai' });
+    const result = toAssistantModelMessage({ msg: msg, provider: 'openai', providerName: 'openai' });
     const reasoningPart = (result.content as Array<{ type: string; text?: string; providerOptions?: unknown }>).find(
       p => p.type === 'reasoning',
     );
@@ -196,8 +197,9 @@ describe('toAssistantModelMessage', () => {
       content: null,
     };
     Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'step two', signature: 'sig-ant' }]);
+    Reflect.set(msg, 'source', { provider_name: 'anthropic', model_name: 'test' });
 
-    const result = toAssistantModelMessage({ msg: msg, provider: 'anthropic' });
+    const result = toAssistantModelMessage({ msg: msg, provider: 'anthropic', providerName: 'anthropic' });
     const reasoningPart = (result.content as Array<{ type: string; providerOptions?: unknown }>).find(
       p => p.type === 'reasoning',
     );
@@ -211,7 +213,7 @@ describe('toAssistantModelMessage', () => {
     };
     Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'step', signature: 'sig-gen' }]);
 
-    const result = toAssistantModelMessage({ msg: msg, provider: 'custom' });
+    const result = toAssistantModelMessage({ msg: msg, provider: 'custom', providerName: 'custom' });
     const reasoningPart = (result.content as Array<{ type: string; text?: string; providerOptions?: unknown }>).find(
       p => p.type === 'reasoning',
     );
@@ -227,7 +229,7 @@ describe('toAssistantModelMessage', () => {
     };
     Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'step', signature: 'sig' }]);
 
-    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini' });
+    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini', providerName: 'google-gemini' });
     const reasoningPart = (result.content as Array<{ type: string; providerOptions?: unknown }>).find(
       p => p.type === 'reasoning',
     );
@@ -244,7 +246,7 @@ describe('toAssistantModelMessage', () => {
       tool_calls: [toolCall],
     };
 
-    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini' });
+    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini', providerName: 'google-gemini' });
     const toolCallPart = (result.content as Array<{ type: string; providerOptions?: unknown }>).find(
       p => p.type === 'tool-call',
     );
@@ -258,7 +260,7 @@ describe('toAssistantModelMessage', () => {
       tool_calls: [{ id: 'call-1', type: 'function', function: { name: 'fn', arguments: '{}' } }],
     };
 
-    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini' });
+    const result = toAssistantModelMessage({ msg: msg, provider: 'google-gemini', providerName: 'google-gemini' });
     const toolCallPart = (result.content as Array<{ type: string }>).find(p => p.type === 'tool-call');
     expect(toolCallPart).not.toHaveProperty('providerOptions');
   });
@@ -273,7 +275,11 @@ describe('convertMessages', () => {
       { role: 'system', content: 'Prompt B' },
       { role: 'user', content: 'hi' },
     ];
-    const { instructions, messages: result } = convertMessages({ messages: messages, provider: 'google-gemini' });
+    const { instructions, messages: result } = convertMessages({
+      messages: messages,
+      provider: 'google-gemini',
+      providerName: 'google-gemini',
+    });
     expect(instructions).toBe('Prompt A\n\nPrompt B');
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ role: 'user' });
@@ -283,6 +289,7 @@ describe('convertMessages', () => {
     const { instructions } = convertMessages({
       messages: [{ role: 'user', content: 'hi' }],
       provider: 'google-gemini',
+      providerName: 'google-gemini',
     });
     expect(instructions).toBeUndefined();
   });
@@ -297,7 +304,11 @@ describe('convertMessages', () => {
       },
       { role: 'tool', tool_call_id: 'c1', content: 'result' },
     ];
-    const { messages: result } = convertMessages({ messages: messages, provider: 'google-gemini' });
+    const { messages: result } = convertMessages({
+      messages: messages,
+      provider: 'google-gemini',
+      providerName: 'google-gemini',
+    });
     expect(result).toHaveLength(3);
     expect(result[0]?.role).toBe('user');
     expect(result[1]?.role).toBe('assistant');
@@ -313,14 +324,22 @@ describe('convertMessages', () => {
       },
       { role: 'tool', tool_call_id: 'c1', content: 'found it' },
     ];
-    const { messages: result } = convertMessages({ messages: messages, provider: 'google-gemini' });
+    const { messages: result } = convertMessages({
+      messages: messages,
+      provider: 'google-gemini',
+      providerName: 'google-gemini',
+    });
     const toolMsg = result.find(m => m.role === 'tool');
     expect(toolMsg?.content).toEqual([expect.objectContaining({ toolName: 'search' })]);
   });
 
   it('falls back to empty string toolName for unresolvable tool_call_id', () => {
     const messages: ChatCompletionMessageParam[] = [{ role: 'tool', tool_call_id: 'unknown-id', content: 'data' }];
-    const { messages: result } = convertMessages({ messages: messages, provider: 'google-gemini' });
+    const { messages: result } = convertMessages({
+      messages: messages,
+      provider: 'google-gemini',
+      providerName: 'google-gemini',
+    });
     expect(result[0]?.content).toEqual([expect.objectContaining({ toolName: '' })]);
   });
 
@@ -330,7 +349,11 @@ describe('convertMessages', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulating unrecognised roles at runtime
       { role: 'developer', content: 'internal' } as any,
     ];
-    const { messages: result } = convertMessages({ messages: messages, provider: 'google-gemini' });
+    const { messages: result } = convertMessages({
+      messages: messages,
+      provider: 'google-gemini',
+      providerName: 'google-gemini',
+    });
     expect(result).toHaveLength(1);
     expect(result[0]?.role).toBe('user');
   });
@@ -338,8 +361,9 @@ describe('convertMessages', () => {
   it('threads the provider into assistant message reasoning parts', () => {
     const msg: ChatCompletionMessageParam = { role: 'assistant', content: null };
     Reflect.set(msg, 'thinking_blocks', [{ type: 'thinking', thinking: 'thought', signature: 'sig' }]);
+    Reflect.set(msg, 'source', { provider_name: 'anthropic', model_name: 'test' });
 
-    const { messages: result } = convertMessages({ messages: [msg], provider: 'anthropic' });
+    const { messages: result } = convertMessages({ messages: [msg], provider: 'anthropic', providerName: 'anthropic' });
     const assistantMsg = result.find(m => m.role === 'assistant');
     const reasoningPart = (
       assistantMsg?.content as Array<{ type: string; providerOptions?: unknown }> | undefined

--- a/packages/harness/tests/core/llm/VercelAILLM.messages.test.ts
+++ b/packages/harness/tests/core/llm/VercelAILLM.messages.test.ts
@@ -266,7 +266,7 @@ describe('toAssistantModelMessage', () => {
     expect(toolCallPart).not.toHaveProperty('providerOptions');
   });
 
-  it('attaches signature when source provider type matches, ignoring model_name', () => {
+  it('attaches signature when source type and provider name match, ignoring model_name', () => {
     const msg: Extract<ChatCompletionMessageParam, { role: 'assistant' }> = {
       role: 'assistant',
       content: null,
@@ -297,7 +297,7 @@ describe('toAssistantModelMessage', () => {
     expect(reasoningPart).not.toHaveProperty('providerOptions');
   });
 
-  it('for custom providers, requires matching provider name (not only type)', () => {
+  it('requires matching provider name for any provider type', () => {
     expect(
       shouldAttachReasoningSignature({
         source: 'custom/gateway-a/model',
@@ -312,9 +312,15 @@ describe('toAssistantModelMessage', () => {
         providerName: 'gateway-b',
       }),
     ).toBe(false);
+    expect(
+      shouldAttachReasoningSignature({
+        source: 'openai/other-name/model',
+        provider: 'openai',
+        providerName: 'openai',
+      }),
+    ).toBe(false);
   });
 
-  // Defensive: well-known gate is type-only; a shared name must not override a type mismatch.
   it('does not attach when provider type differs even if provider_name matches', () => {
     expect(
       shouldAttachReasoningSignature({

--- a/packages/harness/tests/core/llm/VercelAILLM.replay.test.ts
+++ b/packages/harness/tests/core/llm/VercelAILLM.replay.test.ts
@@ -255,6 +255,39 @@ describe('anthropic reasoning replay, on the shape Anthropic actually sends', ()
     expect(parts.map(p => p.type)).toEqual(['reasoning', 'tool-call']);
     expect(parts[0]?.providerOptions).toEqual({ anthropic: { signature: 'ant-delta' } });
   });
+
+  it('does not attach an Anthropic signature when replaying to OpenAI', async () => {
+    const { output } = await drainStream(
+      mapStreamToChunks({
+        stream: makeStream([
+          { type: 'reasoning-start', id: 'r1' },
+          { type: 'reasoning-delta', id: 'r1', text: 'thought' },
+          { type: 'reasoning-delta', id: 'r1', text: '', providerMetadata: { anthropic: { signature: 'ant-sig' } } },
+          { type: 'reasoning-end', id: 'r1' },
+          makeFinishStep('stop'),
+        ]),
+        chunkMeta: CHUNK_META,
+      }),
+    );
+
+    const assistantMsg: Extract<ChatCompletionMessageParam, { role: 'assistant' }> = {
+      role: 'assistant',
+      content: null,
+    };
+    Reflect.set(assistantMsg, 'thinking_blocks', output.thinking_blocks);
+    Reflect.set(assistantMsg, 'source', { provider_name: 'anthropic', model_name: 'opus' });
+
+    const reasoningPart = (
+      toAssistantModelMessage({ msg: assistantMsg, provider: 'openai', providerName: 'openai' }).content as Array<{
+        type: string;
+        text?: string;
+        providerOptions?: unknown;
+      }>
+    ).find(p => p.type === 'reasoning');
+
+    expect(reasoningPart?.text).toBe('thought');
+    expect(reasoningPart).not.toHaveProperty('providerOptions');
+  });
 });
 
 describe('google-gemini reasoning replay round-trip', () => {

--- a/packages/harness/tests/core/llm/VercelAILLM.replay.test.ts
+++ b/packages/harness/tests/core/llm/VercelAILLM.replay.test.ts
@@ -209,7 +209,7 @@ describe.each(REASONING_CASES)(
         content: null,
       };
       Reflect.set(assistantMsg, 'thinking_blocks', output.thinking_blocks);
-      Reflect.set(assistantMsg, 'source', { provider_name: provider, model_name: 'test' });
+      Reflect.set(assistantMsg, 'source', `${provider}/${provider}/test`);
 
       const replayMsg = toAssistantModelMessage({ msg: assistantMsg, provider, providerName: provider });
       const reasoningPart = (replayMsg.content as Array<{ type: string; providerOptions?: unknown }>).find(
@@ -245,7 +245,7 @@ describe('anthropic reasoning replay, on the shape Anthropic actually sends', ()
       ...(output.tool_calls !== undefined ? { tool_calls: output.tool_calls } : {}),
     };
     Reflect.set(assistantMsg, 'thinking_blocks', output.thinking_blocks);
-    Reflect.set(assistantMsg, 'source', { provider_name: 'anthropic', model_name: 'test' });
+    Reflect.set(assistantMsg, 'source', 'anthropic/anthropic/test');
     const parts = toAssistantModelMessage({ msg: assistantMsg, provider: 'anthropic', providerName: 'anthropic' })
       .content as Array<{
       type: string;
@@ -275,7 +275,7 @@ describe('anthropic reasoning replay, on the shape Anthropic actually sends', ()
       content: null,
     };
     Reflect.set(assistantMsg, 'thinking_blocks', output.thinking_blocks);
-    Reflect.set(assistantMsg, 'source', { provider_name: 'anthropic', model_name: 'opus' });
+    Reflect.set(assistantMsg, 'source', 'anthropic/anthropic/opus');
 
     const reasoningPart = (
       toAssistantModelMessage({ msg: assistantMsg, provider: 'openai', providerName: 'openai' }).content as Array<{

--- a/packages/harness/tests/core/llm/VercelAILLM.replay.test.ts
+++ b/packages/harness/tests/core/llm/VercelAILLM.replay.test.ts
@@ -98,7 +98,11 @@ describe('Gemini tool thoughtSignature replay round-trip', () => {
       content: null,
       ...(output.tool_calls !== undefined ? { tool_calls: output.tool_calls } : {}),
     };
-    const replayMsg = toAssistantModelMessage({ msg: assistantMsg, provider: 'google-gemini' });
+    const replayMsg = toAssistantModelMessage({
+      msg: assistantMsg,
+      provider: 'google-gemini',
+      providerName: 'google-gemini',
+    });
     const toolCallPart = (replayMsg.content as Array<{ type: string; providerOptions?: unknown }>).find(
       p => p.type === 'tool-call',
     );
@@ -124,7 +128,11 @@ describe('Gemini tool thoughtSignature replay round-trip', () => {
       content: null,
       ...(output.tool_calls !== undefined ? { tool_calls: output.tool_calls } : {}),
     };
-    const replayMsg = toAssistantModelMessage({ msg: assistantMsg, provider: 'google-gemini' });
+    const replayMsg = toAssistantModelMessage({
+      msg: assistantMsg,
+      provider: 'google-gemini',
+      providerName: 'google-gemini',
+    });
     const toolCallPart = (replayMsg.content as Array<{ type: string }>).find(p => p.type === 'tool-call');
     expect(toolCallPart).not.toHaveProperty('providerOptions');
   });
@@ -201,8 +209,9 @@ describe.each(REASONING_CASES)(
         content: null,
       };
       Reflect.set(assistantMsg, 'thinking_blocks', output.thinking_blocks);
+      Reflect.set(assistantMsg, 'source', { provider_name: provider, model_name: 'test' });
 
-      const replayMsg = toAssistantModelMessage({ msg: assistantMsg, provider });
+      const replayMsg = toAssistantModelMessage({ msg: assistantMsg, provider, providerName: provider });
       const reasoningPart = (replayMsg.content as Array<{ type: string; providerOptions?: unknown }>).find(
         p => p.type === 'reasoning',
       );
@@ -236,7 +245,9 @@ describe('anthropic reasoning replay, on the shape Anthropic actually sends', ()
       ...(output.tool_calls !== undefined ? { tool_calls: output.tool_calls } : {}),
     };
     Reflect.set(assistantMsg, 'thinking_blocks', output.thinking_blocks);
-    const parts = toAssistantModelMessage({ msg: assistantMsg, provider: 'anthropic' }).content as Array<{
+    Reflect.set(assistantMsg, 'source', { provider_name: 'anthropic', model_name: 'test' });
+    const parts = toAssistantModelMessage({ msg: assistantMsg, provider: 'anthropic', providerName: 'anthropic' })
+      .content as Array<{
       type: string;
       providerOptions?: unknown;
     }>;
@@ -272,7 +283,11 @@ describe('google-gemini reasoning replay round-trip', () => {
     };
     Reflect.set(assistantMsg, 'thinking_blocks', output.thinking_blocks);
 
-    const replayMsg = toAssistantModelMessage({ msg: assistantMsg, provider: 'google-gemini' });
+    const replayMsg = toAssistantModelMessage({
+      msg: assistantMsg,
+      provider: 'google-gemini',
+      providerName: 'google-gemini',
+    });
     const reasoningPart = (replayMsg.content as Array<{ type: string }>).find(p => p.type === 'reasoning');
     expect(reasoningPart).toBeDefined();
     expect(reasoningPart).not.toHaveProperty('providerOptions');

--- a/packages/harness/tests/core/llm/toOpenAIChatMessage.test.ts
+++ b/packages/harness/tests/core/llm/toOpenAIChatMessage.test.ts
@@ -32,7 +32,7 @@ function makeAssistantWithReplayFields(): InternalEnrichedAssistantMessage {
       { type: 'redacted_thinking', data: 'redacted-blob' },
     ],
     reasoning_content: 'plain reasoning',
-    source: { provider_name: 'anthropic', model_name: 'opus' },
+    source: 'anthropic/anthropic/opus',
     tool_calls: [
       {
         id: 'call-1',
@@ -54,7 +54,7 @@ describe('toOpenAIChatMessage', () => {
     expect(mapped['content']).toBe('hello');
     expect(mapped['thinking_blocks']).toEqual(msg.thinking_blocks);
     expect(mapped['reasoning_content']).toBe('plain reasoning');
-    expect(mapped['source']).toEqual({ provider_name: 'anthropic', model_name: 'opus' });
+    expect(mapped['source']).toBe('anthropic/anthropic/opus');
 
     const toolCalls = mapped['tool_calls'] as Record<string, unknown>[];
     expect(toolCalls).toHaveLength(1);

--- a/packages/harness/tests/core/llm/toOpenAIChatMessage.test.ts
+++ b/packages/harness/tests/core/llm/toOpenAIChatMessage.test.ts
@@ -32,6 +32,7 @@ function makeAssistantWithReplayFields(): InternalEnrichedAssistantMessage {
       { type: 'redacted_thinking', data: 'redacted-blob' },
     ],
     reasoning_content: 'plain reasoning',
+    source: { provider_name: 'anthropic', model_name: 'opus' },
     tool_calls: [
       {
         id: 'call-1',
@@ -53,6 +54,7 @@ describe('toOpenAIChatMessage', () => {
     expect(mapped['content']).toBe('hello');
     expect(mapped['thinking_blocks']).toEqual(msg.thinking_blocks);
     expect(mapped['reasoning_content']).toBe('plain reasoning');
+    expect(mapped['source']).toEqual({ provider_name: 'anthropic', model_name: 'opus' });
 
     const toolCalls = mapped['tool_calls'] as Record<string, unknown>[];
     expect(toolCalls).toHaveLength(1);


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/sdk`, `.github/fern/openapi/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-turn reasoning signature replay, which can affect conversation continuity across providers if matching logic is wrong. Covered by focused unit and round-trip tests.
> 
> **Overview**
> Fixes broken multi-turn reasoning when switching models by tagging assistant messages with a `source` (`provider_type/provider_name/model_name`) and only replaying provider-specific reasoning signatures when that source matches the current provider.
> 
> `VercelAILLM` now stamps `source` on completed assistant output and uses `shouldAttachReasoningSignature` during message conversion. Mismatched or missing sources still replay reasoning text, but omit signature `providerOptions`. Like `thinking_blocks`, `source` stays internal for context replay and is stripped from client events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd646eb723fb52582daecfa35767d809776216d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->