### PR TITLE
refactor: update visibility logic for ClearChatButton and related hooks to handle mutable sessions

### DIFF
--- a/packages/trueforge-ui-sdk/src/atoms/ClearChatButton.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/ClearChatButton.tsx
@@ -5,7 +5,7 @@ import { Icon } from '../icons/Icon.js';
 import { useOptionalShellMode } from '../server/ShellModeContext.js';
 import { auiButtonClass } from './lib/buttonClasses.js';
 
-// Resets the current named or draft chat. Hidden on untitled empty drafts.
+// Resets an immutable (named) chat. Hidden while idle or on mutable drafts.
 export function ClearChatButton() {
   const shell = useOptionalShellMode();
   const visible = useChatChromeActionsVisible();

--- a/packages/trueforge-ui-sdk/src/hooks/useChatChromeActionsVisible.ts
+++ b/packages/trueforge-ui-sdk/src/hooks/useChatChromeActionsVisible.ts
@@ -1,10 +1,8 @@
 'use client';
 
-import { useAuiState } from '@assistant-ui/react';
 import { useTrueFoundryAgentSpec } from '@truefoundry/assistant-ui-runtime';
 
 import { useOptionalShellMode } from '../server/ShellModeContext.js';
-import { isNewChatView } from '../utils/isNewChatView.js';
 
 // Immutable named-agent title in the thread header.
 export function useNamedAgentHeaderVisible(): boolean {
@@ -22,21 +20,10 @@ export function useSaveAgentVisible(): boolean {
   return Boolean(agentSpec?.model?.name?.trim());
 }
 
-// Clear chat: after a chat has started (drafts need a model).
-// Named / saved agents keep Clear visible even on an empty welcome thread.
+// Clear chat: only on immutable (named / saved) sessions — same gate as the agent title.
 export function useChatChromeActionsVisible(): boolean {
   const shell = useOptionalShellMode();
-  const { agentSpec } = useTrueFoundryAgentSpec();
-  const isEmpty = useAuiState(isNewChatView);
-
-  if (shell == null || shell.mode.status !== 'active') return false;
-  if (shell.mode.isMutable && !agentSpec?.model?.name?.trim()) return false;
-  if (isEmpty) {
-    const boundName = shell.mode.agentName ?? shell.mode.agentId;
-    const isNamedOrSaved = boundName != null && boundName.length > 0;
-    if (!isNamedOrSaved) return false;
-  }
-  return true;
+  return shell != null && shell.mode.status === 'active' && !shell.mode.isMutable;
 }
 
 // True when the thread header has anything to show (title, Save, and/or Clear).

--- a/packages/trueforge-ui-sdk/test/atoms/ClearChatButton.test.tsx
+++ b/packages/trueforge-ui-sdk/test/atoms/ClearChatButton.test.tsx
@@ -53,11 +53,11 @@ describe('ClearChatButton', () => {
     expect(screen.getByRole('button', { name: 'Clear chat' })).toBeInTheDocument();
   });
 
-  it('is hidden on an empty untitled draft', () => {
+  it('is hidden on mutable sessions', () => {
     render(
       <SlotsProvider>
         <ShellModeProvider agentConfig={{ mode: 'AgentComposer' }}>
-          <RuntimeHarness messages={[]}>
+          <RuntimeHarness messages={startedMessages}>
             <ClearChatButton />
           </RuntimeHarness>
         </ShellModeProvider>

--- a/packages/trueforge-ui-sdk/test/hooks/useChatChromeActionsVisible.test.tsx
+++ b/packages/trueforge-ui-sdk/test/hooks/useChatChromeActionsVisible.test.tsx
@@ -62,7 +62,7 @@ describe('useChatHeaderContentVisible', () => {
     expect(result.current.header).toBe(true);
   });
 
-  it('is false on an empty untitled draft with no model', () => {
+  it('hides Clear on mutable sessions even after chat has started', () => {
     const { result } = renderHook(
       () => ({
         named: useNamedAgentHeaderVisible(),
@@ -72,15 +72,12 @@ describe('useChatHeaderContentVisible', () => {
       }),
       {
         wrapper: wrap({
-          messages: [],
           agentConfig: { mode: 'AgentComposer' },
         }),
       },
     );
 
     expect(result.current.named).toBe(false);
-    expect(result.current.save).toBe(false);
     expect(result.current.clear).toBe(false);
-    expect(result.current.header).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI visibility change in chat chrome with no auth or data-path changes; behavior is narrower and covered by updated unit tests.
> 
> **Overview**
> **Clear chat** is now shown only for **active, immutable** (named/saved) shell sessions—the same gate as the named agent header—not for mutable `AgentComposer` drafts.
> 
> `useChatChromeActionsVisible` no longer depends on thread emptiness, selected model, or `isNewChatView`; it only checks `shell.mode.status === 'active'` and `!shell.mode.isMutable`. Comments on `ClearChatButton` were updated to match.
> 
> Tests now assert Clear stays hidden on mutable sessions even after messages exist, instead of only on empty untitled drafts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf3969314104362a8fd2bdedd1c01f86d0c139d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->