### PR TITLE
chore:  improved nested approval handling

### DIFF
--- a/.changeset/nested-approvals-ui-patch.md
+++ b/.changeset/nested-approvals-ui-patch.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Improve nested tool approval handling and bump `@truefoundry/assistant-ui-runtime`.

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -24,7 +24,7 @@
     "@assistant-ui/core": "0.2.22",
     "@assistant-ui/react": "^0.14.24",
     "@assistant-ui/store": "0.2.21",
-    "@truefoundry/assistant-ui-runtime": "0.1.17",
+    "@truefoundry/assistant-ui-runtime": "0.1.18",
     "@truefoundry/trueforge-sdk": "workspace:*",
     "@truefoundry/trueforge-ui": "workspace:*",
     "monaco-editor": "^0.52.0",

--- a/packages/trueforge-ui-sdk/CHANGELOG.md
+++ b/packages/trueforge-ui-sdk/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`@truefoundry/assistant-ui-runtime` ≥ 0.1.19** — depends on the consolidated
+- **`@truefoundry/assistant-ui-runtime` ≥ 0.1.18** — depends on the consolidated
   runtime release that includes:
   - `getModels` → `properties.reasoningEfforts` for thinking-capable models
   - extras ancestor walk so nested/readonly AUI clients resolve

--- a/packages/trueforge-ui-sdk/CHANGELOG.md
+++ b/packages/trueforge-ui-sdk/CHANGELOG.md
@@ -26,6 +26,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`@truefoundry/assistant-ui-runtime` ≥ 0.1.19** — depends on the consolidated
+  runtime release that includes:
+  - `getModels` → `properties.reasoningEfforts` for thinking-capable models
+  - extras ancestor walk so nested/readonly AUI clients resolve
+    `useTrueFoundryRespondToToolApproval` (sub-agent Allow/Deny)
+  - parallel enabled-models + provider-metadata CP fetches
+  - `ModelSelectorEntry.name` / `id` = `model_fqn` (`account/model-id`)
+  - gateway mount sanitization (`normalizeMcpMount` / `normalizeSkillMount`,
+    registry `enableTools` default `["@all"]`)
+
+### Fixed
+
+- **Sub-agent Allow/Deny** — nested tool approvals inside `create_sub_agent` now
+  call `useTrueFoundryRespondToToolApproval` with the _nested_ tool's approval
+  id. The old bridge keyed off the outer sub-agent part (usually with no
+  approval), so clicks silently no-op'd. Requires `@truefoundry/assistant-ui-runtime`
+  ≥ 0.1.19 so extras resolve through the readonly nested AUI client.
+- **Sandbox provider contract** — drop `snapshotName` from `SandboxProviderConfig`
+  and wrap `listSandboxProviders` as `{ data, snapshotSyncStatus }` (Harness
+  `status` / `status_reason`). Re-exports `SandboxProviderListEntry` /
+  `SandboxSnapshotSyncStatus`.
+
 ### Added
 
 - **`type: "trueforge"` built-in server** — `<TrueforgeUI server={{ type: 'trueforge', baseUrl?, token?, fetch? }} />`

--- a/packages/trueforge-ui-sdk/docs/compatibility.md
+++ b/packages/trueforge-ui-sdk/docs/compatibility.md
@@ -21,7 +21,7 @@ Install once at the app root.
 | ----------------------------------- | ------------- |
 | `@assistant-ui/core`                | `^0.2.22`     |
 | `@assistant-ui/react`               | `^0.14.24`    |
-| `@truefoundry/assistant-ui-runtime` | `0.1.16`      |
+| `@truefoundry/assistant-ui-runtime` | `0.1.18`      |
 | `truefoundry-gateway-sdk`           | `^0.4.0-rc.6` |
 | `lucide-react`                      | `^0.562.0`    |
 

--- a/packages/trueforge-ui-sdk/example/package.json
+++ b/packages/trueforge-ui-sdk/example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@assistant-ui/core": "^0.2.22",
     "@assistant-ui/react": "^0.14.24",
