### PR TITLE
ci: allow fork pull requests without Generate SDK commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,5 +16,5 @@ Closes #
 
 - [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
 - [ ] Tests added/updated where it makes sense
-- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`)
+- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
 - [ ] Docs / `.env.example` updated if configuration or behavior changed

--- a/.github/workflows/generate-sdk.yaml
+++ b/.github/workflows/generate-sdk.yaml
@@ -1,7 +1,10 @@
 name: Generate SDK
 
 # Regenerates the OpenAPI document and the SDK, and commits both to the branch.
+# Fork PRs cannot receive that commit; main regenerates after merge.
 on:
+  # Manual regen on main if the post-merge push job missed or failed.
+  workflow_dispatch:
   push:
     branches: [main]
     # Only sources the document is built from; tests and metadata cannot change it.
@@ -24,6 +27,9 @@ concurrency:
   group: generate-sdk-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   generate:
     name: Generate OpenAPI and TypeScript SDK
@@ -36,20 +42,19 @@ jobs:
     if: >
       github.actor != 'github-actions[bot]' &&
       github.actor != 'trueforge-dev-bot[bot]'
-    permissions:
-      contents: write
 
     steps:
       - name: Create GitHub App token
         id: app-token
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.TRUEFORGE_GENERATE_SDK_APP_ID }}
           private-key: ${{ secrets.TRUEFORGE_GENERATE_SDK_APP_PRIVATE_KEY }}
 
-      # Branch tip, not the merge commit, so output can be pushed back; forks need the head repo named.
-      - name: Check out repository code
+      # Writable checkout: App token minted only for same-repo / push / dispatch.
+      - name: Check out branch
+        if: steps.app-token.outcome == 'success'
         uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -57,6 +62,15 @@ jobs:
           # Full history, so the gate below can diff against the base commit.
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token || github.token }}
+
+      # Fork PRs: App token is skipped; use base-repo pull refs (no fork credentials).
+      - name: Check out pull request head
+        if: github.event_name == 'pull_request' && steps.app-token.outcome != 'success'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -105,11 +119,12 @@ jobs:
           fi
 
       # Same entrypoint as local `pnpm sdk:generate` (re-runs openapi:write; idempotent).
+      # App-token success = we can push; forks skip Fern so a flake cannot block the PR.
       - name: Generate OpenAPI document and TypeScript SDK
-        if: steps.decide.outputs.needed == 'true'
+        if: steps.decide.outputs.needed == 'true' && steps.app-token.outcome == 'success'
         run: pnpm sdk:generate
 
-      # Forks get a read-only token, so only the commit is skipped. TODO: an approval flow that can push to the fork.
+      # App-token success = writable head; forks cannot receive this commit.
       - name: Commit generated output
         if: steps.decide.outputs.needed == 'true' && steps.app-token.outcome == 'success'
         # Passed as env, never interpolated into the script, so it cannot inject shell.
@@ -144,4 +159,12 @@ jobs:
       - name: Report skipped commit on fork
         if: steps.decide.outputs.needed == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: |
-          echo "::notice::Generation succeeded. The commit was skipped because pull requests from forks cannot push; a maintainer will regenerate after merge."
+          set -euo pipefail
+          {
+            echo "### Fork pull request"
+            echo
+            echo "OpenAPI/SDK commits are skipped on forks (GitHub Apps cannot push to the head repo)."
+            echo "Do not hand-edit \`packages/trueforge-sdk\` or the OpenAPI documents."
+            echo "After merge, **Generate SDK** on \`main\` regenerates both (or run it manually from Actions)."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::Fork PR: OpenAPI/SDK will be regenerated on main after merge. Do not hand-edit generated files."

--- a/.github/workflows/generate-sdk.yaml
+++ b/.github/workflows/generate-sdk.yaml
@@ -46,7 +46,10 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app-token
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: >
+          github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.TRUEFORGE_GENERATE_SDK_APP_ID }}
@@ -63,7 +66,8 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token || github.token }}
 
-      # Fork PRs: App token is skipped; use base-repo pull refs (no fork credentials).
+      # Forks skip the writable checkout above; without this the job has no code.
+      # Use base-repo pull refs (head.sha) — cloning the fork with GITHUB_TOKEN 403s.
       - name: Check out pull request head
         if: github.event_name == 'pull_request' && steps.app-token.outcome != 'success'
         uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ For security vulnerabilities, do **not** open a public issue — see [SECURITY.m
 
 - **Node.js 22.13+** (see [`.nvmrc`](.nvmrc); required by pnpm 11.16)
 - **pnpm** (version pinned via `packageManager` in [`package.json`](package.json); `corepack enable` handles it)
-- **Docker** — only needed for Postgres/Redis dev infra, the smoke test, and SDK generation
+- **Docker** — only needed for Postgres/Redis dev infra, the smoke test, and local SDK generation (maintainers). Fork contributors do not generate the SDK.
 
 ## Repository layout
 
@@ -202,7 +202,7 @@ Prettier and ESLint run as pre-commit hooks via husky + lint-staged.
 ## Pull requests
 
 1. Fork (or branch) and create a topic branch: `git checkout -b my-fix`.
-2. Make your change, with tests where it makes sense.
+2. Make your change, with tests where it makes sense. Do not commit generated OpenAPI/SDK output (forks: source only; `main` regenerates after merge).
 3. Make sure `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass — CI runs exactly these.
 4. Keep PRs focused and reasonably small; describe **what** changed and **why** in the description.
 5. Open the PR. A maintainer will review it; squash-merge is the norm.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ We compare TrueForge against Claude Managed Agents and deepagents on the same ta
 
 ## Contributing
 
-We love contributions - bug reports, features, and docs fixes. See [CONTRIBUTING.md](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md).
+We love contributions - bug reports, features, and docs fixes. See [CONTRIBUTING.md](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md). Fork PRs should change source only; maintainers regenerate the SDK after merge.
 
 To report a security vulnerability, follow [SECURITY.md](SECURITY.md) instead of opening a public issue.
 


### PR DESCRIPTION
## Summary

GitHub Apps cannot push to forks, so Generate SDK could not commit OpenAPI/SDK updates on fork PRs and checkout of the fork with the base token was unreliable. Unblock open-source contributions: fork PRs stay source-only; OpenAPI/SDK regenerate on `main` after merge (with a manual Actions fallback).

Related: AGE-1753

## Changes

- Split Generate SDK checkout: App-token writable checkout for same-repo / `main` / dispatch; fork PRs use base-repo pull refs
- Skip Fern generate and commit when there is no App token (forks), so CI does not fail trying to push
- Add `workflow_dispatch` for manual regen on `main` if the post-merge job misses or fails
- Document the fork flow in CONTRIBUTING, README, and the PR checklist; clearer Actions notice/summary when a fork skip happens

## How was this tested?

- Reviewed workflow condition paths for fork vs same-repo vs `push` / `workflow_dispatch`
- YAML parse check on `.github/workflows/generate-sdk.yaml`
- Docs wording review for contributor vs maintainer ownership

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and contributor-docs only; no runtime or API behavior changes. Fork PRs may briefly have stale generated artifacts until post-merge regen.
> 
> **Overview**
> **Generate SDK** no longer tries to push OpenAPI/SDK commits on **fork PRs** (GitHub Apps cannot write to fork heads). Fork runs still check out the PR head via base-repo refs, run the regen gate, and pass without Fern generate/commit when there is no App token.
> 
> Same-repo PRs, **`main` pushes**, and manual **`workflow_dispatch`** keep the writable App-token checkout, `pnpm sdk:generate`, and bot commit flow. Job-level **`contents: write`** was removed in favor of default read permissions.
> 
> **CONTRIBUTING**, **README**, and the PR checklist now tell fork contributors to change source only and expect regeneration on **`main`** after merge, with a richer Actions step summary when a fork skip occurs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd6c2a1c19f2d2147a79e5cc28e1fa59be8efad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->