### PR TITLE
feat: add max request body middleware

### DIFF
--- a/.changeset/20260817101700-max-request-body-bytes.md
+++ b/.changeset/20260817101700-max-request-body-bytes.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge': patch
+---
+
+Reject oversized HTTP request bodies with 413 via config-driven Hono bodyLimit (MAX_REQUEST_BODY_BYTES).

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -5815,6 +5815,16 @@
             },
             "description": "Requested action cannot be performed on the session because it is no longer usable."
           },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Request body exceeds the configured maximum size (MAX_REQUEST_BODY_BYTES)."
+          },
           "422": {
             "content": {
               "application/json": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5815,6 +5815,16 @@
             },
             "description": "Requested action cannot be performed on the session because it is no longer usable."
           },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Request body exceeds the configured maximum size (MAX_REQUEST_BODY_BYTES)."
+          },
           "422": {
             "content": {
               "application/json": {

--- a/packages/trueforge-sdk/src/api/resources/sessions/client/Client.ts
+++ b/packages/trueforge-sdk/src/api/resources/sessions/client/Client.ts
@@ -1082,6 +1082,17 @@ export class SessionsClient {
                         }),
                         _response.rawResponse,
                     );
+                case 413:
+                    throw new TrueForge.ContentTooLargeError(
+                        serializers.RequestErrorResponse.parseOrThrow(_response.error.body, {
+                            unrecognizedObjectKeys: "passthrough",
+                            allowUnrecognizedUnionMembers: true,
+                            allowUnrecognizedEnumValues: true,
+                            skipValidation: true,
+                            breadcrumbsPrefix: ["response"],
+                        }),
+                        _response.rawResponse,
+                    );
                 case 422:
                     throw new TrueForge.UnprocessableEntityError(
                         serializers.RequestErrorResponse.parseOrThrow(_response.error.body, {
@@ -1125,6 +1136,7 @@ export class SessionsClient {
      * @throws {@link TrueForge.ForbiddenError}
      * @throws {@link TrueForge.NotFoundError}
      * @throws {@link TrueForge.PreconditionFailedError}
+     * @throws {@link TrueForge.ContentTooLargeError}
      * @throws {@link TrueForge.UnprocessableEntityError}
      * @throws {@link errors.TrueForgeError}
      * @throws {@link errors.TrueForgeTimeoutError}
@@ -1230,6 +1242,17 @@ export class SessionsClient {
                     );
                 case 412:
                     throw new TrueForge.PreconditionFailedError(
+                        serializers.RequestErrorResponse.parseOrThrow(_response.error.body, {
+                            unrecognizedObjectKeys: "passthrough",
+                            allowUnrecognizedUnionMembers: true,
+                            allowUnrecognizedEnumValues: true,
+                            skipValidation: true,
+                            breadcrumbsPrefix: ["response"],
+                        }),
+                        _response.rawResponse,
+                    );
+                case 413:
+                    throw new TrueForge.ContentTooLargeError(
                         serializers.RequestErrorResponse.parseOrThrow(_response.error.body, {
                             unrecognizedObjectKeys: "passthrough",
                             allowUnrecognizedUnionMembers: true,

--- a/packages/trueforge-sdk/tests/wire/sessions.test.ts
+++ b/packages/trueforge-sdk/tests/wire/sessions.test.ts
@@ -873,6 +873,26 @@ describe("SessionsClient", () => {
             .post("/api/v1/sessions/session_id/turns")
             .jsonBody(rawRequestBody)
             .respondWith()
+            .statusCode(413)
+            .jsonBody(rawResponseBody)
+            .build();
+
+        await expect(async () => {
+            return await client.sessions.createTurnStream("session_id", {});
+        }).rejects.toThrow(TrueForgeTypes.ContentTooLargeError);
+    });
+
+    test("create_turn_stream (7)", async () => {
+        const server = mockServerPool.createServer();
+        const client = new TrueForge({ maxRetries: 0, token: "test", baseUrl: server.baseUrl });
+        const rawRequestBody = { stream: true };
+        const rawResponseBody = { error: { message: "message" } };
+
+        server
+            .mockEndpoint()
+            .post("/api/v1/sessions/session_id/turns")
+            .jsonBody(rawRequestBody)
+            .respondWith()
             .statusCode(422)
             .jsonBody(rawResponseBody)
             .build();
@@ -1009,6 +1029,26 @@ describe("SessionsClient", () => {
     });
 
     test("create_turn (6)", async () => {
+        const server = mockServerPool.createServer();
+        const client = new TrueForge({ maxRetries: 0, token: "test", baseUrl: server.baseUrl });
+        const rawRequestBody = { stream: false };
+        const rawResponseBody = { error: { message: "message" } };
+
+        server
+            .mockEndpoint()
+            .post("/api/v1/sessions/session_id/turns")
+            .jsonBody(rawRequestBody)
+            .respondWith()
+            .statusCode(413)
+            .jsonBody(rawResponseBody)
+            .build();
+
+        await expect(async () => {
+            return await client.sessions.createTurn("session_id", {});
+        }).rejects.toThrow(TrueForgeTypes.ContentTooLargeError);
+    });
+
+    test("create_turn (7)", async () => {
         const server = mockServerPool.createServer();
         const client = new TrueForge({ maxRetries: 0, token: "test", baseUrl: server.baseUrl });
         const rawRequestBody = { stream: false };

--- a/packages/trueforge/.env.example
+++ b/packages/trueforge/.env.example
@@ -107,6 +107,10 @@ REDIS_URL=redis://localhost:6379
 ## Max bytes for a single file download out of the sandbox. Default 20 MB (same as gateway).
 # SANDBOX_FILE_MAX_BYTES_FOR_DOWNLOAD=20971520
 
+## Max bytes for an HTTP request body. Default 30 MB.
+## Reverse proxies must allow at least this (e.g. nginx client_max_body_size).
+# MAX_REQUEST_BODY_BYTES=31457280
+
 ## ---------------------------------------------------------------------------
 ## Postgres (used when STANDALONE=false; also read by Compose postgres
 ## services via env_file). Config defaults match these values if unset.

--- a/packages/trueforge/src/app.ts
+++ b/packages/trueforge/src/app.ts
@@ -4,7 +4,8 @@ import { OpenAPIHono, z } from '@hono/zod-openapi';
 import type { ISessionStore, Sessions, TurnStreamingEvent } from '@truefoundry/trueforge-core/agent-session';
 import { extractErrorLogFields } from '@truefoundry/trueforge-core/core';
 import type { RequestReplyRouter } from '@truefoundry/trueforge-core/request-reply';
-import type { Context, ErrorHandler } from 'hono';
+import type { Context, ErrorHandler, MiddlewareHandler } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
 import { HTTPException } from 'hono/http-exception';
 import type { Configuration } from 'openid-client';
 import type { RedisClientType } from 'redis';
@@ -26,6 +27,7 @@ import type { McpCatalog } from './catalog/McpCatalog';
 import type { ModelCatalog } from './catalog/ModelCatalog';
 import type { SandboxCatalog } from './catalog/SandboxCatalog';
 import type { SkillCatalog } from './catalog/SkillCatalog';
+import configuration from './config';
 import type { IAgentStore } from './db/agentStore';
 import type { IMcpServerStore } from './db/mcpServerStore';
 import type { IModelProviderStore } from './db/modelProviderStore';
@@ -39,6 +41,15 @@ import type { EventSubscriptionRegistry } from './runtime/event-subscription';
 import { zodErrorResponse, zodValidationHook } from './zodErrorResponse';
 
 const BEARER_AUTH_SCHEME = 'BearerAuth';
+
+/** Hono bodyLimit wrapper that returns the API error envelope on 413. */
+export function createRequestBodyLimitMiddleware(maxSize: number): MiddlewareHandler {
+  return bodyLimit({
+    maxSize,
+    onError: c =>
+      c.json({ error: { message: `Request body exceeds the maximum size of ${String(maxSize)} bytes` } }, 413),
+  });
+}
 
 export function createAppErrorHandler(params: { logger: Logger }): ErrorHandler {
   return (error, c) => {
@@ -151,6 +162,8 @@ export interface ServerDeps<TTransaction> {
 export function createServerApp<TTransaction>(deps: ServerDeps<TTransaction>) {
   const app = new OpenAPIHono({ defaultHook: zodValidationHook });
   const authEnabled = deps.oidcClient != null;
+
+  app.use('*', createRequestBodyLimitMiddleware(configuration.MAX_REQUEST_BODY_BYTES));
 
   app.get('/healthz', c => c.text('OK!'));
 

--- a/packages/trueforge/src/config.ts
+++ b/packages/trueforge/src/config.ts
@@ -20,6 +20,8 @@ import envPaths from 'env-paths';
 const DEFAULT_PORT = 8790;
 /** Loopback default; container images set HOST=0.0.0.0 so probes and Service traffic reach the process. */
 const DEFAULT_HOST = 'localhost';
+/** Default HTTP request body ceiling: 30 MB. */
+const DEFAULT_MAX_REQUEST_BODY_BYTES = 30 * 1024 * 1024;
 /**
  * Package root whether this module runs as `src/config.ts` (tsx) or is bundled
  * into `dist/main.js` / `dist/cli.js` (`import.meta` → `dist/` → parent).
@@ -328,6 +330,10 @@ export interface SharedServerConfiguration {
    */
   SANDBOX_FILE_MAX_BYTES_FOR_DOWNLOAD: number;
   /**
+   * Max bytes for an HTTP request body. Env: `MAX_REQUEST_BODY_BYTES`. Default 30 MB.
+   */
+  MAX_REQUEST_BODY_BYTES: number;
+  /**
    * Max seconds to wait for turn cancellation + connection drain on SIGTERM/SIGINT.
    * Env: `GRACEFUL_TIMEOUT_SECONDS`. Default 30.
    */
@@ -478,6 +484,11 @@ const shared: SharedServerConfiguration = {
     envKey: 'SANDBOX_FILE_MAX_BYTES_FOR_DOWNLOAD',
     raw: getEnv('SANDBOX_FILE_MAX_BYTES_FOR_DOWNLOAD'),
     defaultValue: 20_971_520,
+  }),
+  MAX_REQUEST_BODY_BYTES: parsePositiveInt({
+    envKey: 'MAX_REQUEST_BODY_BYTES',
+    raw: getEnv('MAX_REQUEST_BODY_BYTES'),
+    defaultValue: DEFAULT_MAX_REQUEST_BODY_BYTES,
   }),
   GRACEFUL_TIMEOUT_SECONDS: parsePositiveInt({
     envKey: 'GRACEFUL_TIMEOUT_SECONDS',

--- a/packages/trueforge/src/routes/turnRoutes.ts
+++ b/packages/trueforge/src/routes/turnRoutes.ts
@@ -224,6 +224,10 @@ Use \`previous_turn_id\` to chain to the session's last turn (defaults to \`auto
       content: { 'application/json': { schema: RequestErrorResponseSchema } },
       description: 'Requested action cannot be performed on the session because it is no longer usable.',
     },
+    413: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'Request body exceeds the configured maximum size (MAX_REQUEST_BODY_BYTES).',
+    },
     422: {
       content: { 'application/json': { schema: RequestErrorResponseSchema } },
       description:

--- a/packages/trueforge/tests/unit/requestBodyLimit.test.ts
+++ b/packages/trueforge/tests/unit/requestBodyLimit.test.ts
@@ -1,0 +1,63 @@
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { createRequestBodyLimitMiddleware } from '../../src/app';
+
+const MAX_SIZE = 16;
+
+function createApp() {
+  const app = new OpenAPIHono();
+  let handlerCalled = false;
+  app.use('*', createRequestBodyLimitMiddleware(MAX_SIZE));
+  app.get('/test', c => c.json({ ok: true }));
+  app.post('/test', async c => {
+    handlerCalled = true;
+    await c.req.json();
+    return c.json({ ok: true });
+  });
+  return {
+    app,
+    wasHandlerCalled: () => handlerCalled,
+  };
+}
+
+describe('createRequestBodyLimitMiddleware', () => {
+  it('returns 413 when Content-Length exceeds the max and does not call the handler', async () => {
+    const { app, wasHandlerCalled } = createApp();
+    const body = 'x'.repeat(MAX_SIZE + 1);
+
+    const response = await app.request('/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': String(body.length) },
+      body,
+    });
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({
+      error: { message: `Request body exceeds the maximum size of ${String(MAX_SIZE)} bytes` },
+    });
+    expect(wasHandlerCalled()).toBe(false);
+  });
+
+  it('allows a body at or under the max', async () => {
+    const { app, wasHandlerCalled } = createApp();
+    const body = JSON.stringify({ a: 1 }); // 7 bytes
+
+    const response = await app.request('/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': String(body.length) },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(wasHandlerCalled()).toBe(true);
+  });
+
+  it('passes GET requests with no body', async () => {
+    const { app } = createApp();
+
+    const response = await app.request('/test');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Global middleware affects every route with a body; misconfiguration or a limit below proxy limits could break large turn payloads or file uploads, though defaults and docs aim to align with deployment.
> 
> **Overview**
> Adds a **global request body size cap** (default **30 MB**, env **`MAX_REQUEST_BODY_BYTES`**) so oversized POST/PUT bodies are rejected early with **413** and the standard `{ error: { message } }` envelope instead of hitting route handlers.
> 
> **`createRequestBodyLimitMiddleware`** wraps Hono’s `bodyLimit` and is registered on **`app.use('*', …)`** for the whole server. OpenAPI documents **413** on session turn creation; the SDK maps it to **`ContentTooLargeError`** with wire tests for streaming and non-streaming create-turn.
> 
> **`.env.example`** documents the knob and notes reverse proxies should allow at least the same limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8adafba49cf7aa95192a0b10b0fd348df0939f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->