### PR TITLE
Fix SQLite sandbox_provider status migration on non-empty tables.

### DIFF
--- a/packages/server/src/db/sqlite/migrations/20260815_000001_sandbox_provider_status.ts
+++ b/packages/server/src/db/sqlite/migrations/20260815_000001_sandbox_provider_status.ts
@@ -18,7 +18,9 @@ const RELEASE_IMAGE_URI =
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`ALTER TABLE sandbox_provider ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'`.execute(db);
   await sql`ALTER TABLE sandbox_provider ADD COLUMN status_reason TEXT`.execute(db);
-  await sql`ALTER TABLE sandbox_provider ADD COLUMN build_metadata BLOB NOT NULL DEFAULT (jsonb('{}'))`.execute(db);
+  // SQLite forbids non-constant DEFAULTs on ADD COLUMN when rows exist, so add nullable then fill.
+  await sql`ALTER TABLE sandbox_provider ADD COLUMN build_metadata BLOB`.execute(db);
+  await sql`UPDATE sandbox_provider SET build_metadata = jsonb('{}') WHERE build_metadata IS NULL`.execute(db);
 
   await sql`
     UPDATE sandbox_provider


### PR DESCRIPTION
SQLite rejects parenthesized expression defaults when ADD COLUMN must backfill existing rows; use the constant jsonb('{}') blob X'0C' instead.

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/sdk`, `.github/fern/openapi/openapi.json`)
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SQLite-only migration adjustment with no application logic changes; reduces risk of failed upgrades on non-empty databases.
> 
> **Overview**
> Fixes the SQLite `sandbox_provider` status migration so it succeeds when the table already has rows.
> 
> **`build_metadata`** was added with `NOT NULL DEFAULT (jsonb('{}'))`, which SQLite rejects when `ADD COLUMN` must backfill existing rows (non-constant expression defaults). The migration now adds **`build_metadata`** as a nullable `BLOB`, then runs an **`UPDATE`** to set `jsonb('{}')` where the column is null. The later backfill for rows with `manifest.snapshot_name` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b9c60ef7e5aef21809f9d34cf182adc8e1552d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->