### PR TITLE
feat(ui): Agents Library row — connectors first, composer skill icon, hover names

### DIFF
--- a/.changeset/20260817145404-agents-library-row-icons.md
+++ b/.changeset/20260817145404-agents-library-row-icons.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Agents Library rows: show connectors before skills, use the composer's lightbulb icon for skills, and reveal the connector/skill names in a tooltip on hover.

--- a/packages/trueforge-ui/src/atoms/AgentsLibrary.tsx
+++ b/packages/trueforge-ui/src/atoms/AgentsLibrary.tsx
@@ -11,6 +11,7 @@ import { useSearchAgentsList } from './lib/useSearchAgentsList.js';
 import { CenteredModal } from './primitives/CenteredModal.js';
 import SearchInput from './primitives/SearchInput.js';
 import { Skeleton } from './primitives/Skeleton.js';
+import { Tooltip } from './primitives/Tooltip.js';
 
 export type AgentsLibraryProps = {
   open: boolean;
@@ -36,6 +37,10 @@ function AgentLibraryRow({ agent, showEdit, onTry, onEdit }: AgentLibraryRowProp
   const modelName = spec?.model.name;
   const skillsCount = spec?.skills?.length ?? 0;
   const mcpCount = spec?.mcpServers?.length ?? 0;
+  const skillNames = (spec?.skills ?? []).map(s => (s as { name?: string }).name).filter(Boolean);
+  const mcpNames = (spec?.mcpServers ?? []).map(m => (m as { name?: string }).name).filter(Boolean);
+  const connectorsTitle = mcpNames.length ? `Connectors: ${mcpNames.join(', ')}` : `${mcpCount} connectors`;
+  const skillsTitle = skillNames.length ? `Skills: ${skillNames.join(', ')}` : `${skillsCount} skills`;
 
   return (
     <div
@@ -60,14 +65,18 @@ function AgentLibraryRow({ agent, showEdit, onTry, onEdit }: AgentLibraryRowProp
               <span className="truncate">{displayModelLabel(modelName)}</span>
             </span>
           ) : null}
-          <span className="inline-flex items-center gap-1 text-xs" aria-label={`${skillsCount} skills`}>
-            <Icon name="wrench" className="size-3.5" />
-            {skillsCount}
-          </span>
-          <span className="inline-flex items-center gap-1 text-xs" aria-label={`${mcpCount} MCP servers`}>
-            <Icon name="plug" className="size-3.5" />
-            {mcpCount}
-          </span>
+          <Tooltip content={connectorsTitle}>
+            <span className="inline-flex items-center gap-1 text-xs" aria-label={connectorsTitle}>
+              <Icon name="plug" className="size-3.5" />
+              {mcpCount}
+            </span>
+          </Tooltip>
+          <Tooltip content={skillsTitle}>
+            <span className="inline-flex items-center gap-1 text-xs" aria-label={skillsTitle}>
+              <Icon name="lightbulb" className="size-3.5" />
+              {skillsCount}
+            </span>
+          </Tooltip>
         </span>
       ) : null}
       <span className="flex shrink-0 items-center gap-1.5">

--- a/packages/trueforge-ui/test/atoms/AgentsLibrary.test.tsx
+++ b/packages/trueforge-ui/test/atoms/AgentsLibrary.test.tsx
@@ -152,8 +152,8 @@ describe('AgentsLibrary', () => {
     await waitFor(() => {
       expect(screen.getByText('gpt-5-5')).toBeInTheDocument();
     });
-    expect(screen.getByLabelText('1 skills')).toBeInTheDocument();
-    expect(screen.getByLabelText('1 MCP servers')).toBeInTheDocument();
+    expect(screen.getByLabelText('Connectors: github')).toBeInTheDocument();
+    expect(screen.getByLabelText('Skills: paint')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Try agent bare' })).toBeInTheDocument();
     expect(screen.queryByLabelText('0 skills')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
Polish for the Agents Library rows so the icon set matches the composer and the counts aren't ambiguous.

## Changes (`packages/trueforge-ui/src/atoms/AgentsLibrary.tsx`)
- **Order:** show **Connectors** (plug) first, then **Skills** — matching the composer's Connectors→Skills order.
- **Skill icon:** use the composer's **`lightbulb`** icon instead of `wrench`. The wrench read as "tools," which was confusing next to the connector count.
- **Hover:** reveal the actual **connector/skill names** on hover (e.g. *"Connectors: exa, github"*, *"Skills: web-artifacts-builder"*) via the shared `Tooltip` primitive — the same component the composer uses. Replaces the plain `title` attribute so it's styled and consistent, and it renders above the Agents Library modal.

## Notes
- Verified live: the tooltip renders correctly above the `CenteredModal` (no z-index/portal issue).
- `@truefoundry/trueforge-ui` patch changeset included.
- No behavior change beyond the row's presentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UI in Agents Library rows; no auth, data, or selection behavior changes.
> 
> **Overview**
> **Agents Library** list rows now match the composer’s connector/skill presentation: **connectors (plug) appear before skills**, skills use the **`lightbulb`** icon instead of **`wrench`**, and both counts are wrapped in the shared **`Tooltip`** so hover shows named lists (e.g. `Connectors: github`, `Skills: paint`) with fallback count-only labels when names are missing. **`aria-label`** on those spans uses the same strings for accessibility.
> 
> Tests expect the updated labels instead of generic “1 skills” / “1 MCP servers”. A patch **changeset** documents the `@truefoundry/trueforge-ui` tweak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b28f7331ed6b6f7d7291d2784460321ff4fc07fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->