### PR TITLE
refactor: enhance NamedAgentHeaderLabel to support mutable edit state and update related hooks

### DIFF
--- a/packages/trueforge-ui-sdk/src/atoms/NamedAgentHeaderLabel.tsx
+++ b/packages/trueforge-ui-sdk/src/atoms/NamedAgentHeaderLabel.tsx
@@ -1,26 +1,27 @@
 'use client';
 
-import { useNamedAgentHeaderVisible } from '../hooks/useChatChromeActionsVisible.js';
+import { useNamedAgentHeaderState } from '../hooks/useChatChromeActionsVisible.js';
 import { Icon } from '../icons/Icon.js';
-import { useOptionalShellMode } from '../server/ShellModeContext.js';
 import { cn } from './lib/cn.js';
 
-/** Left-of-header title for an immutable (named) agent chat. Hidden for idle / draft. */
+/** Left-of-header title for a named agent, including its mutable edit state. */
 export function NamedAgentHeaderLabel({ className }: { className?: string }) {
-  const shell = useOptionalShellMode();
-  const visible = useNamedAgentHeaderVisible();
-  if (!visible || shell == null || shell.mode.status !== 'active') return null;
-
-  const name = shell.mode.agentName ?? shell.mode.agentId;
-  if (name == null || name.length === 0) return null;
+  const state = useNamedAgentHeaderState();
+  if (state === null) return null;
 
   return (
     <h1
       className={cn('flex min-w-0 items-center gap-1.5 px-1 text-sm font-medium text-text-primary', className)}
-      title={name}
+      title={state.name}
     >
       <Icon name="robot" className="size-3.5 shrink-0" />
-      <span className="truncate">{name}</span>
+      <span className="truncate">{state.name}</span>
+      {state.isEditing ? (
+        <span className="bg-secondary-bg text-text-secondary inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium">
+          <Icon name="pencil" className="size-3" />
+          Editing
+        </span>
+      ) : null}
     </h1>
   );
 }

--- a/packages/trueforge-ui-sdk/src/hooks/useChatChromeActionsVisible.ts
+++ b/packages/trueforge-ui-sdk/src/hooks/useChatChromeActionsVisible.ts
@@ -4,12 +4,23 @@ import { useTrueFoundryAgentSpec } from '@truefoundry/assistant-ui-runtime';
 
 import { useOptionalShellMode } from '../server/ShellModeContext.js';
 
-// Immutable named-agent title in the thread header.
-export function useNamedAgentHeaderVisible(): boolean {
+export type NamedAgentHeaderState = {
+  name: string;
+  isEditing: boolean;
+};
+
+// Canonical named-agent header state, including mutable edit mode.
+export function useNamedAgentHeaderState(): NamedAgentHeaderState | null {
   const shell = useOptionalShellMode();
-  if (shell == null || shell.mode.status !== 'active' || shell.mode.isMutable) return false;
+  if (shell == null || shell.mode.status !== 'active') return null;
   const name = shell.mode.agentName ?? shell.mode.agentId;
-  return name != null && name.length > 0;
+  if (name == null || name.length === 0) return null;
+  return { name, isEditing: shell.mode.isMutable };
+}
+
+export function useNamedAgentHeaderVisible(): boolean {
+  const state = useNamedAgentHeaderState();
+  return state !== null;
 }
 
 // Mutable draft/edit with a selected model — drives Save Agent + header chrome.

--- a/packages/trueforge-ui-sdk/test/atoms/NamedAgentHeaderLabel.test.tsx
+++ b/packages/trueforge-ui-sdk/test/atoms/NamedAgentHeaderLabel.test.tsx
@@ -14,6 +14,25 @@ function SelectNamed() {
   );
 }
 
+function SelectEditable() {
+  const shell = useShellMode();
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        shell.selectLibraryAgent({
+          isMutable: true,
+          agentId: 'reviewer',
+          agentName: 'reviewer',
+          agentSpec: { model: { name: 'openai/gpt-4.1' } },
+        })
+      }
+    >
+      edit
+    </button>
+  );
+}
+
 describe('NamedAgentHeaderLabel', () => {
   it('shows the agent name for a named (immutable) chat', () => {
     render(
@@ -24,13 +43,28 @@ describe('NamedAgentHeaderLabel', () => {
     expect(screen.getByRole('heading', { name: 'support' })).toBeInTheDocument();
   });
 
-  it('is hidden for draft / mutable chats', () => {
+  it('is hidden for unnamed draft chats', () => {
     render(
       <ShellModeProvider agentConfig={{ mode: 'AgentComposer' }}>
         <NamedAgentHeaderLabel />
       </ShellModeProvider>,
     );
     expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  it('shows an Editing label for a saved agent opened in mutable mode', () => {
+    render(
+      <ShellModeProvider agentConfig={{ mode: 'AgentComposer' }}>
+        <SelectEditable />
+        <NamedAgentHeaderLabel />
+      </ShellModeProvider>,
+    );
+
+    act(() => {
+      screen.getByRole('button', { name: 'edit' }).click();
+    });
+
+    expect(screen.getByRole('heading', { name: 'reviewer Editing' })).toBeInTheDocument();
   });
 
   it('is hidden while idle, then appears after selecting a named agent', () => {


### PR DESCRIPTION
<img width="1261" height="765" alt="Screenshot 2026-08-13 at 11 46 19 AM" src="https://github.com/user-attachments/assets/f0cf817e-2a4e-4628-9360-0992afac214a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only header chrome and hook refactor with no changes to auth, data, or save/clear gating for other actions.
> 
> **Overview**
> The thread header **named agent title** now appears for **mutable edit sessions** on saved agents, not only for immutable chats. A new **`useNamedAgentHeaderState`** hook centralizes **name** and **`isEditing`** (`shell.mode.isMutable`); **`NamedAgentHeaderLabel`** uses it and shows a pill with pencil icon and **Editing** when editing.
> 
> Unnamed drafts without an agent name still hide the header. **`useNamedAgentHeaderVisible`** is unchanged for callers—it now derives visibility from the new state hook. Tests cover the Editing label and clarify unnamed draft vs mutable named edit cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b607e31c0a838e6e6e55d262b92c675cf940989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->