### PR TITLE
ci: run lint after typecheck so PRs fail faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,14 @@ jobs:
 
   # Always-on: format + lint cover the whole tree (incl. roots outside packages/*);
   # typecheck/build stay always-on. Per-package jobs only run tests.
+
+  # Order matters for fail-fast and lint correctness:
+  # - format first (cheapest signal)
+  # - typecheck next (types + sdk/ui pretypecheck so .d.ts exist)
+  # - lint after typecheck (type-aware eslint resolves workspace packages via dist)
+  # - build last (full emit; not required for lint, still always-on as a ship gate)
   typecheck-and-build:
-    name: Format, Lint, Typecheck and Build
+    name: Format, Typecheck, Lint and Build
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -128,12 +134,12 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Build
-        run: pnpm build
-
-      # After typecheck/build so trueforge-ui and sdk .d.ts exist for type-aware eslint.
+      # After typecheck so trueforge-ui and sdk .d.ts exist for type-aware eslint.
       - name: Lint
         run: pnpm lint:ci
+
+      - name: Build
+        run: pnpm build
 
   # Path-gated tests only — format/lint are covered by the global job above.
   package-checks:


### PR DESCRIPTION
## Summary
Reorder the always-on CI job to `format → typecheck → lint → build` so format/type/lint failures surface before the full monorepo emit, without weakening checks.

Closes AGE-1666

## Changes

- Run `lint:ci` immediately after `typecheck` (sdk/ui `.d.ts` already come from typecheck `pretypecheck`)
- Keep always-on `pnpm build` as the last step (emit/ship gate; not required for eslint)
- Document why the step order matters in `.github/workflows/ci.yml`

## How was this tested?

- [ ] Reviewed that frontend/UI `pretypecheck` builds sdk/ui dist used by type-aware eslint
- [ ] CI green on this PR (`Format, Typecheck, Lint and Build`)

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/sdk`, `.github/fern/openapi/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow ordering and comments only; no application code or check coverage changes.
> 
> **Overview**
> Reorders the always-on **`typecheck-and-build`** job so steps run **format → typecheck → lint → build** instead of running **build** before **lint**.
> 
> **Lint** now runs right after **typecheck**, when sdk/ui `.d.ts` are already produced via package **`pretypecheck`** hooks—so type-aware eslint still works without waiting on the full monorepo **`pnpm build`**. **`pnpm build`** stays last as the emit/ship gate.
> 
> Adds inline comments in **`ci.yml`** explaining fail-fast ordering and updates the job display name to **Format, Typecheck, Lint and Build**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 754080f9f72e5bca31e24032f20bc1c5d2a4ecfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->