-    "@truefoundry/assistant-ui-runtime": "0.1.17",
+    "@truefoundry/assistant-ui-runtime": "0.1.18",
     "@truefoundry/trueforge-ui": "link:..",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/packages/trueforge-ui-sdk/example/yarn.lock
+++ b/packages/trueforge-ui-sdk/example/yarn.lock
@@ -1425,10 +1425,10 @@
     "@tailwindcss/oxide" "4.3.3"
     tailwindcss "4.3.3"
 
-"@truefoundry/assistant-ui-runtime@0.1.15":
-  version "0.1.15"
-  resolved "https://registry.yarnpkg.com/@truefoundry/assistant-ui-runtime/-/assistant-ui-runtime-0.1.15.tgz#9acfd809a1364d2a9b58c48ddc28ff67fb1ee1bd"
-  integrity sha512-WHbQJ0pEoVNYJ5dt99powKqPqLQejpOEYX5jsLkmZMLwty1fgGYgflovXo0StD2VUAblklstL9vpwu/pqMMh/g==
+"@truefoundry/assistant-ui-runtime@0.1.18":
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/@truefoundry/assistant-ui-runtime/-/assistant-ui-runtime-0.1.18.tgz#08ddf4cf7ea1ae3c4780ad9760b73ffa47d86e0b"
+  integrity sha512-xiEp2UwJfjqtRh2HmDLhyy5oBx4UOgKvxkOi4sYziTmStWNRg8JDTFoADu3ZV3Qr4MwRb8abQc1eoXvjzVoRNA==
   dependencies:
     "@assistant-ui/core" "^0.2.22"
     "@assistant-ui/store" "^0.2.21"

--- a/packages/trueforge-ui-sdk/package.json
+++ b/packages/trueforge-ui-sdk/package.json
@@ -94,7 +94,7 @@
     "@openuidev/react-headless": "^0.9.4",
     "@openuidev/react-lang": "^0.2.9",
     "@openuidev/react-ui": "^0.13.2",
-    "@truefoundry/assistant-ui-runtime": "0.1.17",
+    "@truefoundry/assistant-ui-runtime": "0.1.18",
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",
     "monaco-editor": "^0.56.0",

--- a/packages/trueforge-ui-sdk/src/containers/SettingsBuilder/ConnectorSettings.tsx
+++ b/packages/trueforge-ui-sdk/src/containers/SettingsBuilder/ConnectorSettings.tsx
@@ -157,6 +157,7 @@ const ConnectorSettings = () => {
           : { type: 'none' });
     await connectorCatalog.createConnector({
       name: entry.name,
+      description: entry.description ?? entry.url,
       url: entry.url,
       auth,
     });
