### PR TITLE
Custom theme updates

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -96,10 +96,7 @@
               "ui-sdk/guides/agent-modes",
               {
                 "group": "Setup Custom UI",
-                "pages": [
-                  "ui-sdk/setup-custom-ui/custom-theme",
-                  "ui-sdk/setup-custom-ui/custom-layout"
-                ]
+                "pages": ["ui-sdk/setup-custom-ui/custom-theme", "ui-sdk/setup-custom-ui/custom-layout"]
               },
               {
                 "group": "Setup Custom Server",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -98,9 +98,7 @@
                 "group": "Setup Custom UI",
                 "pages": [
                   "ui-sdk/setup-custom-ui/custom-theme",
-                  "ui-sdk/setup-custom-ui/custom-layout",
-                  "ui-sdk/setup-custom-ui/slot-overrides",
-                  "ui-sdk/setup-custom-ui/mcp-oauth"
+                  "ui-sdk/setup-custom-ui/custom-layout"
                 ]
               },
               {

--- a/docs/ui-sdk/guides/agent-modes.mdx
+++ b/docs/ui-sdk/guides/agent-modes.mdx
@@ -28,6 +28,34 @@ All chats are done with one named agent which can be configured in `name`  param
   ![Single Agent 1](/images/single-agent-1.png "Single Agent 1")
 </Frame>
 
+<AccordionGroup>
+  <Accordion title="SingleAgent">
+    Pins the UI to one named agent. All selection controls are hidden and the user cannot switch agents or open the composer.
+  </Accordion>
+
+  <Accordion title="AgentLibrary">
+    Users pick from agents your `searchAgents` implementation returns, but cannot author a new one. Note that "new chat" is disabled in this mode only.
+
+    <Frame caption="The Agents Library: users pick from the agents your `searchAgents` returns.">
+      ![The Agents Library dialog listing saved agents to choose from](/images/agent-registry.png)
+    </Frame>
+  </Accordion>
+
+  <Accordion title="AgentComposer">
+    Users assemble an ad-hoc agent — model, skills, MCP servers — without browsing a library, and can save it back to the library.
+
+    <Frame caption="Composing an agent — pick a model, add connectors and skills, then save it to the library.">
+      <div style={{ position: "relative", boxSizing: "content-box", width: "100%", aspectRatio: "1.46", padding: "40px 0" }}>
+  <iframe src="https://app.supademo.com/embed/cmsk13xio00k81p0j1wj6amj6?embed_v=2&utm_source=embed" loading="lazy" title="Compose an agent in TrueForge" allow="clipboard-write" allowFullScreen style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }} />
+</div>
+    </Frame>
+  </Accordion>
+
+  <Accordion title="AgentLibraryWithComposer">
+    Both surfaces, and the default. Users can pick an existing agent or author a new one.
+  </Accordion>
+</AccordionGroup>
+
 ## AgentComposer
 
 Users compose/create a new agent by selecting models, skills, MCP servers and can save it to the library.

--- a/docs/ui-sdk/setup-custom-ui/custom-theme.mdx
+++ b/docs/ui-sdk/setup-custom-ui/custom-theme.mdx
@@ -55,22 +55,6 @@ type ThemeConfig = {
 }
 ```
 
-## Precedence
-
-The provider resolves the preset for the current mode, merges your `theme.tokens` over it, and writes the result as **inline styles** on the theme root. So within `theme.tokens`, your entries beat the preset — that part is straightforward.
-
-<Warning>
-  Because those tokens land as inline styles, a `:root { --primary: … }` rule in your own CSS will **not** override them. This applies to every token a preset defines, whether or not you passed `theme.tokens`. Use `theme.tokens` to change these, not CSS.
-</Warning>
-
-A few tokens are absent from the presets — `scrollbarThumb`, `assistantBubble`, and `assistantBubbleForeground`. Those are not written inline unless you set them, so they fall through to the stylesheet's low-precedence layer and a host `:root` rule does take effect.
-
-`theme.className` is applied to the theme root, for utility-class adjustments alongside the tokens.
-
-<Note>
-  `brand`, `icons`, and `classNames` are not part of this cascade — they are separate context values, not tokens that layer over one another.
-</Note>
-
 ## Reading theme state
 
 ```tsx
@@ -93,12 +77,6 @@ One token breaks that rule:
 | Token | CSS variable |
 | --- | --- |
 | `fontFamily` | `--font-agent-ui` |
-
-Alongside the usual surface and text tokens, the palette includes status pairs for `destructive`, `success`, and `warning`, each with a matching `*Foreground`.
-
-<Note>
-  `theme.tokens` is a `Partial`, so you only supply the tokens you want to change and the preset fills in the rest. The status pairs matter only if you construct a complete `SemanticTokens` object — for instance when building your own preset — in which case all four of `success`, `successForeground`, `warning`, and `warningForeground` are required.
-</Note>
 
 ## Styling rendered content
 

