### PR TITLE
docs: README copy — 'you only need a model key'

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ See the [chart README](charts/trueforge/README.md) (including [`configs.oidc`](c
 
 ## Build your first agent
 
-Full walkthrough: [Quickstart](https://trueforge.dev/quickstart). The example below builds a **web research briefer** — it searches the web, fans out to parallel subagents, and renders an interactive brief. To get started, you also need a model key.
+Full walkthrough: [Quickstart](https://trueforge.dev/quickstart). The example below builds a **web research briefer** — it searches the web, fans out to parallel subagents, and renders an interactive brief. To get started, you only need a model key.
 
 1. **Add a model provider** - **Settings → Models**, pick a provider, paste your API key.
 


### PR DESCRIPTION
One-word copy fix in the "Build your first agent" intro: "you also need a model key" → "you **only** need a model key" — reinforces that everything else (Exa no-auth, the skill, and the now-optional sandbox) doesn't require a key to get started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or security impact.
> 
> **Overview**
> In the **Build your first agent** intro on `README.md`, the quickstart line now says you **only** need a model key to get started (replacing “you also need”), so readers aren’t led to think extra credentials are required beyond the model provider step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b932438a1b8bb03d5a968c3df2a466b499b45cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->