### PR TITLE
fix: update SANDBOX_IMAGE_URI to new image

### DIFF
--- a/packages/harness/src/core/sandbox/sandboxImage.ts
+++ b/packages/harness/src/core/sandbox/sandboxImage.ts
@@ -2,5 +2,4 @@
  * Release-owned sandbox image. In-memory for now; CI will later replace this
  * with the tag it pushes on each release.
  */
-export const SANDBOX_IMAGE_URI =
-  'tfy.jfrog.io/tfy-images/trueforge-sandbox:ce9e802ff68514dfc6ff138ff81c8f26dbaaf724';
+export const SANDBOX_IMAGE_URI = 'tfy.jfrog.io/tfy-images/trueforge-sandbox:ce9e802ff68514dfc6ff138ff81c8f26dbaaf724';

--- a/packages/harness/src/core/sandbox/sandboxImage.ts
+++ b/packages/harness/src/core/sandbox/sandboxImage.ts
@@ -3,4 +3,4 @@
  * with the tag it pushes on each release.
  */
 export const SANDBOX_IMAGE_URI =
-  'tfy.jfrog.io/tfy-images/truefoundry-utils-core-sandbox:029ea5ff6438cf86b79282e087bfc17528067946';
+  'tfy.jfrog.io/tfy-images/trueforge-sandbox:ce9e802ff68514dfc6ff138ff81c8f26dbaaf724';


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Updates Sandbox URI

## Changes

- Updates Sandbox URI

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/sdk`, `.github/fern/openapi/openapi.json`)
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant swap for the default sandbox image; tenants with persisted build metadata stay pinned to their prior image.
> 
> **Overview**
> Updates the release-owned **`SANDBOX_IMAGE_URI`** in `sandboxImage.ts` from `truefoundry-utils-core-sandbox` (tag `029ea5ff…`) to **`trueforge-sandbox`** (tag `ce9e802f…`) on the same JFrog registry.
> 
> That constant is what the server uses when building Daytona sandboxes on **first configure** (no persisted `build_metadata`), so new tenant setups will pull the corrected image name and digest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 786603de44c9fb69740987852e65c58b96fdf105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->