### PR TITLE
Enable npm provenance on publish and add CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Last matching pattern wins. Enable "Require review from Code Owners" on the
+# default branch for these rules to gate merges.
+#
+# UI packages have their own owners; everyone else falls through to `*`.
+
+* @debajyoti-truefoundry @chiragjn @heerambavi1998 @sr07asthana @bhaveshpatel640 @thesujai
+
+/packages/trueforge-ui/ @govindavashishtha @sayan-truefoundry @qaifi-tf @vinit-truefoundry
+/packages/frontend/ @govindavashishtha @sayan-truefoundry @qaifi-tf @vinit-truefoundry

--- a/.github/fern/generators.yml
+++ b/.github/fern/generators.yml
@@ -55,7 +55,7 @@ groups:
               url: https://github.com/truefoundry/trueforge/issues
             publishConfig:
               access: public
-              provenance: false
+              provenance: true
             engines:
               node: '>=22'
           allowExtraFields: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,9 +169,12 @@ jobs:
         with:
           pack-dir-artifact-id: ${{ needs.pack.outputs.pack-dir-artifact-id }}
           create-github-releases: true
-        # TODO(oss): set NPM_CONFIG_PROVENANCE once the repo is public. Do NOT
-        # set it now: provenance publicly attests the source repo and commit.
-        # publishConfig.provenance is false on every public package.
+        env:
+          # Attest source repo + commit on every publish. Trusted publishing
+          # already uses OIDC (`id-token: write`); this flag is what changesets
+          # / pnpm honor (they do not accept `--provenance`).
+          # publishConfig.provenance is true on every public package.
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Detect @truefoundry/trueforge publish
         id: trueforge

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -83,6 +83,10 @@ Each public package must list this repo + workflow as a trusted publisher on npm
 Do not set `NPM_TOKEN` / `_authToken` on the publish job — that disables OIDC.
 Only the **publish** job has `id-token: write`.
 
+Publish attaches npm provenance (`NPM_CONFIG_PROVENANCE` on the publish job, and
+`publishConfig.provenance: true` on every public package). That publicly attests
+the source repo and commit on npmjs.com.
+
 ## Local without publishing
 
 ```bash

--- a/packages/trueforge-core/package.json
+++ b/packages/trueforge-core/package.json
@@ -15,7 +15,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": false
+    "provenance": true
   },
   "private": false,
   "type": "module",

--- a/packages/trueforge-sdk/package.json
+++ b/packages/trueforge-sdk/package.json
@@ -273,6 +273,6 @@
     },
     "publishConfig": {
         "access": "public",
-        "provenance": false
+        "provenance": true
     }
 }

--- a/packages/trueforge-ui/package.json
+++ b/packages/trueforge-ui/package.json
@@ -22,7 +22,7 @@
   ],
   "publishConfig": {
     "access": "public",
-    "provenance": false
+    "provenance": true
   },
   "type": "module",
   "exports": {

--- a/packages/trueforge/package.json
+++ b/packages/trueforge/package.json
@@ -15,7 +15,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": false
+    "provenance": true
   },
   "private": false,
   "type": "module",


### PR DESCRIPTION
The repo is public, so publish can attest source repo and commit. Path owners split UI packages from the rest of the tree.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Provenance changes affect the release publish path; a misconfiguration could break npm publishes until fixed. CODEOWNERS only affects review policy, not runtime behavior.
> 
> **Overview**
> Turns on **npm provenance** for public package publishes now that the repo is public, so npmjs.com can attest source repo and commit alongside existing OIDC trusted publishing.
> 
> `publishConfig.provenance` flips from `false` to `true` on `@truefoundry/trueforge-core`, `@truefoundry/trueforge`, `@truefoundry/trueforge-sdk`, and `@truefoundry/trueforge-ui`, plus the Fern SDK generator config. The **Release** publish job sets `NPM_CONFIG_PROVENANCE: "true"` (replacing a TODO that deferred provenance until the repo was public). **RELEASING.md** documents the provenance behavior.
> 
> Adds **`.github/CODEOWNERS`**: default reviewers for `*`, with separate owners for `/packages/trueforge-ui/` and `/packages/frontend/`. Comments note enabling “Require review from Code Owners” on the default branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5eb8d8f8d8e55e9f5476fc80e4881d18ac44782. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->