--- a/docs/ui-sdk/setup-custom-ui/custom-theme.mdx
+++ b/docs/ui-sdk/setup-custom-ui/custom-theme.mdx
@@ -93,15 +93,3 @@ type ContentClassNames = {
 ```
 
 For CSS-only adjustments you can instead target the stable class names directly: `.aui-markdown`, `.aui-syntax-highlighter`, `.aui-openui`, `.aui-monaco`.
-
-## Presets
-
-```ts
-import { PRESETS, resolvePresetTokens } from "@truefoundry/trueforge-ui";
-
-const tokens = resolvePresetTokens("gemini", "dark");
-```
-
-`PRESETS` is a `Record<ThemePreset, { light, dark }>` — useful for building a preset picker.
-
-Refer to [Building custom theme](/ui-sdk/setup-custom-ui/custom-theme) to build a theme from scratch

--- a/docs/ui-sdk/setup-custom-ui/custom-theme.mdx
+++ b/docs/ui-sdk/setup-custom-ui/custom-theme.mdx
@@ -11,9 +11,8 @@ Theme object supports params to pass `tokens` to override styles of UI component
 type ThemeConfig = {
   ...
   tokens?: Partial<SemanticTokens>;
-  className?: string;
   icons?: IconMap;
-  classNames?: ContentClassNames;
+  ...
 };
 ```
 
@@ -21,31 +20,39 @@ type ThemeConfig = {
 
 ```json Token Object
 {
-    background: "#c18585",
-    foreground: "#1f1f1f",
-    card: "#ffffff",
-    cardForeground: "#1f1f1f",
-    popover: "#f0f4f9",
-    popoverForeground: "#1f1f1f",
-    primary: "#1f3b9b",
-    primaryForeground: "#ffffff",
-    secondary: "#e8eaed",
-    secondaryForeground: "#1f1f1f",
-    muted: "#f8fafd",
-    mutedForeground: "#444746",
-    accent: "#e9eef6",
-    accentForeground: "#1f1f1f",
-    destructive: "#b3261e",
-    destructiveForeground: "#ffffff",
-    border: "#dadce0",
-    input: "#dadce0",
-    ring: "#1f3b9b",
-    userBubble: "#f3f6fc",
-    userBubbleForeground: "#1f1f1f",
-    radius: "1rem",
-    composerRadius: "2rem",
-    fontSans: "\"GeistSans\", \"GeistSans Fallback\", ui-sans-serif, system-ui, -apple-system, \"Segoe UI\", sans-serif",
-  }
+  "sidebarBg": "#ffffff",
+  "topbarBg": "#ffffff",
+  "primaryBg": "#ffffff",
+  "secondaryBg": "#f4f4f5",
+  "border": "#e4e4e7",
+  "inputBoxBg": "#ffffff",
+  "inputBorder": "#e4e4e7",
+  "textPrimary": "#09090b",
+  "textSecondary": "#62626a",
+  "cardBg": "#ffffff",
+  "dropdownSelectedItemBg": "#f1f1f2",
+  "dropdownSelectedItemText": "#09090b",
+  "userMessageBg": "#09090b",
+  "userMessageText": "#ffffff",
+  "assistantMessageBg": "transparent",
+  "assistantMessageText": "#09090b",
+  "primaryButtonBg": "#09090b",
+  "primaryButtonHover": "#27272a",
+  "primaryButtonText": "#ffffff",
+  "secondaryButtonBg": "#f4f4f5",
+  "secondaryButtonHover": "#e4e4e7",
+  "secondaryButtonText": "#09090b",
+  "ghostButtonBg": "transparent",
+  "ghostButtonHover": "#f1f1f2",
+  "ghostButtonText": "#09090b",
+  "successBg": "#16a34a",
+  "successText": "#ffffff",
+  "failureBg": "#ef4444",
+  "failureText": "#ffffff",
+  "warningBg": "#d97706",
+  "warningText": "#ffffff",
+  "scrollbarThumb": "#62626a"
+}
 ```
 
 ## Precedence


### PR DESCRIPTION
<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://app.mintlify.com/truefoundry/trueforge/editor/custom-ui-docs?preview=%2Fui-sdk%2Fguides%2Fagent-modes&source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg" alt="Review in Mintlify"></picture></a>

<!-- /mintlify-comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Mintlify UI SDK guides and navigation; no runtime or security-sensitive code is modified.
> 
> **Overview**
> Updates UI SDK docs for the new custom theme token model and clearer agent-mode guidance.
> 
> **Custom theme** docs now show the redesigned `SemanticTokens` palette (`sidebarBg`, message/button colors, status tokens, etc.) and drop outdated sections on token precedence, presets, and `className`/`classNames` on `ThemeConfig`.
> 
> **Agent modes** guide adds an accordion overview (with library screenshot and composer demo) under Single Agent. Nav also drops `slot-overrides` and `mcp-oauth` from Setup Custom UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335a09ac90034faf4916afcc087bd183b960440a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->