@@ -193,6 +194,7 @@ const ConnectorSettings = () => {
         await connectorCatalog.updateConnector({
           id: existingConnector.id,
           name: existingConnector.name,
+          description: existingConnector.description,
           url: existingConnector.url,
           auth,
         });
@@ -211,6 +213,7 @@ const ConnectorSettings = () => {
     await runMutation(async () => {
       await connectorCatalog.createConnector({
         name: draft.name,
+        description: draft.url,
         url: draft.url,
         auth: draft.auth,
       });

--- a/packages/trueforge-ui-sdk/src/containers/ToolCallContainer.tsx
+++ b/packages/trueforge-ui-sdk/src/containers/ToolCallContainer.tsx
@@ -59,14 +59,36 @@ function NestedSubAgentAssistantMessage() {
 }
 
 function ToolApprovalSlot({ part }: { part: ToolCallMessagePartProps }) {
-  const nestedBridge = useNestedApprovalBridge();
+  const isNestedReadonly = useNestedApprovalBridge();
+  const respondToNestedApproval = useTrueFoundryRespondToToolApproval();
 
   const respond = (response: ToolApprovalResponse) => {
-    if (nestedBridge) {
-      nestedBridge(response);
+    if (!isNestedReadonly) {
+      part.respondToApproval(response);
       return;
     }
-    part.respondToApproval(response);
+    // Readonly nested thread: use this part's approval id, not the outer
+    // create_sub_agent tool (which usually has no approval of its own).
+    if (part.approval == null) return;
+
+    let approved: boolean | undefined;
+    let optionId: string | undefined;
+    if ('approved' in response) {
+      approved = response.approved;
+    } else if ('optionId' in response) {
+      const option = buildApprovalOptions(part.approval.options).find(o => o.id === response.optionId);
+      if (option == null) return;
+      approved = option.isAllow;
+      optionId = response.optionId;
+    }
+    if (approved === undefined) return;
+
+    respondToNestedApproval({
+      approvalId: part.approval.id,
+      approved,
+      ...(optionId != null && optionId !== '__allow' && optionId !== '__deny' ? { optionId } : {}),
+      ...('reason' in response && response.reason != null ? { reason: response.reason } : {}),
+    });
   };
 
   const onSelectOption = (optionId: string, reason?: string) => {
@@ -114,7 +136,6 @@ export const ToolCallContainer: ToolCallMessagePartComponent = part => {
   const ToolCallCard = useSlot('ToolCallCard');
   const SubAgentCard = useSlot('SubAgentCard');
   const AskUserPrompt = useSlot('AskUserPrompt');
-  const respondToNestedApproval = useTrueFoundryRespondToToolApproval();
   const elapsedMs = useToolCallElapsed();
   const isRequiresAction = part.status?.type === 'requires-action';
   const isSubAgent = part.toolName === SUB_AGENT_TOOL_NAME;
@@ -163,13 +184,6 @@ export const ToolCallContainer: ToolCallMessagePartComponent = part => {
   if (isSubAgent) {
     const { agentName, instruction, stepCount } = resolveSubAgentMeta(part);
 
-    const bridge = (response: ToolApprovalResponse) => {
-      if (part.approval == null) return;
-      const approved = 'approved' in response ? response.approved : undefined;
-      if (approved === undefined) return;
-      respondToNestedApproval({ approvalId: part.approval.id, approved });
-    };
-
     return (
       <div data-slot="tool-call-card" data-variant="sub-agent" className="w-full">
         <SubAgentCard
@@ -181,7 +195,7 @@ export const ToolCallContainer: ToolCallMessagePartComponent = part => {
           instruction={instruction}
           stepCount={stepCount}
         >
-          <NestedApprovalBridgeContext.Provider value={bridge}>
+          <NestedApprovalBridgeContext.Provider value={true}>
             <MessagePartPrimitive.Messages
               components={{
                 AssistantMessage: NestedSubAgentAssistantMessage,

--- a/packages/trueforge-ui-sdk/src/containers/nestedApprovalBridge.ts
+++ b/packages/trueforge-ui-sdk/src/containers/nestedApprovalBridge.ts
@@ -1,18 +1,16 @@
 'use client';
 
-import type { ToolApprovalResponse } from '@assistant-ui/react';
 import { createContext, useContext } from 'react';
 
 /**
- * Sub-agent tool calls render inside a read-only nested thread context
- * (`MessagePartPrimitive.Messages`), so the standard `respondToApproval` prop
- * on their parts doesn't route back to the gateway. `ToolCallContainer` uses
- * this bridge instead when rendering nested calls, translating the response
- * through `useTrueFoundryRespondToToolApproval()` -- mirrors the reference's
- * `nestedToolCallMessageComponents` override.
+ * Sub-agent tool calls render inside a read-only nested thread
+ * (`MessagePartPrimitive.Messages`), so `part.respondToApproval` throws.
+ * When this flag is set, `ToolApprovalSlot` routes Allow/Deny through
+ * `useTrueFoundryRespondToToolApproval()` using the *nested* tool's
+ * approval id (not the outer `create_sub_agent` part).
  */
-export const NestedApprovalBridgeContext = createContext<((response: ToolApprovalResponse) => void) | null>(null);
+export const NestedApprovalBridgeContext = createContext(false);
 
-export function useNestedApprovalBridge(): ((response: ToolApprovalResponse) => void) | null {
+export function useNestedApprovalBridge(): boolean {
   return useContext(NestedApprovalBridgeContext);
 }

--- a/packages/trueforge-ui-sdk/src/plugins/trueforge-agent-server-adapter/catalogs/connectorCatalog.ts
+++ b/packages/trueforge-ui-sdk/src/plugins/trueforge-agent-server-adapter/catalogs/connectorCatalog.ts
@@ -191,27 +191,24 @@ export function createConnectorCatalog(
     },
     createConnector: async req => {
       const auth = await resolveWriteAuth({ auth: req.auth });
-      const catalog = await client.catalog.mcpServers.list();
-      const preset = catalog.data.find(server => server.name === req.name);
       const body = await client.settings.mcpServers.create({
         manifest: toHarnessManifest({
           name: req.name,
           url: req.url,
           auth,
-          description: preset?.description,
+          description: req.description,
         }),
       });
       return toUiConnector(body.data);
     },
     updateConnector: async req => {
-      const existing = await getConfigured(req.id);
       const auth = await resolveWriteAuth({ id: req.id, auth: req.auth });
       const body = await client.settings.mcpServers.upsert({
         manifest: toHarnessManifest({
           name: req.id,
           url: req.url,
           auth,
-          description: existing.manifest.description,
+          description: req.description,
         }),
       });
       return toUiConnector(body.data);

--- a/packages/trueforge-ui-sdk/src/plugins/trueforge-agent-server-adapter/catalogs/sandboxProviderCatalog.ts
+++ b/packages/trueforge-ui-sdk/src/plugins/trueforge-agent-server-adapter/catalogs/sandboxProviderCatalog.ts
@@ -34,8 +34,6 @@ export function configFromHarness(
   provider: TrueForgeApi.CatalogDaytonaSandboxProvider | TrueForgeApi.SandboxProviderManifest,
 ): SandboxProviderConfig {
   return {
-    // Snapshot/image is now release-owned; the field is gone from the backend. The external
-    // SandboxProviderConfig still requires it, so send an empty placeholder until that type drops it.
     execTimeoutMs: provider.execTimeoutMs,
     autoStopIntervalInMinutes: provider.autoStopIntervalInMinutes,
     autoArchiveIntervalInMinutes: provider.autoArchiveIntervalInMinutes,
@@ -96,7 +94,7 @@ export function toHarnessManifest(
   req: {
     type: string;
     apiKey: string;
-  } & Omit<SandboxProviderConfig, 'snapshotName'>,
+  } & SandboxProviderConfig,
 ): TrueForgeApi.SandboxProviderManifest {
   if (req.type !== DAYTONA_TYPE) {
     throw new Error(`Unsupported sandbox provider type: ${req.type}`);

--- a/packages/trueforge-ui-sdk/src/plugins/trueforge-agent-server-adapter/index.ts
+++ b/packages/trueforge-ui-sdk/src/plugins/trueforge-agent-server-adapter/index.ts
@@ -34,8 +34,10 @@ export {
 export {
   configFromHarness,
   createSandboxProviderCatalog,
+  filterUiSandboxProviders,
   toHarnessManifest as toHarnessSandboxManifest,
   toUiSandboxProvider,
+  toUiSandboxProviderListEntry,
 } from './catalogs/sandboxProviderCatalog.js';
 export { createSkillCatalog, toHarnessManifest as toHarnessSkillManifest, toUiSkill } from './catalogs/skillCatalog.js';
 export {

--- a/packages/trueforge-ui-sdk/test/containers/ToolCallContainer.test.tsx
+++ b/packages/trueforge-ui-sdk/test/containers/ToolCallContainer.test.tsx
@@ -11,6 +11,18 @@ import { AssistantMessageContainer } from '@/containers/AssistantMessageContaine
 import { SlotsProvider, type SlotOverrides } from '@/theme/SlotsProvider.js';
 import { RuntimeHarness } from './RuntimeHarness.js';
 
+const { respondToNestedApproval } = vi.hoisted(() => ({
+  respondToNestedApproval: vi.fn(),
+}));
+
+vi.mock('@truefoundry/assistant-ui-runtime', async importOriginal => {
+  const actual = await importOriginal<typeof import('@truefoundry/assistant-ui-runtime')>();
+  return {
+    ...actual,
+    useTrueFoundryRespondToToolApproval: () => respondToNestedApproval,
+  };
+});
+
 function renderToolCallMessage(content: ThreadMessageLike['content'], overrides?: SlotOverrides) {
   const message: ThreadMessageLike = { role: 'assistant', content };
   return render(
@@ -224,6 +236,70 @@ describe('ToolCallContainer', () => {
       }),
     );
     expect(screen.getByText('Nested agent response')).toBeInTheDocument();
+  });
+
+  it('routes Allow inside a sub-agent to the nested tool approval id', () => {
+    respondToNestedApproval.mockClear();
+    const SubAgentCard = createSubAgentCardProbe();
+    const nestedMessage: ThreadMessage = {
+      id: 'nested-message-1',
+      role: 'assistant',
+      createdAt: new Date('2026-07-01T00:00:00Z'),
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'nested-tool-1',
+          toolName: 'delete_file',
+          args: {},
+          argsText: '{}',
+          interrupt: { type: 'human', payload: {} },
+          approval: { id: 'nested-approval-1', approved: undefined },
+        },
+      ],
+      status: { type: 'requires-action', reason: 'tool-calls' },
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {
+          subAgent: {
+            title: 'Research specialist',
+            input: 'Clean up temp files',
+          },
+        },
+      },
+    };
+
+    render(
+      <SlotsProvider overrides={{ SubAgentCard }}>
+        <RuntimeHarness
+          messages={[
+            {
+              role: 'assistant',
+              status: { type: 'requires-action', reason: 'tool-calls' },
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'sub-agent-1',
+                  toolName: 'create_sub_agent',
+                  args: {},
+                  // Parent create_sub_agent has no approval — only the nested tool does.
+                  messages: [nestedMessage],
+                },
+              ],
+            },
+          ]}
+        >
+          <ThreadPrimitive.Messages>{() => <AssistantMessageContainer />}</ThreadPrimitive.Messages>
+        </RuntimeHarness>
+      </SlotsProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow' }));
+    expect(respondToNestedApproval).toHaveBeenCalledWith(
+      expect.objectContaining({ approvalId: 'nested-approval-1', approved: true }),
+    );
   });
 
   it('auto-expands and shows the approval bar while an approval is pending', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: 0.2.21
         version: 0.2.21(@assistant-ui/tap@0.9.5(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react@19.2.8)
       '@truefoundry/assistant-ui-runtime':
-        specifier: 0.1.17
-        version: 0.1.17(@assistant-ui/tap@0.9.5(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(assistant-cloud@0.1.35(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.0)(zustand@5.0.14(@types/react@19.2.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
+        specifier: 0.1.18
+        version: 0.1.18(@assistant-ui/tap@0.9.5(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(assistant-cloud@0.1.35(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.0)(zustand@5.0.14(@types/react@19.2.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
       '@truefoundry/trueforge-sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -368,8 +368,8 @@ importers:
         specifier: ^0.13.2
         version: 0.13.3(@openuidev/react-headless@0.9.4(react@19.2.8)(zustand@5.0.14(@types/react@19.2.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))))(@openuidev/react-lang@0.2.9(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(react@19.2.8)(zod@4.4.3))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(zod@4.4.3)(zustand@5.0.14(@types/react@19.2.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
       '@truefoundry/assistant-ui-runtime':
-        specifier: 0.1.17
-        version: 0.1.17(@assistant-ui/tap@0.9.5(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(assistant-cloud@0.1.35(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.0)(zustand@5.0.14(@types/react@19.2.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
+        specifier: 0.1.18
+        version: 0.1.18(@assistant-ui/tap@0.9.5(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(assistant-cloud@0.1.35(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.0)(zustand@5.0.14(@types/react@19.2.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
       '@truefoundry/trueforge-sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -3478,8 +3478,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@truefoundry/assistant-ui-runtime@0.1.17':
-    resolution: {integrity: sha512-wk5GPcZ9gRdLX1o+nhSPBh/IWIJ0P0Q7vqp5Ziyme5bAh3940yyK0ZsNpasPpgFEcfqUnFYjoXyJBXJjzVyhig==}
+  '@truefoundry/assistant-ui-runtime@0.1.18':
+    resolution: {integrity: sha512-xiEp2UwJfjqtRh2HmDLhyy5oBx4UOgKvxkOi4sYziTmStWNRg8JDTFoADu3ZV3Qr4MwRb8abQc1eoXvjzVoRNA==}
     peerDependencies:
       '@types/react': '*'
       react: ^18 || ^19
@@ -10619,7 +10619,7 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@truefoundry/assistant-ui-runtime@0.1.17(@assistant-ui/tap@0.9.5(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(assistant-cloud@0.1.35(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.0)(zustand@5.0.14(@types/react@19.2.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))':
+  '@truefoundry/assistant-ui-runtime@0.1.18(@assistant-ui/tap@0.9.5(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(assistant-cloud@0.1.35(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.0)(zustand@5.0.14(@types/react@19.2.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))':
     dependencies:
       '@assistant-ui/core': 0.2.22(@assistant-ui/store@0.2.21(@assistant-ui/tap@0.9.5(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react@19.2.8))(@assistant-ui/tap@0.9.5(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(assistant-cloud@0.1.35(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(zustand@5.0.14(@types/react@19.2.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
       '@assistant-ui/store': 0.2.21(@assistant-ui/tap@0.9.5(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ allowBuilds:
 # Silence peer mismatches between trueforge-ui peers and the versions we pin.
 peerDependencyRules:
   allowedVersions:
-    '@truefoundry/assistant-ui-runtime': '0.1.16'
+    '@truefoundry/assistant-ui-runtime': '0.1.18'
 
 # One Context module for assistant-ui (avoids "requires an AuiProvider").
 overrides:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes human-in-the-loop approval routing for nested agents and connector/sandbox API mapping; incorrect approval ids would block or mis-handle tool execution, but the change is targeted and covered by a new test.
> 
> **Overview**
> Bumps **`@truefoundry/assistant-ui-runtime`** to **0.1.18** across the UI packages and documents the consolidated runtime changes in the changelog.
> 
> **Nested sub-agent Allow/Deny** no longer bridges approvals through the outer `create_sub_agent` part. The nested readonly thread sets a flag on context; **`ToolApprovalSlot`** then calls **`useTrueFoundryRespondToToolApproval`** with the **nested** tool’s approval id (including custom options and deny reasons). This fixes silent no-ops when only inner tools required approval.
> 
> **MCP connector writes** pass **`description`** from the settings UI into the Harness manifest on create/update (catalog description or URL fallback), instead of re-fetching catalog presets in the adapter.
> 
> **Sandbox provider adapter** aligns with the backend by dropping **`snapshotName`** from mapped config and exposing list entries with Harness snapshot sync **`status` / `statusReason`** via new mapping helpers and re-exports.
> 
> Adds a unit test that **Allow** inside a sub-agent targets **`nested-approval-1`**, not the parent tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e295b257f8eaf7cd1fcb8bfe231c099b8973d070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->