### PR TITLE
ci: push Generate SDK commits with a GitHub App token

### DIFF
--- a/.github/workflows/generate-sdk.yaml
+++ b/.github/workflows/generate-sdk.yaml
@@ -31,11 +31,21 @@ jobs:
     timeout-minutes: 30
     # A pull_request path filter matches the whole PR, not just the new commit,
     # so this job's own commits would otherwise retrigger it indefinitely.
-    if: github.actor != 'github-actions[bot]'
+    if: >
+      github.actor != 'github-actions[bot]' &&
+      github.actor != format('{0}[bot]', vars.GENERATE_SDK_APP_SLUG)
     permissions:
       contents: write
 
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GENERATE_SDK_APP_ID }}
+          private-key: ${{ secrets.GENERATE_SDK_APP_PRIVATE_KEY }}
+
       # Branch tip, not the merge commit, so output can be pushed back; forks need the head repo named.
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -44,6 +54,7 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
           # Full history, so the gate below can diff against the base commit.
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -98,10 +109,11 @@ jobs:
 
       # Forks get a read-only token, so only the commit is skipped. TODO: an approval flow that can push to the fork.
       - name: Commit generated output
-        if: steps.decide.outputs.needed == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: steps.decide.outputs.needed == 'true' && steps.app-token.outcome == 'success'
         # Passed as env, never interpolated into the script, so it cannot inject shell.
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -euo pipefail
 
@@ -111,8 +123,8 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
 
           # Bot-authored sdk diffs need a changeset; the PR author never touches this commit.
           # Skip packages/sdk/.fern — Fern metadata only, not a consumer-facing change.

--- a/.github/workflows/generate-sdk.yaml
+++ b/.github/workflows/generate-sdk.yaml
@@ -31,9 +31,11 @@ jobs:
     timeout-minutes: 30
     # A pull_request path filter matches the whole PR, not just the new commit,
     # so this job's own commits would otherwise retrigger it indefinitely.
+    # github-actions[bot]: legacy GITHUB_TOKEN pushes (if any still land).
+    # trueforge-dev-bot[bot]: App-token pushes from this workflow (slug of the Generate SDK App).
     if: >
       github.actor != 'github-actions[bot]' &&
-      github.actor != format('{0}[bot]', vars.GENERATE_SDK_APP_SLUG)
+      github.actor != 'trueforge-dev-bot[bot]'
     permissions:
       contents: write
 
@@ -43,8 +45,8 @@ jobs:
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GENERATE_SDK_APP_ID }}
-          private-key: ${{ secrets.GENERATE_SDK_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.TRUEFORGE_GENERATE_SDK_APP_ID }}
+          private-key: ${{ secrets.TRUEFORGE_GENERATE_SDK_APP_PRIVATE_KEY }}
 
       # Branch tip, not the merge commit, so output can be pushed back; forks need the head repo named.
       - name: Check out repository code


### PR DESCRIPTION
## Summary

Push Generate SDK commits with a GitHub App token so follow-on PR checks run without manual approval, and so a ruleset bypass (if configured) can allow pushes to `main`.

Closes AGE-1540

## Changes

- Mint an installation token via `actions/create-github-app-token` (`TRUEFORGE_GENERATE_SDK_APP_ID` / `TRUEFORGE_GENERATE_SDK_APP_PRIVATE_KEY`)
- Pass that token to `actions/checkout` so `git push` authenticates as the App (not `GITHUB_TOKEN`)
- Skip re-runs when the actor is `trueforge-dev-bot[bot]` (hardcoded App slug)
- Commit only when the App token step succeeds; forks still skip the push

## Setup (required before merge / first successful run)

### GitHub App

App already created and installed:

| Field | Value |
|-------|--------|
| App | `trueforge-dev-bot` |
| App ID | `<app-id>` |
| Permissions | Contents: Read and write |

### Repo secrets (`trueforge` → Settings → Secrets → Actions)

| Secret | Value |
|--------|--------|
| `TRUEFORGE_GENERATE_SDK_APP_ID` | `<app-id>` |
| `TRUEFORGE_GENERATE_SDK_APP_PRIVATE_KEY` | Full `.pem` contents |

No Actions **variable** is required (slug is hardcoded in the workflow).

### Ruleset (only if Generate SDK still pushes to `main`)

1. **Settings → Rules → Rulesets** → ruleset for `main`
2. **Bypass list** → add **`trueforge-dev-bot`**
3. Bypass mode: **Always**

Skip this if you only push to PR branches.

**Without App secrets configured:** no loop — token mint fails, nothing is pushed, job fails once.

## How was this tested?

- [ ] Manual: open a same-repo PR that changes OpenAPI sources → Generate SDK pushes → CI runs without “Approve workflows to run”
- [ ] Manual (if bypass configured): merge to `main` that regenerates OpenAPI → Generate SDK push to `main` succeeds (no GH013)
- [x] Confirm `TRUEFORGE_GENERATE_SDK_APP_ID` and `TRUEFORGE_GENERATE_SDK_APP_PRIVATE_KEY` are set on the repo

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense — N/A (workflow-only)
- [x] No hand-edits to generated code (`packages/sdk`, `.github/fern/openapi/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed — N/A (repo secrets + App install; documented in Setup above)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI authentication and push behavior for bot commits; missing or misconfigured App secrets will fail the job or block pushes until setup is complete.
> 
> **Overview**
> **Automated OpenAPI/SDK regeneration** now authenticates with a **GitHub App** (`actions/create-github-app-token` using `TRUEFORGE_GENERATE_SDK_APP_ID` / `TRUEFORGE_GENERATE_SDK_APP_PRIVATE_KEY`) on `push` and same-repo PRs, and passes that token to `actions/checkout` so `git push` runs as the App rather than the default `GITHUB_TOKEN`.
> 
> The job **no longer runs** when the triggering actor is `trueforge-dev-bot[bot]` (in addition to `github-actions[bot]`), avoiding infinite re-runs from the workflow’s own commits. The **commit step** is gated on the App token step succeeding (`steps.app-token.outcome == 'success'`) instead of the previous explicit same-repo / push event check; fork PRs still skip the push when the token step does not run. Commit **author identity** comes from `steps.app-token.outputs.app-slug` (`{slug}[bot]`) instead of hardcoded `github-actions[bot]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b1fa7355c62efeecce1385ba5fd1a8a27e6de90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->