### PR TITLE
Refactor AgentsLibrary component to enhance agent card display and fu…

### DIFF
--- a/packages/trueforge-ui-sdk/src/atoms/AgentsLibrary.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/AgentsLibrary.tsx
@@ -3,12 +3,13 @@
 import { useEffect, useState } from 'react';
 
 import { Icon } from '../icons/Icon.js';
+import '../icons/registerAgentIcons.js';
 import { libraryAgentId, useOptionalShellMode } from '../server/ShellModeContext.js';
 import type { AgentLibraryEntry, AgentSpec } from '../server/types.js';
 import { auiButtonClass } from './lib/buttonClasses.js';
 import { cn } from './lib/cn.js';
-import { useCompactLayout } from './lib/CompactLayoutContext.js';
 import { useSearchAgentsList } from './lib/useSearchAgentsList.js';
+import { CatalogLogo } from './primitives/CatalogLogo.js';
 import { CenteredModal } from './primitives/CenteredModal.js';
 import SearchInput from './primitives/SearchInput.js';
 import { Skeleton } from './primitives/Skeleton.js';
@@ -19,69 +20,99 @@ export type AgentsLibraryProps = {
   onSelectAgent?: (agentName: string) => void;
 };
 
-type AgentLibraryRowProps = {
+type AgentLibraryCardProps = {
   agent: AgentLibraryEntry;
   showEdit: boolean;
   onTry: () => void;
   onEdit: () => void;
 };
 
-function rowActionClass(compact: boolean) {
-  return cn(
-    'shrink-0 opacity-100 transition-opacity',
-    !compact && 'md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100',
-    'focus-visible:opacity-100',
-  );
+function modelSegment(modelName: string): string {
+  const slash = modelName.lastIndexOf('/');
+  return slash >= 0 ? modelName.slice(slash + 1) : modelName;
 }
 
-function AgentLibraryRow({ agent, showEdit, onTry, onEdit }: AgentLibraryRowProps) {
-  const compact = useCompactLayout();
+function countLabel({ count, singular }: { count: number; singular: string }): string {
+  return `${count} ${singular}${count === 1 ? '' : 's'}`;
+}
+
+/** Hosts may widen `model` with `providerLogo`; base AgentSpec has no logo field. */
+function optionalModelLogo(model: AgentSpec['model']): string | undefined {
+  if (!('providerLogo' in model)) return undefined;
+  const value = Reflect.get(model, 'providerLogo');
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function ModelMark({ logo, className }: { logo?: string; className?: string }) {
+  if (logo != null && logo.length > 0) {
+    return <CatalogLogo src={logo} alt="" className={cn('shrink-0 rounded object-contain', className)} aria-hidden />;
+  }
+  // Local fallback only — never fetched; agentSpec rarely carries providerLogo today.
+  return <Icon name="ai" className={cn('shrink-0 text-foreground', className)} />;
+}
+
+function AgentLibraryCard({ agent, showEdit, onTry, onEdit }: AgentLibraryCardProps) {
+  const agentSpec = agent.agentSpec;
+  const instructions = agentSpec?.instructions?.trim() ?? '';
+  const model = agentSpec?.model;
+  const modelName = model?.name;
+  const modelLogo = model != null ? optionalModelLogo(model) : undefined;
+  const toolCount = agentSpec?.mcpServers?.length ?? 0;
+  const skillCount = agentSpec?.skills?.length ?? 0;
 
   return (
     <div
       role="menuitem"
       className={cn(
-        'group flex w-full items-center gap-2.5 rounded-md border border-transparent px-2.5 py-2 transition-colors',
-        'hover:border-border hover:bg-accent',
-        'focus-within:border-border focus-within:bg-accent',
+        'group flex min-h-[9rem] flex-col justify-between gap-4 rounded-xl border border-border bg-background p-4',
+        'transition-colors hover:border-border hover:bg-accent/40',
+        'focus-within:border-border focus-within:bg-accent/40',
       )}
     >
-      <span className="bg-background text-muted-foreground inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-border">
-        <Icon name="robot" className="size-4" />
-      </span>
-      <span className="text-foreground min-w-0 flex-1 truncate text-left text-sm font-medium leading-tight">
-        {agent.name}
-      </span>
-      <span className="flex shrink-0 items-center gap-1.5">
-        {showEdit ? (
+      <div className="flex min-w-0 items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <h3 className="text-foreground truncate text-sm font-semibold leading-5">{agent.name}</h3>
+          {agentSpec != null && modelName != null ? (
+            <p className="text-muted-foreground mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs leading-4">
+              <span className="inline-flex min-w-0 max-w-full items-center gap-1">
+                <ModelMark logo={modelLogo} className="size-3.5" />
+                <span className="truncate">{modelSegment(modelName)}</span>
+              </span>
+              <span aria-hidden>·</span>
+              <span className="shrink-0">{countLabel({ count: toolCount, singular: 'tool' })}</span>
+              <span aria-hidden>·</span>
+              <span className="shrink-0">{countLabel({ count: skillCount, singular: 'skill' })}</span>
+            </p>
+          ) : null}
+        </div>
+        <div className="-mr-1 -mt-0.5 flex shrink-0 items-center gap-0.5">
+          {showEdit ? (
+            <button
+              type="button"
+              aria-label={`Edit agent ${agent.name}`}
+              className={auiButtonClass({ variant: 'ghost', size: 'sm' })}
+              onClick={onEdit}
+            >
+              <Icon name="pencil" className="size-3.5" />
+              Edit
+            </button>
+          ) : null}
           <button
             type="button"
-            aria-label={`Edit agent ${agent.name}`}
-            className={auiButtonClass({
-              variant: 'ghost',
-              size: 'sm',
-              className: rowActionClass(compact),
-            })}
-            onClick={onEdit}
+            aria-label={`Try agent ${agent.name}`}
+            className={auiButtonClass({ variant: 'secondary', size: 'sm' })}
+            onClick={onTry}
           >
-            <Icon name="pencil" className="size-3.5" />
-            Edit
+            <Icon name="play" className="size-3.5" />
+            Try
           </button>
-        ) : null}
-        <button
-          type="button"
-          aria-label={`Try agent ${agent.name}`}
-          className={auiButtonClass({
-            variant: 'outline',
-            size: 'sm',
-            className: rowActionClass(compact),
-          })}
-          onClick={onTry}
-        >
-          <Icon name="play" className="size-3.5" />
-          Try
-        </button>
-      </span>
+        </div>
+      </div>
+      {instructions.length > 0 ? (
+        <p className="text-muted-foreground mt-auto line-clamp-2 text-xs leading-5">{instructions}</p>
+      ) : (
+        <div className="mt-auto" aria-hidden />
+      )}
     </div>
   );
 }
@@ -141,16 +172,15 @@ export function AgentsLibrary({ open, onOpenChange, onSelectAgent }: AgentsLibra
             </p>
           ) : null}
         </div>
-        <div
-          ref={listRef}
-          className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-2"
-          role="menu"
-          aria-label="Agents"
-        >
+        <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto p-3" role="menu" aria-label="Agents">
           {isInitialLoading ? (
-            <div className="flex flex-col gap-2 p-1" role="status" aria-label="Loading agents">
+            <div
+              className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+              role="status"
+              aria-label="Loading agents"
+            >
               {Array.from({ length: 6 }, (_, i) => (
-                <Skeleton key={i} className="h-11 w-full rounded-md" />
+                <Skeleton key={i} className="h-[8.5rem] w-full rounded-lg" />
               ))}
             </div>
           ) : error ? (
@@ -163,21 +193,23 @@ export function AgentsLibrary({ open, onOpenChange, onSelectAgent }: AgentsLibra
             </p>
           ) : (
             <>
-              {agents.map(agent => {
-                const agentSpec = agent.agentSpec;
-                const showEdit = canEdit && agentSpec != null;
-                return (
-                  <AgentLibraryRow
-                    key={libraryAgentId(agent)}
-                    agent={agent}
-                    showEdit={showEdit}
-                    onTry={() => handleTry(agent)}
-                    onEdit={() => {
-                      if (agentSpec != null) handleEdit(agent, agentSpec);
-                    }}
-                  />
-                );
-              })}
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {agents.map(agent => {
+                  const agentSpec = agent.agentSpec;
+                  const showEdit = canEdit && agentSpec != null;
+                  return (
+                    <AgentLibraryCard
+                      key={libraryAgentId(agent)}
+                      agent={agent}
+                      showEdit={showEdit}
+                      onTry={() => handleTry(agent)}
+                      onEdit={() => {
+                        if (agentSpec != null) handleEdit(agent, agentSpec);
+                      }}
+                    />
+                  );
+                })}
+              </div>
               {hasMore ? (
                 <div ref={sentinelRef} className="flex h-8 shrink-0 items-center justify-center" aria-hidden>
                   {loadingMore ? (

--- a/packages/trueforge-ui-sdk/test/atoms/AgentsLibrary.test.tsx
+++ b/packages/trueforge-ui-sdk/test/atoms/AgentsLibrary.test.tsx
@@ -26,7 +26,12 @@ function mockServer(
   agents: Array<{
     name: string;
     agentId: string;
-    agentSpec?: { model: { name: string }; skills?: Array<{ id: string; name: string }> };
+    agentSpec?: {
+      model: { name: string; providerLogo?: string };
+      instructions?: string;
+      skills?: Array<{ id: string; name: string }>;
+      mcpServers?: Array<{ name: string }>;
+    };
   }> = [{ name: 'alpha-agent', agentId: 'alpha-agent' }],
 ): AgentUIServer {
   return createMockAgentUIServer({
@@ -119,6 +124,84 @@ describe('AgentsLibrary', () => {
     });
     expect(screen.queryByRole('button', { name: 'Edit agent try-only' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Try agent try-only' })).toBeInTheDocument();
+  });
+
+  it('renders agentSpec card details from the Agent object only', async () => {
+    const server = mockServer([
+      {
+        name: 'on-call-copilot',
+        agentId: 'on-call-copilot',
+        agentSpec: {
+          model: { name: 'anthropic/claude-opus-4.8' },
+          instructions: 'Builds incident timelines from alerts, pages and chat threads. Extra line ignored.',
+          skills: [{ id: 's1', name: 'Skill' }],
+          mcpServers: [{ name: 'pagerduty' }, { name: 'slack' }, { name: 'logs' }],
+        },
+      },
+      { name: 'try-only', agentId: 'try-only' },
+    ]);
+
+    render(
+      <SlotsProvider>
+        <ServerProvider server={server}>
+          <ShellModeProvider agentConfig={{ mode: 'AgentLibraryWithComposer' }}>
+            <AgentsLibrary open onOpenChange={() => undefined} />
+          </ShellModeProvider>
+        </ServerProvider>
+      </SlotsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('on-call-copilot')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText('Builds incident timelines from alerts, pages and chat threads. Extra line ignored.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('claude-opus-4.8')).toBeInTheDocument();
+    expect(screen.getByText('3 tools')).toBeInTheDocument();
+    expect(screen.getByText('1 skill')).toBeInTheDocument();
+    expect(screen.queryByText('anthropic/claude-opus-4.8')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Try agent try-only' })).toBeInTheDocument();
+    expect(screen.queryByText('0 tools')).not.toBeInTheDocument();
+  });
+
+  it('shows a model logo only when agentSpec.model carries providerLogo', async () => {
+    const server = mockServer([
+      {
+        name: 'writer',
+        agentId: 'writer',
+        agentSpec: {
+          model: {
+            name: 'openai/gpt-4.1',
+            providerLogo: 'https://assets.example/openai.svg',
+          },
+          mcpServers: [],
+          skills: [],
+        },
+      },
+      {
+        name: 'no-logo',
+        agentId: 'no-logo',
+        agentSpec: { model: { name: 'anthropic/claude-opus-4.8' }, mcpServers: [], skills: [] },
+      },
+    ]);
+
+    render(
+      <SlotsProvider>
+        <ServerProvider server={server}>
+          <ShellModeProvider agentConfig={{ mode: 'AgentLibraryWithComposer' }}>
+            <AgentsLibrary open onOpenChange={() => undefined} />
+          </ShellModeProvider>
+        </ServerProvider>
+      </SlotsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('gpt-4.1')).toBeInTheDocument();
+    });
+    expect(document.querySelector('img[src="https://assets.example/openai.svg"]')).not.toBeNull();
+    expect(screen.getByText('claude-opus-4.8')).toBeInTheDocument();
+    expect(document.querySelectorAll('img').length).toBe(1);
   });
 
   it('hides Edit when composer is disabled (AgentLibrary only)', async () => {


### PR DESCRIPTION
…nctionality

- Renamed AgentLibraryRow to AgentLibraryCard for clarity.
- Introduced new utility functions for model segment and count labels.
- Updated layout and styling for agent cards, including a new ModelMark component for displaying logos.
- Enhanced agentSpec details rendering, including instructions and tool/skill counts.
- Improved loading state presentation with a grid layout for skeleton loaders.
- Updated tests to cover new agentSpec card details and logo rendering logic based on providerLogo presence.

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/sdk`, `.github/fern/openapi/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed
