### PR TITLE
Map TFY Gateway costInUSD into completion usage

### DIFF
--- a/packages/harness/src/core/llm/VercelAILLM.ts
+++ b/packages/harness/src/core/llm/VercelAILLM.ts
@@ -945,9 +945,12 @@ export function normalizeUsage(usage: {
     reasoningTokens: number | undefined;
     textTokens: number | undefined;
   };
+  // LanguageModelUsage.raw: AI SDK has no cost field; extras like gateway costInUSD live here.
+  raw?: JSONObject;
 }): CompletionUsage {
   const input = usage.inputTokens ?? 0;
   const output = usage.outputTokens ?? 0;
+  const costInUsd = usage.raw?.['costInUSD'];
   return {
     input_tokens: input,
     output_tokens: output,
@@ -955,6 +958,7 @@ export function normalizeUsage(usage: {
     cache_read_tokens: usage.inputTokenDetails.cacheReadTokens ?? undefined,
     cache_write_tokens: usage.inputTokenDetails.cacheWriteTokens ?? undefined,
     reasoning_tokens: usage.outputTokenDetails.reasoningTokens ?? undefined,
+    cost_in_usd: typeof costInUsd === 'number' && costInUsd >= 0 ? costInUsd : undefined,
   };
 }
 

--- a/packages/harness/tests/core/llm/VercelAILLM.stream.test.ts
+++ b/packages/harness/tests/core/llm/VercelAILLM.stream.test.ts
@@ -107,6 +107,19 @@ describe('normalizeUsage', () => {
     expect(result.cache_read_tokens).toBeUndefined();
     expect(result.cache_write_tokens).toBeUndefined();
     expect(result.reasoning_tokens).toBeUndefined();
+    expect(result.cost_in_usd).toBeUndefined();
+  });
+
+  it('maps gateway costInUSD from usage.raw onto cost_in_usd', () => {
+    const usage = makeUsage(10, 5);
+    usage.raw = { costInUSD: 0.0042 };
+    expect(normalizeUsage(usage).cost_in_usd).toBe(0.0042);
+  });
+
+  it('omits cost_in_usd when raw.costInUSD is not a nonnegative number', () => {
+    const usage = makeUsage();
+    usage.raw = { costInUSD: -0.01 };
+    expect(normalizeUsage(usage).cost_in_usd).toBeUndefined();
   });
 });
 
@@ -544,14 +557,21 @@ describe('mapStreamToChunks', () => {
 
   it('emits a finish chunk with usage and sets the final message finish_reason', async () => {
     const usage = makeUsage(20, 10);
+    usage.raw = { costInUSD: 0.12 };
     const { chunks, final } = await drainStream(
       mapStreamToChunks({ stream: makeStream([makeFinishStep('length', usage)]), chunkMeta: CHUNK_META }),
     );
 
     const finishChunk = chunks.find(c => c.choices[0]?.finish_reason !== null);
     expect(finishChunk?.choices[0]?.finish_reason).toBe('length');
-    expect(finishChunk?.usage).toMatchObject({ input_tokens: 20, output_tokens: 10, total_tokens: 30 });
+    expect(finishChunk?.usage).toMatchObject({
+      input_tokens: 20,
+      output_tokens: 10,
+      total_tokens: 30,
+      cost_in_usd: 0.12,
+    });
     expect(final.finish_reason).toBe('length');
+    expect(final.usage.cost_in_usd).toBe(0.12);
   });
 
   it('rejects with the provider message on an error part', async () => {


### PR DESCRIPTION
## Summary

Restores turn cost metrics for TFY Gateway after the Vercel AI SDK migration. `OpenAILLM` used to map gateway `usage.costInUSD` → harness `cost_in_usd`; `VercelAILLM.normalizeUsage` dropped that, so `total_cost_in_usd` stayed unset even when the gateway injected cost.

Closes #

## Changes

- Map `LanguageModelUsage.raw.costInUSD` → `CompletionUsage.cost_in_usd` in `normalizeUsage` (nonnegative numbers only)
- Cover mapping + finish-step stream path in `VercelAILLM.stream.test.ts`

## How was this tested?

- Unit tests in `packages/harness/tests/core/llm/VercelAILLM.stream.test.ts` (`normalizeUsage` + finish chunk with cost)
- `pnpm --filter @truefoundry/utils-core exec jest --config jest.config.cjs tests/core/llm/VercelAILLM.stream.test.ts`

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/sdk`, `.github/fern/openapi/openapi.json`)
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested usage-field mapping with nonnegative validation. Incorrect mapping would only affect reported cost metrics, not request handling.
> 
> **Overview**
> Restores turn cost metrics for TFY Gateway after the Vercel AI SDK migration by mapping `LanguageModelUsage.raw.costInUSD` → `CompletionUsage.cost_in_usd` in `normalizeUsage` (nonnegative numbers only).
> 
> Without this, gateway-injected cost was dropped and `total_cost_in_usd` stayed unset. Unit tests cover the mapping and the finish-step stream path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21eba739db1db020f8f4f65b10adaddaed9cb708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->