### PR TITLE
docs: review-pass fixes — dead links, correctness, and consistency

### DIFF
--- a/docs/agent-library.mdx
+++ b/docs/agent-library.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'Agent Library'
-sidebarTitle: 'Agent Library'
+title: 'Agents Library'
+sidebarTitle: 'Agents Library'
 description: 'Browse, edit, and try saved agents from one place.'
 ---
 
-The **Agent Library** is where saved agents live. Open it from the chat UI to search agents, edit their configuration, or start a conversation with **Try**.
+The **Agents Library** is where saved agents live. Open it from the chat UI to search agents, edit their configuration, or start a conversation with **Try**.
 
 <Frame caption="Agents Library — search, edit, and try saved agents.">
   <img src="/images/agents-library.png" alt="Agents Library modal listing saved agents with Edit and Try actions" />

--- a/docs/api/overview.mdx
+++ b/docs/api/overview.mdx
@@ -4,7 +4,7 @@ sidebarTitle: 'Overview'
 description: 'Understand Agent, Session, Turn, Event, and Delta, then drive TrueForge with the TypeScript SDK.'
 ---
 
-Everything the chat UI does, you can do in code. The TypeScript client [`@truefoundry/trueforge-sdk`](https://www.npmjs.com/package/trueforge-sdk) creates sessions, streams turns, and handles approvals. This page explains the model; [Use an agent](/api/use-agent) is the runnable cookbook, and the **API Reference** tab has the raw HTTP schemas.
+Everything the chat UI does, you can do in code. The TypeScript client [`@truefoundry/trueforge-sdk`](https://www.npmjs.com/package/@truefoundry/trueforge-sdk) creates sessions, streams turns, and handles approvals. This page explains the model; [Use an agent](/api/use-agent) is the runnable cookbook, and the **API Reference** tab has the raw HTTP schemas.
 
 ## Core concepts
 

--- a/docs/api/turn-events.mdx
+++ b/docs/api/turn-events.mdx
@@ -6,6 +6,10 @@ description: 'Every event type streamed while a turn runs — lifecycle, model o
 
 While a turn runs, the SDK streams events to your app. Each event is a JSON object; the stream also carries a **sequence number** you can use to [reconnect](/api/use-agent) after a disconnect without missing or double-processing events.
 
+<Note>
+  Field names on this page use the HTTP/JSON wire format (snake_case, e.g. `turn_id`, `source_event_id`). The TypeScript SDK returns the same fields camelCased (`turnId`, `sourceEventId`) — so a field you see here maps directly to its camelCase form in SDK code.
+</Note>
+
 Every event carries:
 
 | Field        | Description                                                                                                                                                                                                        |

--- a/docs/api/use-agent.mdx
+++ b/docs/api/use-agent.mdx
@@ -4,7 +4,7 @@ sidebarTitle: 'Use an agent'
 description: 'Run a saved agent with the TypeScript SDK: a complete example, then recipes for streaming, approvals, questions, threads, and reconnects.'
 ---
 
-The recipe book for running an agent with [`@truefoundry/trueforge-sdk`](https://www.npmjs.com/package/trueforge-sdk). For the mental model (Agent → Session → Turn → Event → Delta), start with [SDK Overview](/api/overview); for every event field, see [Turn events](/api/turn-events).
+The recipe book for running an agent with [`@truefoundry/trueforge-sdk`](https://www.npmjs.com/package/@truefoundry/trueforge-sdk). For the mental model (Agent → Session → Turn → Event → Delta), start with [SDK Overview](/api/overview); for every event field, see [Turn events](/api/turn-events).
 
 <Note>
 Prerequisite: a named agent in the registry, or an inline [agent spec](/create-agent/overview#create-an-agent-via-the-api) you pass when creating the session. The examples below run the **`web-research-brief`** agent from the [Quickstart](/quickstart); build it there first, or swap in your own agent name / inline spec.
@@ -15,7 +15,7 @@ Every snippet is self-contained and runnable. They all use the `client` from [In
 ## Install and connect
 
 ```bash
-npm i -s @truefoundry/trueforge-sdk
+npm i @truefoundry/trueforge-sdk
 ```
 
 ```typescript

--- a/docs/create-agent/overview.mdx
+++ b/docs/create-agent/overview.mdx
@@ -44,7 +44,7 @@ Each option below is part of the agent definition. The **Set in** line on each s
   <Accordion title="Tool approval (API only)" icon="user-shield">
     Some tool calls shouldn't run without a human's sign-off. **Tool approval** pauses the agent before such a call, shows the tool name and arguments, and resumes only after the user chooses **Allow** or **Deny** in the chat UI.
 
-    By default, the harness decides what to gate from the tool's own **MCP annotation**: if the server marks a tool as destructive, the agent pauses for approval before running it. Read-only tools run autonomously.
+    By default, the harness decides what to gate from the tool's own **MCP annotation**: if the server marks a tool as **write or destructive** (the default `["@write", "@destructive"]`), the agent pauses for approval before running it. Read-only tools run autonomously.
 
     <Frame caption="The chat UI pauses on a sensitive tool call with Allow / Deny.">
       <img src="/images/hitl.png" alt="Chat UI pausing on a tool call, showing the request payload with Allow and Deny buttons" />
@@ -90,7 +90,7 @@ Each option below is part of the agent definition. The **Set in** line on each s
     **Set in:** UI + API
   </Accordion>
 
-  <Accordion title="Ask user questions" icon="circle-question">
+  <Accordion title="Ask clarifying questions" icon="circle-question">
     Lets the agent pause at a decision it shouldn't guess — which environment to deploy to, which of several matches the user meant, an ambiguous required field — show a multiple-choice prompt, and resume with the chosen answer. On by default.
 
     <Frame caption="The chat UI renders the question and options as a selectable card.">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -76,7 +76,6 @@
               {
                 "group": "Frontend Customisation",
                 "pages": [
-                  "ui-sdk/guides/layouts",
                   "ui-sdk/guides/layouts-and-theme",
                   "ui-sdk/guides/agent-modes",
                   "ui-sdk/setup-custom-ui/custom-theme",

--- a/docs/harness/initial-setup.mdx
+++ b/docs/harness/initial-setup.mdx
@@ -8,10 +8,10 @@ Before you build agents, configure the shared resources TrueForge orchestrates. 
 
 | Resource | Settings page | Purpose | Shipped catalog |
 | --- | --- | --- | --- |
-| [Models](/models) | **Settings → Models** | Provider credentials and available model IDs | [`model-catalog.yaml`](https://github.com/truefoundry/trueforge/blob/main/packages/trueforge/src/catalog/model-catalog.yaml) |
-| [MCP servers](/mcp-servers) | **Settings → Connectors** | Tools and data from external systems | [`mcp-catalog.yaml`](https://github.com/truefoundry/trueforge/blob/main/packages/trueforge/src/catalog/mcp-catalog.yaml) |
-| [Skills](/skills) | **Settings → Skills** | Git-backed procedures the agent can load on demand | [`skill-catalog.yaml`](https://github.com/truefoundry/trueforge/blob/main/packages/trueforge/src/catalog/skill-catalog.yaml) |
-| [Sandbox](/sandbox) | **Settings → Sandbox providers** | Isolated compute for code, files, and skill execution | [`sandbox-catalog.yaml`](https://github.com/truefoundry/trueforge/blob/main/packages/trueforge/src/catalog/sandbox-catalog.yaml) |
+| [Models](/models) | **Settings → Models** | Provider credentials and available model IDs | [`model-catalog.yaml`](https://github.com/truefoundry/trueforge/blob/main/packages/trueforge/catalog/model-catalog.yaml) |
+| [MCP servers](/mcp-servers) | **Settings → Connectors** | Tools and data from external systems | [`mcp-catalog.yaml`](https://github.com/truefoundry/trueforge/blob/main/packages/trueforge/catalog/mcp-catalog.yaml) |
+| [Skills](/skills) | **Settings → Skills** | Git-backed procedures the agent can load on demand | [`skill-catalog.yaml`](https://github.com/truefoundry/trueforge/blob/main/packages/trueforge/catalog/skill-catalog.yaml) |
+| [Sandbox](/sandbox) | **Settings → Sandbox providers** | Isolated compute for code, files, and skill execution | [`sandbox-catalog.yaml`](https://github.com/truefoundry/trueforge/blob/main/packages/trueforge/catalog/sandbox-catalog.yaml) |
 
 ## What is supported out of the box
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -116,7 +116,7 @@ The agent features are identical in both modes — only the backend around the s
     Configure models, MCP servers, skills, and sandbox — and customize the shipped catalogs.
   </Card>
   <Card title="Create an Agent" icon="robot" href="/create-agent/overview">
-    Select a model, attach connectors and skills, then save to the Agent Library.
+    Select a model, attach connectors and skills, then save to the Agents Library.
   </Card>
   <Card title="Harness Capabilities" icon="layer-group" href="/key-features/overview">
     Sandbox-as-tool, subagents, deferred tools, code mode, compaction, and human checkpoints.

--- a/docs/key-features/overview.mdx
+++ b/docs/key-features/overview.mdx
@@ -11,7 +11,7 @@ TrueForge is more than model + tools. These harness features keep long agent run
 | [Sandbox as a tool](/sandbox) | Isolated code/file execution without putting secrets or the agent loop inside the sandbox |
 | [Context engineering](#what-is-context-engineering) | Progressive skills, deferred tools, subagents, offloading, Code Mode, compaction |
 | [Tool approval](/create-agent/overview#whats-in-an-agent) | Pause before write/destructive MCP tools |
-| [Ask User Questions](/create-agent/overview#whats-in-an-agent) | Structured clarification mid-run |
+| [Ask clarifying questions](/create-agent/overview#whats-in-an-agent) | Structured clarification mid-run |
 | [Generative UI](/create-agent/overview#whats-in-an-agent) | Charts, tables, and cards streamed into chat |
 | [In-chat MCP OAuth](/mcp-servers#in-chat-authentication) | Connect button when a connector needs authorization |
 
@@ -97,7 +97,7 @@ Runtime context is where most of the **context bloat problem** happens. A single
     Delegate focused subtasks to parallel subagents, each with its own clean context. Only the final result flows back —
     the intermediate tool calls never touch the main context.
   </Card>
-  <Card title="Large Result Offloading" icon="file-export" href="/key-features/large-tool-responses">
+  <Card title="Large Tool Responses" icon="file-export" href="/key-features/large-tool-responses">
     When a tool returns more data than fits comfortably in context, the harness writes the full output to a sandbox file
     and replaces it with a short preview and the file path.
   </Card>
@@ -134,7 +134,7 @@ flowchart LR
     Preview --> Continue[Agent reads parts on demand via sandbox]
 ```
 
-The agent can then use sandbox tools to inspect the file, infer its schema, extract specific fields, or filter the data — all without the raw payload ever entering the conversation. See [Large Result Offloading](/key-features/large-tool-responses).
+The agent can then use sandbox tools to inspect the file, infer its schema, extract specific fields, or filter the data — all without the raw payload ever entering the conversation. See [Large Tool Responses](/key-features/large-tool-responses).
 
 ### Code Mode — process tool output in code
 

--- a/docs/key-features/subagents.mdx
+++ b/docs/key-features/subagents.mdx
@@ -63,11 +63,10 @@ flowchart LR
 ```
 
 <Note>
-  - **Shared tools and sandbox** — subagents have access to the same MCP tools and sandbox environment as the root
-  agent. - **No user interaction** — subagents cannot ask the user questions. Only the root agent talks to the user.
-  Subagent tool calls that require [approval](/create-agent/overview#whats-in-an-agent) still pause for the user, though. - **No nesting** —
-  subagents cannot create other subagents. Delegation is one level deep. - **Parallel execution** — multiple subagents
-  run concurrently. The root agent waits for all of them before continuing.
+  - **Shared tools and sandbox** — subagents have access to the same MCP tools and sandbox environment as the root agent.
+  - **No user interaction** — subagents cannot ask the user questions. Only the root agent talks to the user. Subagent tool calls that require [approval](/create-agent/overview#whats-in-an-agent) still pause for the user, though.
+  - **No nesting** — subagents cannot create other subagents. Delegation is one level deep.
+  - **Parallel execution** — multiple subagents run concurrently. The root agent waits for all of them before continuing.
 </Note>
 
 ## Example

--- a/docs/ui-sdk/concepts/architecture.mdx
+++ b/docs/ui-sdk/concepts/architecture.mdx
@@ -25,7 +25,7 @@ Two kinds of component are exported, and the distinction determines which one yo
 
 **Atoms** are presentational. `AssistantMessageBubble`, `ComposerShell`, and `ToolCallCard` take everything they render as props and hold no runtime state. You rarely render an atom directly — instead you replace one, and the container that renders it picks up your version.
 
-That replacement is what `overrides` does: name a component, supply your own, and it is used everywhere that component appears. See [Slot overrides](/ui-sdk/guides/slot-overrides).
+That replacement is what `overrides` does: name a component, supply your own, and it is used everywhere that component appears. See [Slot overrides](/ui-sdk/setup-custom-ui/slot-overrides).
 
 ## Provider stack
 
@@ -53,4 +53,4 @@ Order matters: `SlotsProvider` must be outside `TrueFoundryChatProvider`.
 
 These class names and attributes are stable and safe to target from your own CSS: `.aui-root`, `.aui-theme-root`, `.aui-markdown`, `.aui-syntax-highlighter`, `.aui-openui`, `.aui-monaco`, plus `data-slot` attributes on individual components. Most slot values are prefixed `aui_`, but not all — `avatar`, `tool-call-card`, and `tool-group-card` are among the unprefixed ones, so inspect the element rather than assuming the prefix.
 
-For token-level changes, prefer [theming](/ui-sdk/guides/theming) over CSS overrides.
+For token-level changes, prefer [theming](/ui-sdk/setup-custom-ui/custom-theme) over CSS overrides.

--- a/docs/ui-sdk/get-started/quickstart.mdx
+++ b/docs/ui-sdk/get-started/quickstart.mdx
@@ -25,7 +25,7 @@ yarn add @truefoundry/trueforge-ui @truefoundry/trueforge-sdk
 
 ## Render the UI
 
-Point `TrueForgeUI` at your TrueForge server with a Bearer token:
+Point `TrueForgeUI` at your TrueForge server:
 
 ```tsx App.tsx
 import { TrueForgeUI } from "@truefoundry/trueforge-ui";
@@ -35,7 +35,9 @@ export default function App() {
     <div style={{ height: "100dvh" }}>
       <TrueForgeUI
         server={{
-          type: "trueforge"
+          type: "trueforge",
+          baseUrl: "http://localhost:8790",
+          // token: "<bearer token>", // only if the server has OIDC login enabled
         }}
         layout="sidebar"
       />
@@ -44,7 +46,7 @@ export default function App() {
 }
 ```
 
-That is enough to get a full agent chat with streaming, history, and tool calls.
+`baseUrl` is your harness API root (defaults to `/` for same-origin). Add `token` — a Bearer token for the SDK — only when the server has OIDC login enabled. That is enough to get a full agent chat with streaming, history, and tool calls.
 
 <Frame caption="What `TrueForgeUI` renders — a full agent chat with streaming, history, and tool calls.">
   ![The TrueForgeUI component rendering an agent chat with an agent-steps panel and a streamed response](/images/agent-composer-with-library.png)

--- a/docs/ui-sdk/guides/troubleshooting.mdx
+++ b/docs/ui-sdk/guides/troubleshooting.mdx
@@ -79,7 +79,7 @@ description: "Common failure modes and their causes."
   </Accordion>
 
   <Accordion title="Only the OAuth screen renders — no chat">
-    A `screenType=mcp-auth` query parameter is present on the URL. `TrueForgeUI` renders the OAuth completion screen exclusively in that case. Keep the callback on its own route; see [MCP OAuth](/ui-sdk/guides/mcp-oauth).
+    A `screenType=mcp-auth` query parameter is present on the URL. `TrueForgeUI` renders the OAuth completion screen exclusively in that case. Keep the callback on its own route; see [MCP OAuth](/ui-sdk/setup-custom-ui/mcp-oauth).
   </Accordion>
 
   <Accordion title="Dark mode fights with the host application">
@@ -87,7 +87,7 @@ description: "Common failure modes and their causes."
   </Accordion>
 
   <Accordion title="Import of Button or AskUserPrompt fails">
-    A few names are published as types only, so importing them as values fails. `Button` and `IconButton` are restyled through [theme tokens](/ui-sdk/guides/theming) rather than replaced. `AskUserPrompt`, `McpAuthPrompt`, and `ReasoningCard` are override-only — supply your own component typed with the published props.
+    A few names are published as types only, so importing them as values fails. `Button` and `IconButton` are restyled through [theme tokens](/ui-sdk/setup-custom-ui/custom-theme) rather than replaced. `AskUserPrompt`, `McpAuthPrompt`, and `ReasoningCard` are override-only — supply your own component typed with the published props.
   </Accordion>
 
   <Accordion title="SSR or React Server Components errors">

--- a/docs/ui-sdk/reference/atoms.mdx
+++ b/docs/ui-sdk/reference/atoms.mdx
@@ -5,7 +5,7 @@ description: "Presentational components and their prop types."
 
 Atoms are pure presentational components. Most publish a matching `*Props` type, and most are
 overridable slots — but neither is universal, so check
-[Slot overrides](/ui-sdk/guides/slot-overrides) for which names `overrides` accepts, and rely on your
+[Slot overrides](/ui-sdk/setup-custom-ui/slot-overrides) for which names `overrides` accepts, and rely on your
 editor for which props types exist.
 
 ## Messages and content
@@ -79,7 +79,7 @@ type ToolCallCardProps = {
 <Warning>
   `icon` is an icon **name** looked up in the icon registry, not a rendered node — it defaults
   to `"mcp-server"`. Passing an element renders nothing useful. To supply your own artwork, map
-  the name through `theme.icons`; see [Theming](/ui-sdk/guides/theming).
+  the name through `theme.icons`; see [Theming](/ui-sdk/setup-custom-ui/custom-theme).
 </Warning>
 
 Also `ToolCallContentBlock`, `ToolApprovalBar`, `ToolGroupCard`, `SubAgentCard`,
@@ -115,5 +115,5 @@ theme and settings buttons.
 <Note>
   `ButtonProps`, `ButtonVariant`, `ButtonSize`, and `IconButtonProps` are available as types
   for typing your own components. The buttons themselves are styled through semantic tokens
-  rather than replaced — see [Theming](/ui-sdk/guides/theming).
+  rather than replaced — see [Theming](/ui-sdk/setup-custom-ui/custom-theme).
 </Note>

--- a/docs/ui-sdk/reference/catalog.mdx
+++ b/docs/ui-sdk/reference/catalog.mdx
@@ -3,7 +3,7 @@ title: "Settings catalog"
 description: "The optional catalog port behind the model, connector, skill, and sandbox settings."
 ---
 
-`catalog` is the optional fourth part of an [`AgentUIServer`](/ui-sdk/concepts/server-contract). Attach
+`catalog` is the optional fourth part of an [`AgentUIServer`](/ui-sdk/setup-custom-servers/server-contract). Attach
 it and the settings UI appears; omit it and those surfaces stay hidden.
 
 ```ts
@@ -245,7 +245,7 @@ must render either way.
 ## Widening
 
 Every catalog interface is generic over its row and request types, following the same pattern as
-[the chat and builder ports](/ui-sdk/concepts/server-contract#widening-the-types):
+[the chat and builder ports](/ui-sdk/setup-custom-servers/server-contract#widening-the-types):
 
 ```ts
 interface MyModelEntry extends ModelEntry {

--- a/docs/ui-sdk/reference/events.mdx
+++ b/docs/ui-sdk/reference/events.mdx
@@ -23,7 +23,7 @@ interface TurnStreamData {
 </Note>
 
 `sequenceNumber` must increase monotonically within a turn. It is what
-[`subscribeToTurn`](/ui-sdk/concepts/server-contract#agentchatserver) uses to resume — a reconnecting
+[`subscribeToTurn`](/ui-sdk/setup-custom-servers/server-contract#agentchatserver) uses to resume — a reconnecting
 client passes the last number it saw as `afterSequenceNumber`, and you replay only what follows.
 
 ```ts
@@ -222,7 +222,7 @@ interface McpAuthRequiredEvent {
 }
 ```
 
-`authUrl` is the URL the popup opens. See [MCP OAuth](/ui-sdk/guides/mcp-oauth).
+`authUrl` is the URL the popup opens. See [MCP OAuth](/ui-sdk/setup-custom-ui/mcp-oauth).
 
 <Note>
   These events also appear in `requiredActions` on a `done` turn state. That is how a turn that
@@ -231,7 +231,7 @@ interface McpAuthRequiredEvent {
 </Note>
 
 The user's reply comes back through `createTurn` as a `user.tool_approval` or
-`user.tool_response` [input item](/ui-sdk/concepts/server-contract#turn-input), carrying the same
+`user.tool_response` [input item](/ui-sdk/setup-custom-servers/server-contract#turn-input), carrying the same
 `toolCallId`.
 
 ## Sub-agents
@@ -277,7 +277,7 @@ interface SandboxCreatedEvent {
 ```
 
 `sandboxId` is what you pass to
-[`downloadSandboxFile`](/ui-sdk/concepts/server-contract#agentchatserver) to retrieve artifacts the
+[`downloadSandboxFile`](/ui-sdk/setup-custom-servers/server-contract#agentchatserver) to retrieve artifacts the
 agent produced.
 
 `mcp.initialize` (`{ type, id, createdAt, threadId }`, plus any additional fields you attach)

--- a/docs/ui-sdk/reference/hooks.mdx
+++ b/docs/ui-sdk/reference/hooks.mdx
@@ -24,7 +24,7 @@ const capabilities = useServerCapabilities();
 Returns the resolved value from your server's `getCapabilities()`, or `null` while it is still
 loading or if the call failed. Use it to gate your own chrome the same way the SDK gates its
 sandbox, skill, and settings affordances. See
-[Server contract](/ui-sdk/concepts/server-contract#capabilities).
+[Server contract](/ui-sdk/setup-custom-servers/server-contract#capabilities).
 
 ## MCP auth
 
@@ -34,7 +34,7 @@ const auth = useMCPAuth({ callbackPath: "/mcp-callback" });
 
 `MCP_AUTH_POPUP_CHANNEL` is `"truefoundry-mcp-auth-popup"` — the `BroadcastChannel` name used
 to signal completion back to the opener. Types: `McpAuthCallback`, `McpAuthPopupMessage`,
-`UseMCPAuthOptions`. See [MCP OAuth](/ui-sdk/guides/mcp-oauth).
+`UseMCPAuthOptions`. See [MCP OAuth](/ui-sdk/setup-custom-ui/mcp-oauth).
 
 ## assistant-ui state
 

--- a/docs/ui-sdk/reference/server.mdx
+++ b/docs/ui-sdk/reference/server.mdx
@@ -83,5 +83,5 @@ to reference:
   </Accordion>
 </AccordionGroup>
 
-Full method signatures are on [Server contract](/ui-sdk/concepts/server-contract); a worked
-implementation is on [Bring your own server](/ui-sdk/guides/custom-server).
+Full method signatures are on [Server contract](/ui-sdk/setup-custom-servers/server-contract); a worked
+implementation is on [Bring your own server](/ui-sdk/setup-custom-servers/custom-server).

--- a/docs/ui-sdk/reference/theme.mdx
+++ b/docs/ui-sdk/reference/theme.mdx
@@ -47,7 +47,7 @@ type SlotOverrides = Partial<AtomSlots>;
 
 `AtomSlots` is derived from the SDK's default slot table, so it enumerates exactly the
 overridable slots — your editor's autocomplete on `overrides` is authoritative. See
-[Slot overrides](/ui-sdk/guides/slot-overrides).
+[Slot overrides](/ui-sdk/setup-custom-ui/slot-overrides).
 
 Most token names map to a CSS variable of the same name; the exceptions are listed in
-[Theming](/ui-sdk/guides/theming).
+[Theming](/ui-sdk/setup-custom-ui/custom-theme).

--- a/docs/ui-sdk/reference/trueforge-ui.mdx
+++ b/docs/ui-sdk/reference/trueforge-ui.mdx
@@ -168,7 +168,7 @@ import { TrueForgeUI } from "@truefoundry/trueforge-ui";
       functions, or SVGR components.
     </ParamField>
     <ParamField path="classNames" type="ContentClassNames">
-      Host CSS classes for content renderers. See [Custom Theme — Styling rendered content](/ui-sdk/setup-custom-ui/custom-theme#styling-rendered-content).
+      Host CSS classes for content renderers. See [Custom Theme — Styling rendered content](/ui-sdk/setup-custom-ui/custom-theme).
       <Expandable title="ContentClassNames">
         <ParamField path="markdown" type="string">
           Root of the markdown renderer (joins `.aui-markdown`).
@@ -192,13 +192,13 @@ import { TrueForgeUI } from "@truefoundry/trueforge-ui";
     </ParamField>
   </Expandable>
 
-  See [Theming](/ui-sdk/guides/theming).
+  See [Theming](/ui-sdk/setup-custom-ui/custom-theme).
 </ParamField>
 
 <ParamField path="overrides" type="SlotOverrides">
   Replace any built-in component. `Partial<AtomSlots>`, derived from the SDK's default slot
   table — so editor autocomplete lists the overridable names. See
-  [Slot overrides](/ui-sdk/guides/slot-overrides).
+  [Slot overrides](/ui-sdk/setup-custom-ui/slot-overrides).
 </ParamField>
 
 <ParamField path="className" type="string">
@@ -228,7 +228,7 @@ Persisted sessions remain available through the thread list.
 
 <Warning>
   If `window.location.search` contains `screenType=mcp-auth`, the component renders only the
-  OAuth completion screen and no layout. See [MCP OAuth](/ui-sdk/guides/mcp-oauth).
+  OAuth completion screen and no layout. See [MCP OAuth](/ui-sdk/setup-custom-ui/mcp-oauth).
 </Warning>
 
 ## Example

--- a/docs/ui-sdk/setup-custom-servers/connect-with-truefoundry.mdx
+++ b/docs/ui-sdk/setup-custom-servers/connect-with-truefoundry.mdx
@@ -13,8 +13,8 @@ export default function App() {
       <TrueForgeUI
         server={{
           type: "truefoundry",
-          apiKey: {{API_KEY}},
-          controlPlaneURL: {{CONTROL_PLANE_URL}},
+          apiKey: import.meta.env.VITE_TFY_API_KEY,
+          controlPlaneURL: import.meta.env.VITE_TFY_CONTROL_PLANE_URL,
         }}
         layout="sidebar"
       />

--- a/docs/ui-sdk/setup-custom-servers/server-contract.mdx
+++ b/docs/ui-sdk/setup-custom-servers/server-contract.mdx
@@ -315,7 +315,7 @@ const server: AgentChatServer<MySpec> & AgentBuilderServer<MySpec, MyModel> = {
 };
 ```
 
-The UI keeps reading only the fields it knows about; your own components — supplied through [slot overrides](/ui-sdk/guides/slot-overrides) — can read the rest.
+The UI keeps reading only the fields it knows about; your own components — supplied through [slot overrides](/ui-sdk/setup-custom-ui/slot-overrides) — can read the rest.
 
 ## Next
 

--- a/docs/ui-sdk/setup-custom-ui/slot-overrides.mdx
+++ b/docs/ui-sdk/setup-custom-ui/slot-overrides.mdx
@@ -91,7 +91,7 @@ honor the props you receive — several are rendered nodes (`actionBar`, `error`
 <Note>
   `Button` and `IconButton` publish their prop types for typing your own components. The
   buttons themselves are restyled through semantic tokens and CSS rather than replaced — see
-  [Theming](/ui-sdk/guides/theming).
+  [Theming](/ui-sdk/setup-custom-ui/custom-theme).
 </Note>
 
 ## Discovering slot names


### PR DESCRIPTION
Fixes from a full UX review of the docs, read with a newcomer / slightly-non-technical lens. Docs-only; 23 files.

## Structural (P0)
- **~21 dead UI-SDK links** from an unfinished folder move — `concepts/server-contract` → `setup-custom-servers/server-contract`; `guides/{theming,slot-overrides,mcp-oauth,custom-server}` → the real `setup-custom-ui/*` and `setup-custom-servers/*` pages; plus a broken `#styling-rendered-content` anchor. The previously-orphaned pages are now reachable through these in-page links.
- Removed the redundant, `hidden:true` **`guides/layouts`** from the sidebar (file kept; `layouts-and-theme` is the superset).
- Fixed the **shipped-catalog links** on `harness/initial-setup` (`packages/trueforge/catalog/…`, not `…/src/catalog/…`).

## Correctness (P1)
- **Approval default** (`create-agent`): prose now says *write or destructive*, matching the code default `["@write","@destructive"]` (was "destructive" only).
- **UI-SDK quickstart**: shows `baseUrl` + an optional `token` instead of an empty `trueforge` config the prose promised a token for.
- **connect-with-truefoundry**: replaced invalid `{{PLACEHOLDER}}` TSX with `import.meta.env` vars.
- **API pages**: link the scoped `@truefoundry/trueforge-sdk` npm package; dropped `npm i -s`.

## Consistency (P2)
- **"Agents Library"** everywhere (matches the app); route/asset names unchanged.
- **"Ask clarifying questions"** as the label (matches the composer); code identifiers `ask_user_question(s)` unchanged.
- One name for the feature: **"Large Tool Responses"**.
- `turn-events`: note that the reference uses snake_case and the SDK camelCases fields.
- `subagents`: the constraints Note now renders as a real list.

## Deliberately NOT in this PR (tracked follow-ups)
- **P3 newcomer polish** — define MCP/OIDC on first use, break up the intro jargon sentence, fix the Chat-UI "product tour vs SDK" mismatch.
- **`connect-with-truefoundry` "Build the server yourself"** still references stale adapter symbols (`createTrueFoundryAgentUIServer`, `createTrueFoundryChatServer`, `TrueFoundryAgentUIServer`) from the wrong package — needs the adapter owner to confirm the intended public API.
- `troubleshooting.mdx` has a duplicated paragraph.

> Note: not yet validated against a Mintlify build — relying on the PR's preview deploy to confirm rendering, image paths, and the dotted-heading anchors (`#model-message`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no impact on authentication, data handling, or application runtime behavior.
> 
> **Overview**
> **Docs-only** UX review fixes across **23 files** — no runtime or API code changes.
> 
> **Navigation & links:** Repairs broken UI-SDK cross-links after an incomplete folder move (`concepts/server-contract` → `setup-custom-servers/server-contract`; `guides/*` → `setup-custom-ui/*` and `setup-custom-servers/*`). Removes the redundant hidden **`guides/layouts`** entry from `docs.json` (keeps `layouts-and-theme`). Updates **shipped catalog** URLs on initial setup to `packages/trueforge/catalog/…` instead of `…/src/catalog/…`.
> 
> **Correctness:** API/SDK pages link the scoped **`@truefoundry/trueforge-sdk`** package; install snippet drops `npm i -s`. **Tool approval** prose matches the default gate `["@write", "@destructive"]`. UI-SDK **quickstart** shows `baseUrl` and an optional OIDC `token`; **connect-with-truefoundry** uses `import.meta.env` instead of invalid `{{PLACEHOLDER}}` TSX.
> 
> **Consistency:** **Agents Library** naming in prose; **Ask clarifying questions** as the UI label; **Large Tool Responses** as the single feature name. **Turn events** adds a note that HTTP docs use snake_case while the TS SDK camelCases fields. **Subagents** constraints render as a proper bullet list in a Note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c2d451320f6642d862fad13cef6ab3ca5fabb08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->