### PR TITLE
feat: add PostHog remote server configuration to MCP catalog

### DIFF
--- a/packages/server/catalog/mcp-catalog.yaml
+++ b/packages/server/catalog/mcp-catalog.yaml
@@ -80,3 +80,9 @@ mcp_servers:
     url: https://mcp.atlassian.com/v1/mcp
     auth:
       type: dcr
+  - type: remote
+    name: posthog
+    logo: https://assets.production.truefoundry.com/posthog.svg
+    url: https://mcp.posthog.com/mcp
+    auth:
+      type: dcr


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Add posthog

## Changes

- update catalog mcp

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/sdk`, `.github/fern/openapi/openapi.json`)
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML catalog-only addition mirroring existing remote presets; no auth, execution, or API behavior changes.
> 
> **Overview**
> Adds a **PostHog** remote MCP server preset to the shipped catalog (`mcp-catalog.yaml`), so it appears in **GET /api/v1/catalog/mcp-servers** for the UI like Linear, Jira, and Stripe.
> 
> The entry points to `https://mcp.posthog.com/mcp` with **DCR** auth and the standard PostHog logo asset URL—discovery-only; no runtime MCP execution logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a67a98c8b6fb1bcb07459cff43f88ca7594e280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->