### PR TITLE
chore: set max width for settings related pages

### DIFF
--- a/packages/trueforge-ui-sdk/src/containers/SettingsBuilder/index.tsx
+++ b/packages/trueforge-ui-sdk/src/containers/SettingsBuilder/index.tsx
@@ -132,13 +132,15 @@ const TruefoundrySettingsBuilder = () => {
           ))}
         </nav>
 
-        <section className="flex h-full flex-1 flex-col overflow-y-hidden px-6 py-4">
-          <Suspense fallback={<SettingsSectionFallback />}>
-            {section === 'models' ? <ModelSettings /> : null}
-            {section === 'connectors' ? <ConnectorSettings /> : null}
-            {section === 'skills' && hasSkills ? <SkillSettings /> : null}
-            {section === 'sandbox' && hasSandbox ? <SandboxSettings /> : null}
-          </Suspense>
+        <section className="flex flex-col h-full flex-1 overflow-y-hidden px-6 py-4">
+          <div className="w-full max-w-210 h-full min-h-0 flex flex-col mx-auto">
+            <Suspense fallback={<SettingsSectionFallback />}>
+              {section === 'models' ? <ModelSettings /> : null}
+              {section === 'connectors' ? <ConnectorSettings /> : null}
+              {section === 'skills' && hasSkills ? <SkillSettings /> : null}
+              {section === 'sandbox' && hasSandbox ? <SandboxSettings /> : null}
+            </Suspense>
+          </div>
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/sdk`, `.github/fern/openapi/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure layout/CSS class changes in the Settings shell with no logic, data, or API impact.
> 
> **Overview**
> **Centers and caps the width of Settings tab content** in `SettingsBuilder` so models, connectors, skills, and sandbox sections do not stretch across the full panel on wide layouts.
> 
> The main content area now wraps the lazy-loaded section components in an inner `div` with `max-w-210`, `mx-auto`, and flex column sizing (`h-full min-h-0`), while the outer `section` keeps overflow and padding. Section switching and Suspense behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a113d345a285ad1b5d0722d065b4ce7224de215c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->