### PR TITLE
feedback from prev pr

### DIFF
--- a/packages/trueforge-ui-sdk/README.md
+++ b/packages/trueforge-ui-sdk/README.md
@@ -433,9 +433,7 @@ import { TrueforgeUI, type AssistantMessageBubbleProps } from '@truefoundry/true
 function MyBubble({ children, error, actionBar, className }: AssistantMessageBubbleProps) {
   return (
     <div className={`flex flex-col gap-2 border-l-2 border-primary-button-bg pl-3.5 ${className ?? ''}`}>
-      {error ? (
-        <div className="rounded-lg bg-failure-bg/10 px-2.5 py-2 text-[13px] text-failure-text">{error}</div>
-      ) : null}
+      {error ? <div className="rounded-lg bg-failure-bg/10 px-2.5 py-2 text-sm text-failure-bg">{error}</div> : null}
       <div>{children}</div>
       {actionBar}
     </div>

--- a/packages/trueforge-ui-sdk/src/atoms/AssistantMessageBubble.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/AssistantMessageBubble.tsx
@@ -20,7 +20,7 @@ export function AssistantMessageBubble({ children, error, actionBar, className }
     >
       <div className="min-w-0 max-w-full">
         {children}
-        {error && <div className="mt-2 text-sm text-failure-text">{error}</div>}
+        {error && <div className="mt-2 text-sm text-failure-bg">{error}</div>}
       </div>
       {actionBar && <div className="mt-1">{actionBar}</div>}
     </div>

--- a/packages/trueforge-ui-sdk/src/atoms/MessageErrorBanner.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/MessageErrorBanner.tsx
@@ -10,7 +10,7 @@ export function MessageErrorBanner({ message, className }: MessageErrorBannerPro
     <div
       role="alert"
       className={cn(
-        'aui-message-error-root border-failure-bg bg-failure-bg/10 text-failure-text mt-2 rounded-md border p-3 text-sm',
+        'aui-message-error-root border-failure-bg bg-failure-bg/10 text-failure-bg mt-2 rounded-md border p-3 text-sm',
         className,
       )}
     >

--- a/packages/trueforge-ui-sdk/src/atoms/SandboxToolCallCard.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/SandboxToolCallCard.tsx
@@ -86,7 +86,7 @@ function SandboxBody({
               <span
                 className={cn(
                   'inline-flex h-6 items-center gap-1 rounded px-1.5 text-xs lowercase',
-                  exitCode === 0 ? 'bg-success-bg/10 text-success-text' : 'bg-failure-bg/10 text-failure-text',
+                  exitCode === 0 ? 'bg-success-bg/10 text-success-bg' : 'bg-failure-bg/10 text-failure-bg',
                 )}
                 data-testid={dataTestPrefix ? `${dataTestPrefix}-exit-code` : undefined}
               >

--- a/packages/trueforge-ui-sdk/src/atoms/Toast.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/Toast.tsx
@@ -40,11 +40,11 @@ export function Toast({ title, description, open, onOpenChange, className }: Toa
         className,
       )}
     >
-      <Icon name="circle-exclamation" size="1.25em" className="text-failure-text shrink-0" />
+      <Icon name="circle-exclamation" size="1.25em" className="text-failure-bg shrink-0" />
 
       <div className="min-w-0 flex-1">
         <div className="flex items-start justify-between gap-2">
-          <div className="text-failure-text text-sm leading-none font-semibold">{title}</div>
+          <div className="text-failure-bg text-sm leading-none font-semibold">{title}</div>
           <div className="flex shrink-0 items-center gap-1">
             <button
               type="button"

--- a/packages/trueforge-ui-sdk/src/atoms/ToolApprovalBar.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/ToolApprovalBar.tsx
@@ -100,7 +100,7 @@ export function ToolApprovalBar({
                 <Icon
                   name={isDenied ? 'circle-xmark' : 'circle-check'}
                   size="0.875em"
-                  className={cn('shrink-0', isDenied ? 'text-failure-text' : 'text-success-text')}
+                  className={cn('shrink-0', isDenied ? 'text-failure-bg' : 'text-success-bg')}
                 />
               )}
             </div>
@@ -192,7 +192,7 @@ export function ToolApprovalBar({
             </Button>
           </div>
           {showReasonError && (
-            <span id="aui-denial-reason-error" className="text-xs text-failure-text" role="alert">
+            <span id="aui-denial-reason-error" className="text-xs text-failure-bg" role="alert">
               Reason is required
             </span>
           )}

--- a/packages/trueforge-ui-sdk/src/atoms/adapters/AskUserPromptAdapter.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/adapters/AskUserPromptAdapter.tsx
@@ -166,7 +166,7 @@ export function AskUserPrompt({
                     name={`ask-user-question-option-${currentQuestion.id}`}
                     checked={isSelected}
                     onChange={() => handleOptionSelect(opt)}
-                    className="mt-0.5 accent-primary"
+                    className="mt-0.5 accent-primary-button-bg"
                   />
                   <span className="min-w-0 font-sans text-[0.8125rem] font-medium leading-snug text-text-primary">
                     {opt}
@@ -188,7 +188,7 @@ export function AskUserPrompt({
                 name={`ask-user-question-option-${currentQuestion.id}`}
                 checked={isCustomSelected}
                 onChange={() => handleOptionSelect(ASK_USER_CUSTOM_OPTION)}
-                className="accent-primary"
+                className="accent-primary-button-bg"
               />
               <div className="min-w-0 flex-1">
                 <input
@@ -225,7 +225,7 @@ export function AskUserPrompt({
             })}
           >
             {isMultiQuestion && isLastQuestion && !allQuestionsAnswered ? (
-              <span className="text-xs font-medium text-failure-text">Answer all questions to submit</span>
+              <span className="text-xs font-medium text-failure-bg">Answer all questions to submit</span>
             ) : (
               <span />
             )}

--- a/packages/trueforge-ui-sdk/src/atoms/agent-chat/AgentStepRow.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/agent-chat/AgentStepRow.tsx
@@ -122,7 +122,7 @@ export function AgentStepRow({
                 <Icon
                   name="circle-check"
                   size="0.875rem"
-                  className="shrink-0 text-success-text"
+                  className="shrink-0 text-success-bg"
                   data-testid={dataTestPrefix ? `${dataTestPrefix}-success-icon` : undefined}
                 />
               )}
@@ -163,7 +163,7 @@ export function AgentStepRow({
             <Icon
               name="circle-xmark"
               size="0.875rem"
-              className="text-failure-text"
+              className="text-failure-bg"
               data-testid={dataTestPrefix ? `${dataTestPrefix}-error-icon` : undefined}
             />
           )}

--- a/packages/trueforge-ui-sdk/src/containers/TrueforgeUI.tsx
+++ b/packages/trueforge-ui-sdk/src/containers/TrueforgeUI.tsx
@@ -86,7 +86,7 @@ function ServerInitError({ error, className }: { error: unknown; className?: str
     <div
       role="alert"
       className={cn(
-        'flex h-full min-h-48 items-center justify-center bg-primary-bg px-6 text-center text-sm text-failure-text',
+        'flex h-full min-h-48 items-center justify-center bg-primary-bg px-6 text-center text-sm text-failure-bg',
         className,
       )}
     >

--- a/packages/trueforge-ui-sdk/test/atoms/AssistantMessageBubble.test.tsx
+++ b/packages/trueforge-ui-sdk/test/atoms/AssistantMessageBubble.test.tsx
@@ -18,7 +18,7 @@ describe('AssistantMessageBubble', () => {
     const root = container.querySelector('[data-slot="aui_assistant-message-root"]');
     expect(root).toHaveClass('host-bubble');
     expect(root).toContainElement(screen.getByText('Assistant response'));
-    expect(screen.getByText('Generation failed').parentElement).toHaveClass('text-failure-text');
+    expect(screen.getByText('Generation failed').parentElement).toHaveClass('text-failure-bg');
     expect(screen.getByRole('button', { name: 'Copy response' }).parentElement).toHaveClass('mt-1');
   });
 
@@ -26,7 +26,7 @@ describe('AssistantMessageBubble', () => {
     const { container } = render(<AssistantMessageBubble>Only the message</AssistantMessageBubble>);
 
     expect(screen.getByText('Only the message')).toBeInTheDocument();
-    expect(container.querySelector('.text-failure-text')).not.toBeInTheDocument();
+    expect(container.querySelector('.text-failure-bg')).not.toBeInTheDocument();
     expect(container.querySelector('.mt-1')).not.toBeInTheDocument();
   });
 });

--- a/packages/trueforge-ui-sdk/test/atoms/SandboxToolCallCard.test.tsx
+++ b/packages/trueforge-ui-sdk/test/atoms/SandboxToolCallCard.test.tsx
@@ -85,7 +85,7 @@ describe('SandboxToolCallCard', () => {
     for (const editor of screen.getAllByTestId('sandbox-json')) {
       expect(editor).toHaveAttribute('data-read-only', 'true');
     }
-    expect(container.querySelector('svg.text-failure-text')).toBeInTheDocument();
+    expect(container.querySelector('svg.text-failure-bg')).toBeInTheDocument();
     expect(screen.getByTestId('sandbox-exit-code')).toHaveTextContent('exit: 1');
   });
 

--- a/packages/trueforge-ui-sdk/test/atoms/SubAgentCard.test.tsx
+++ b/packages/trueforge-ui-sdk/test/atoms/SubAgentCard.test.tsx
@@ -76,7 +76,7 @@ describe('SubAgentCard', () => {
 
     expect(renderInstruction).toHaveBeenCalledWith('Review changes');
     expect(screen.getByText('Custom: Review changes')).toBeInTheDocument();
-    expect(container.querySelector('svg.text-failure-text')).toBeInTheDocument();
+    expect(container.querySelector('svg.text-failure-bg')).toBeInTheDocument();
   });
 
   it('omits the instruction section for whitespace-only instructions', () => {

--- a/packages/trueforge-ui-sdk/test/atoms/ToolCallCard.test.tsx
+++ b/packages/trueforge-ui-sdk/test/atoms/ToolCallCard.test.tsx
@@ -51,7 +51,7 @@ describe('ToolCallCard', () => {
     expect(screen.getByTestId('run-header-success-icon')).toBeInTheDocument();
 
     rerender(<ToolCallCard toolName="Run" exitCode={2} dataTestPrefix="run" />);
-    expect(container.querySelector('svg.text-failure-text')).toBeInTheDocument();
+    expect(container.querySelector('svg.text-failure-bg')).toBeInTheDocument();
   });
 
   it('honors explicit status and suppresses expansion when no expandable content exists', () => {
@@ -59,7 +59,7 @@ describe('ToolCallCard', () => {
       <ToolCallCard toolName="Failed tool" status="error" onToggle={vi.fn()} dataTestPrefix="failed" />,
     );
 
-    expect(container.querySelector('svg.text-failure-text')).toBeInTheDocument();
+    expect(container.querySelector('svg.text-failure-bg')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Expand step' })).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/sdk`, `.github/fern/openapi/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic theme-token class renames only; no behavior, auth, or data-handling changes.
> 
> **Overview**
> Corrects theme token usage so status and accent colors render with the intended palette values.
> 
> Replaces `text-failure-text` / `text-success-text` with `text-failure-bg` / `text-success-bg` across error banners, toasts, tool approval, agent steps, and related surfaces. Also switches radio accents from `accent-primary` to `accent-primary-button-bg`, and updates the README override example plus unit tests to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f1b92a3966acadb455464a8af465e1d1fd935ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->