### PR TITLE
Enable eslint curly rule as error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
           # already uses OIDC (`id-token: write`); this flag is what changesets
           # / pnpm honor (they do not accept `--provenance`).
           # publishConfig.provenance is true on every public package.
-          NPM_CONFIG_PROVENANCE: "true"
+          NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Detect @truefoundry/trueforge publish
         id: trueforge

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,12 @@ export default defineConfig(
     ],
   },
   {
+    // Require braces on every control statement, including single-line and multi-line.
+    rules: {
+      curly: ['error', 'all'],
+    },
+  },
+  {
     files: ['**/*.{js,mjs,cjs,ts}'],
     ignores: ['packages/frontend/**'],
     extends: [js.configs.recommended, tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked],

--- a/packages/frontend/src/LogoutButton.tsx
+++ b/packages/frontend/src/LogoutButton.tsx
@@ -17,7 +17,9 @@ export function LogoutButton() {
     const state = { cancelled: false };
     void isOidcConnectedSession()
       .then(ok => {
-        if (!state.cancelled) setVisible(ok);
+        if (!state.cancelled) {
+          setVisible(ok);
+        }
       })
       .catch(() => {
         // Failed refetch must not clear a known-good session (e.g. transient network).
@@ -35,7 +37,9 @@ export function LogoutButton() {
   }
 
   const handleConfirm = () => {
-    if (busy) return;
+    if (busy) {
+      return;
+    }
     setBusy(true);
     void logout()
       .then(() => {
@@ -64,7 +68,9 @@ export function LogoutButton() {
       <CenteredModal
         open={confirmOpen}
         onOpenChange={next => {
-          if (!busy) setConfirmOpen(next);
+          if (!busy) {
+            setConfirmOpen(next);
+          }
         }}
         title="Log out"
         description="Sure to logout?"

--- a/packages/local-sandbox/scripts/probe-loopback.ts
+++ b/packages/local-sandbox/scripts/probe-loopback.ts
@@ -57,8 +57,11 @@ async function listenHost(): Promise<{ port: number; close: () => Promise<void> 
     close: () =>
       new Promise((resolve, reject) => {
         server.close(err => {
-          if (err) reject(err);
-          else resolve();
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
         });
       }),
   };
@@ -85,7 +88,9 @@ async function runSandboxed(params: { label: string; command: string; allowedDom
     { commandId: randomUUID(), commandText: params.command },
   );
   const [argv0, ...argvRest] = wrap.argv;
-  if (argv0 === undefined) throw new Error('empty argv');
+  if (argv0 === undefined) {
+    throw new Error('empty argv');
+  }
 
   const result = await new Promise<{ code: number | null; out: string }>((resolve, reject) => {
     const child = spawn(argv0, argvRest, {

--- a/packages/local-sandbox/src/core/CodeModeUdsTransport.ts
+++ b/packages/local-sandbox/src/core/CodeModeUdsTransport.ts
@@ -175,7 +175,9 @@ export class CodeModeUdsTransport implements CodeModeTransport {
     // Oversized / malformed frames only tear down this connection (and notify
     // onProtocolError). Transport is handle-scoped and does not kill the process group.
     const fail = (message: string): void => {
-      if (settled) return;
+      if (settled) {
+        return;
+      }
       settled = true;
       this.onProtocolError?.(message);
       socket.destroy();
@@ -190,7 +192,9 @@ export class CodeModeUdsTransport implements CodeModeTransport {
     });
 
     socket.on('end', () => {
-      if (settled) return;
+      if (settled) {
+        return;
+      }
       settled = true;
       void this.dispatchConnection(socket, reader).catch((error: unknown) => {
         this.onProtocolError?.(error instanceof Error ? error.message : String(error));

--- a/packages/local-sandbox/src/core/hostRun.ts
+++ b/packages/local-sandbox/src/core/hostRun.ts
@@ -258,9 +258,13 @@ function darwinUnixSocketPaths(): string[] {
 
 function syncDarwinUnixSockets(): void {
   // No-op until initSrt: register/unregister may run from transport-only tests.
-  if (SandboxManager.getConfig() === undefined) return;
+  if (SandboxManager.getConfig() === undefined) {
+    return;
+  }
   const platform = requireActivePlatform();
-  if (platform !== 'darwin') return;
+  if (platform !== 'darwin') {
+    return;
+  }
   SandboxManager.updateConfig(buildSessionConfig(platform));
 }
 
@@ -327,7 +331,9 @@ export function isSrtInitialized(): boolean {
  * Child is spawned as a process-group leader (`detached: true` on Unix).
  */
 export function killExecTree(child: ChildProcess | undefined): void {
-  if (!child) return;
+  if (!child) {
+    return;
+  }
   const pid = child.pid;
   if (pid !== undefined && process.platform !== 'win32') {
     try {
@@ -421,8 +427,11 @@ export async function runSupervisorSession(params: {
     stdinStream.on('error', () => undefined);
     await new Promise<void>((resolve, reject) => {
       stdinStream.end(stdin, (error?: Error | null) => {
-        if (error) reject(error);
-        else resolve();
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
       });
     });
   }
@@ -453,8 +462,11 @@ export async function runSupervisorSession(params: {
       return;
     }
     const text = chunk.toString('utf8');
-    if (stream === 'stdout') stdoutText += text;
-    else stderrText += text;
+    if (stream === 'stdout') {
+      stdoutText += text;
+    } else {
+      stderrText += text;
+    }
   };
 
   ignoreStreamError(child.stdout);
@@ -473,7 +485,9 @@ export async function runSupervisorSession(params: {
     }, timeoutMs);
 
     child.on('error', error => {
-      if (closed) return;
+      if (closed) {
+        return;
+      }
       closed = true;
       clearTimeout(timer);
       SandboxManager.cleanupAfterCommand();
@@ -481,7 +495,9 @@ export async function runSupervisorSession(params: {
     });
 
     child.on('close', code => {
-      if (closed) return;
+      if (closed) {
+        return;
+      }
       closed = true;
       clearTimeout(timer);
       SandboxManager.cleanupAfterCommand();

--- a/packages/local-sandbox/src/provider/LocalSandboxProvider.ts
+++ b/packages/local-sandbox/src/provider/LocalSandboxProvider.ts
@@ -109,7 +109,9 @@ export class LocalSandboxProvider implements SandboxProvider {
       let shell: string | undefined;
       for (const name of SHELL_CANDIDATES) {
         const resolved = await resolveCommandOnHost({ platform, name });
-        if (resolved === undefined) continue;
+        if (resolved === undefined) {
+          continue;
+        }
         const probe = await runSupervisorSession({
           sandboxRootPath: probeRoot,
           platform,
@@ -132,7 +134,9 @@ export class LocalSandboxProvider implements SandboxProvider {
       let python: string | undefined;
       for (const name of PYTHON_CANDIDATES) {
         const resolved = await resolveCommandOnHost({ platform, name });
-        if (resolved === undefined) continue;
+        if (resolved === undefined) {
+          continue;
+        }
         const probe = await runSupervisorSession({
           sandboxRootPath: probeRoot,
           platform,
@@ -216,7 +220,9 @@ export class LocalSandboxProvider implements SandboxProvider {
   }
 
   private async ensureSrt(): Promise<void> {
-    if (this.srtInitialized) return;
+    if (this.srtInitialized) {
+      return;
+    }
     await initSrt({ platform: this.support.platform });
     this.srtInitialized = true;
   }

--- a/packages/trueforge-core/scripts/check-dist.mjs
+++ b/packages/trueforge-core/scripts/check-dist.mjs
@@ -26,7 +26,9 @@ for (const modulePath of modulePaths) {
   try {
     require(`${base}.js`);
     await import(pathToFileURL(`${base}.mjs`).href);
-    if (!fs.existsSync(`${base}.d.ts`)) throw new Error('missing .d.ts');
+    if (!fs.existsSync(`${base}.d.ts`)) {
+      throw new Error('missing .d.ts');
+    }
     console.log(`ok ${modulePath}.{js,mjs,d.ts}`);
   } catch (error) {
     failures += 1;

--- a/packages/trueforge-core/src/agent-session/TurnResourceResolver.ts
+++ b/packages/trueforge-core/src/agent-session/TurnResourceResolver.ts
@@ -118,7 +118,9 @@ export class TurnResourceResolver<
     signal: AbortSignal;
     tracing: AgentTracing;
   }): Promise<Sandbox | undefined> {
-    if (!this.deps.sandboxProvider || !specWantsSandbox(input.spec)) return undefined;
+    if (!this.deps.sandboxProvider || !specWantsSandbox(input.spec)) {
+      return undefined;
+    }
     this.#sandbox = await this.deps.sandboxProvider({
       spec: input.spec,
       existingSandboxId: input.existing?.sandbox_id,
@@ -234,7 +236,9 @@ export class TurnResourceResolver<
    */
   protected getOrCreateToolSource(input: { id: string; create: () => Promise<ToolSource> }): Promise<ToolSource> {
     const cached = this.#sources.get(input.id);
-    if (cached) return cached;
+    if (cached) {
+      return cached;
+    }
     const made = input.create();
     this.#sources.set(input.id, made);
     return made;

--- a/packages/trueforge-core/src/agent-session/schemas/turn.ts
+++ b/packages/trueforge-core/src/agent-session/schemas/turn.ts
@@ -160,7 +160,9 @@ export const CreateTurnRequestSchema = z
       .describe('When true (default), stream turn events as SSE. When false, return the running turn immediately.'),
   })
   .superRefine((data, ctx) => {
-    if (!data.input) return;
+    if (!data.input) {
+      return;
+    }
     const hasUser = data.input.some(msg => 'type' in msg && msg.type === 'user.message');
     const hasApprovalOrToolResponse = data.input.some(
       msg => 'type' in msg && (msg.type === 'user.tool_approval' || msg.type === 'user.tool_response'),

--- a/packages/trueforge-core/src/agent-session/store/InMemorySessionStore.ts
+++ b/packages/trueforge-core/src/agent-session/store/InMemorySessionStore.ts
@@ -72,8 +72,12 @@ function turnKey({ session_id, turn_id }: { session_id: string; turn_id: string 
 
 /** Lexicographic session_id order — shared by listSessions sort and keyset filter. */
 function compareSessionId(a: string, b: string): number {
-  if (a < b) return -1;
-  if (a > b) return 1;
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
   return 0;
 }
 
@@ -231,7 +235,9 @@ export class InMemorySessionStore<
   ): Promise<{ data: SessionRecord<TSessionCustom>[]; pagination: TokenPagination }> {
     const records: SessionRecord<TSessionCustom>[] = [];
     for (const stored of this.sessions.values()) {
-      if (stored.record.tenant_id !== input.tenant_id) continue;
+      if (stored.record.tenant_id !== input.tenant_id) {
+        continue;
+      }
       if (
         input.agent_id !== undefined &&
         (stored.record.agent.type !== 'reference' || stored.record.agent.id !== input.agent_id)
@@ -242,8 +248,12 @@ export class InMemorySessionStore<
         continue;
       }
       const createdAt = stored.record.created_at.getTime();
-      if (input.start_timestamp !== undefined && createdAt < input.start_timestamp.getTime()) continue;
-      if (input.end_timestamp !== undefined && createdAt > input.end_timestamp.getTime()) continue;
+      if (input.start_timestamp !== undefined && createdAt < input.start_timestamp.getTime()) {
+        continue;
+      }
+      if (input.end_timestamp !== undefined && createdAt > input.end_timestamp.getTime()) {
+        continue;
+      }
       records.push(stored.record);
     }
     records.sort((a, b) => {
@@ -569,11 +579,17 @@ export class InMemorySessionStore<
     let oldestId = chain[0];
     while (oldestId && oldestId !== anchor.turn_id) {
       const oldest = this.turns.get(turnKey({ session_id: sessionId, turn_id: oldestId }));
-      if (!oldest) break;
+      if (!oldest) {
+        break;
+      }
       const older = oldest.ancestor_ids.filter(id => !seen.has(id));
-      if (older.length === 0) break;
+      if (older.length === 0) {
+        break;
+      }
       chain.unshift(...older);
-      for (const id of older) seen.add(id);
+      for (const id of older) {
+        seen.add(id);
+      }
       oldestId = older[0];
     }
     return chain;

--- a/packages/trueforge-core/src/agent-session/store/OffsetPageToken.ts
+++ b/packages/trueforge-core/src/agent-session/store/OffsetPageToken.ts
@@ -15,7 +15,9 @@ export function encodeOffsetPageToken(offset: number): string {
 }
 
 export function decodeOffsetPageToken(token: string | undefined): number {
-  if (token === undefined || token === '') return 0;
+  if (token === undefined || token === '') {
+    return 0;
+  }
   return decodePageToken(OffsetPageCursorSchema, token).offset;
 }
 

--- a/packages/trueforge-core/src/agent-session/store/SessionListPageToken.ts
+++ b/packages/trueforge-core/src/agent-session/store/SessionListPageToken.ts
@@ -24,7 +24,9 @@ export function encodeSessionListPageToken(cursor: SessionListPageCursor): strin
 }
 
 export function decodeSessionListPageToken(token: string | undefined): SessionListPageCursor | undefined {
-  if (token === undefined) return undefined;
+  if (token === undefined) {
+    return undefined;
+  }
   return decodePageToken(SessionListPageCursorSchema, token);
 }
 

--- a/packages/trueforge-core/src/core/InstructionBuilder.ts
+++ b/packages/trueforge-core/src/core/InstructionBuilder.ts
@@ -72,7 +72,9 @@ export class InstructionBuilder {
   /** Adds raw text (no wrapping tag) to this section. Empty strings are ignored. */
   addContent(content: string): this {
     const trimmed = content.trim();
-    if (trimmed) this.children.push(trimmed);
+    if (trimmed) {
+      this.children.push(trimmed);
+    }
     return this;
   }
 
@@ -82,7 +84,9 @@ export class InstructionBuilder {
    */
   addSection(tag: string, content: string, escapeContent = false): this {
     const trimmed = content.trim();
-    if (!trimmed) return this;
+    if (!trimmed) {
+      return this;
+    }
     const child = new InstructionBuilder(tag, escapeContent);
     child.children.push(trimmed);
     this.children.push(child);
@@ -104,11 +108,15 @@ export class InstructionBuilder {
         inner.push(child);
       } else {
         const output = child.build();
-        if (output) inner.push(output);
+        if (output) {
+          inner.push(output);
+        }
       }
     }
 
-    if (inner.length === 0) return '';
+    if (inner.length === 0) {
+      return '';
+    }
 
     const body = inner.join('\n\n');
     if (this.escapeContent) {

--- a/packages/trueforge-core/src/core/capabilities/builtins/LargeToolResponse.ts
+++ b/packages/trueforge-core/src/core/capabilities/builtins/LargeToolResponse.ts
@@ -25,11 +25,15 @@ interface ToolResultWithInfo {
 }
 
 function categorize(result: ToolCallResult, sandbox: Sandbox | undefined): ResultCategory {
-  if (result.failure) return 'failure';
+  if (result.failure) {
+    return 'failure';
+  }
   if (!result.info) {
     throw new Error(`Unreachable`);
   }
-  if (sandbox && result.info.toolSet === sandbox) return 'sandbox';
+  if (sandbox && result.info.toolSet === sandbox) {
+    return 'sandbox';
+  }
   return 'mcp';
 }
 

--- a/packages/trueforge-core/src/core/llm/VercelAILLM.ts
+++ b/packages/trueforge-core/src/core/llm/VercelAILLM.ts
@@ -574,7 +574,9 @@ export function toFilePart(file: {
   filename?: string | undefined;
 }): FilePart | undefined {
   const { file_data, filename } = file;
-  if (!file_data) return undefined;
+  if (!file_data) {
+    return undefined;
+  }
   const mediaType = parseMimeFromDataUri(file_data) ?? 'application/octet-stream';
   return {
     type: 'file',
@@ -989,7 +991,9 @@ export function describeStreamError(raw: unknown): string {
 }
 
 export function toStreamError(raw: unknown): Error {
-  if (raw instanceof Error) return raw;
+  if (raw instanceof Error) {
+    return raw;
+  }
   return new Error(describeStreamError(raw), { cause: raw });
 }
 

--- a/packages/trueforge-core/src/core/mcp/RemoteMCP.ts
+++ b/packages/trueforge-core/src/core/mcp/RemoteMCP.ts
@@ -123,7 +123,9 @@ export class RemoteMCP implements ToolSource {
   }
 
   private async resolveHeaders(): Promise<ResolveHeadersResult> {
-    if (typeof this.headers !== 'function') return { headers: this.headers };
+    if (typeof this.headers !== 'function') {
+      return { headers: this.headers };
+    }
     return await this.headers();
   }
 
@@ -132,7 +134,9 @@ export class RemoteMCP implements ToolSource {
     // can be revoked or expire mid-request, and callers must get authRequired rather than a generic
     // upstream failure. When already connected the resolved headers are unused (connect is skipped).
     const headersResult = await this.resolveHeaders();
-    if ('authRequired' in headersResult) return { authRequired: headersResult.authRequired };
+    if ('authRequired' in headersResult) {
+      return { authRequired: headersResult.authRequired };
+    }
     return this.connectAndRun(headersResult.headers, operation, true);
   }
 
@@ -179,7 +183,9 @@ export class RemoteMCP implements ToolSource {
       return { result: { tools: this.cachedTools }, wasInitialized: undefined };
     }
     const response = await this.executeWithSessionRetry(() => this.loadTools());
-    if ('authRequired' in response) return response;
+    if ('authRequired' in response) {
+      return response;
+    }
     return { result: { tools: response.result.tools }, wasInitialized: response.wasInitialized };
   }
 
@@ -202,7 +208,9 @@ export class RemoteMCP implements ToolSource {
         },
       ),
     );
-    if ('authRequired' in response) return response;
+    if ('authRequired' in response) {
+      return response;
+    }
     return { result: response.result, wasInitialized: response.wasInitialized };
   }
 
@@ -218,7 +226,9 @@ export class RemoteMCP implements ToolSource {
   }
 
   private async connectIfNeeded(headers: Record<string, string>): Promise<MCPServerInitInfo | undefined> {
-    if (this.isConnected) return undefined;
+    if (this.isConnected) {
+      return undefined;
+    }
     if (this.connectPromise) {
       // Wait for the in-flight connect, but only its originator emits the init metadata.
       await this.connectPromise;

--- a/packages/trueforge-core/src/core/mcp/ToolSelectorPolicy.ts
+++ b/packages/trueforge-core/src/core/mcp/ToolSelectorPolicy.ts
@@ -68,7 +68,9 @@ export class ToolSelectorPolicy {
 
   private isToolPreloaded(toolName: string, annotations: ToolAnnotations | undefined): boolean {
     // Fully-preloaded server: every allowed tool is loaded into context.
-    if (this.preload) return true;
+    if (this.preload) {
+      return true;
+    }
     // Otherwise only the tools matching `preload_tools` stay eager.
     return toolMatchesAnySelector(toolName, annotations, this.preloadTools);
   }

--- a/packages/trueforge-core/src/core/mcp/ToolSet.ts
+++ b/packages/trueforge-core/src/core/mcp/ToolSet.ts
@@ -47,7 +47,9 @@ export class ToolSet implements IToolSet {
 
   async listTools(): Promise<ListToolsResponse> {
     const response = await this.source.listTools();
-    if (isAuthRequired(response)) return response;
+    if (isAuthRequired(response)) {
+      return response;
+    }
 
     const tools = response.result.tools;
     const missingTools = this.policy.missingEnableLiterals(tools);
@@ -68,7 +70,9 @@ export class ToolSet implements IToolSet {
     // Prime the source and surface auth-required before the annotation-based allow/approval checks
     // (which would otherwise see missing annotations and wrongly 403).
     const listed = await this.source.listTools();
-    if (isAuthRequired(listed)) return listed;
+    if (isAuthRequired(listed)) {
+      return listed;
+    }
     const annotations = findAnnotations(listed.result.tools, params.name);
 
     await this.assertToolAllowed(params.name, annotations);
@@ -123,7 +127,9 @@ export class ToolSet implements IToolSet {
 
   private async resolveAnnotations(toolName: string): Promise<ToolAnnotations | undefined> {
     const listed = await this.source.listTools();
-    if (isAuthRequired(listed)) return undefined;
+    if (isAuthRequired(listed)) {
+      return undefined;
+    }
     return findAnnotations(listed.result.tools, toolName);
   }
 }

--- a/packages/trueforge-core/src/core/mcp/convertMCPServers.ts
+++ b/packages/trueforge-core/src/core/mcp/convertMCPServers.ts
@@ -46,7 +46,9 @@ export async function convertMCPServersToTools(params: {
 
   for (let i = 0; i < allServers.length; i++) {
     const listResult = listResults[i];
-    if (!listResult) continue;
+    if (!listResult) {
+      continue;
+    }
     const { serverName, response: listResponse } = listResult;
     if (isAuthRequired(listResponse)) {
       authRequirementInfo.push(listResponse.authRequired);
@@ -63,7 +65,9 @@ export async function convertMCPServersToTools(params: {
     }
     const sortedTools = [...mcpTools.tools].sort((a, b) => (a.name > b.name ? 1 : -1));
     for (const mcpTool of sortedTools) {
-      if (!mcpTool.preload) continue;
+      if (!mcpTool.preload) {
+        continue;
+      }
       const { name: toolName } = getUniqueSanitizedToolName(mcpTool.name, registeredNames);
       registeredNames.add(toolName);
       const description = `mcp server: ${serverName}\n${mcpTool.description ?? ''}`;

--- a/packages/trueforge-core/src/core/mcp/remoteMcpClient.ts
+++ b/packages/trueforge-core/src/core/mcp/remoteMcpClient.ts
@@ -57,14 +57,22 @@ function createTransport(
 }
 
 export function isSessionExpiredError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  if ('code' in error && error.code === 404) return true;
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if ('code' in error && error.code === 404) {
+    return true;
+  }
   return error.message.includes('HTTP 404') || error.message.toLowerCase().includes('session');
 }
 
 function isAuthError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  if ('code' in error && error.code === 401) return true;
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if ('code' in error && error.code === 401) {
+    return true;
+  }
   return error.message.includes('HTTP 401');
 }
 
@@ -78,7 +86,9 @@ function getTransportSessionId(transport: McpTransport): string | null {
 }
 
 function toConnectError(error: unknown): McpConnectionError {
-  if (error instanceof McpConnectionError) return error;
+  if (error instanceof McpConnectionError) {
+    return error;
+  }
   if (isAuthError(error)) {
     return new McpConnectionError('upstream returned 401 Unauthorized (check x-tfy-mcp-headers credentials)', 401, {
       cause: error,
@@ -160,10 +170,14 @@ export async function connectRemoteMcp(params: {
       await client.close().catch(() => {
         /* no-op */
       });
-      if (isAuthError(error)) throw toConnectError(error);
+      if (isAuthError(error)) {
+        throw toConnectError(error);
+      }
       // A session-expired error means the transport is right but the session is stale: surface it so
       // the caller reconnects fresh instead of falling through to a different transport.
-      if (params.sessionId && isSessionExpiredError(error)) throw toConnectError(error);
+      if (params.sessionId && isSessionExpiredError(error)) {
+        throw toConnectError(error);
+      }
       failures.push({ transport: transportType, error: error instanceof Error ? error.message.trim() : String(error) });
       continue;
     }

--- a/packages/trueforge-core/src/core/mcp/toolSelectors.ts
+++ b/packages/trueforge-core/src/core/mcp/toolSelectors.ts
@@ -62,11 +62,15 @@ export function toolMatchesAnySelector(
   annotations: ToolAnnotations | undefined,
   selectors: readonly string[] | undefined,
 ): boolean {
-  if (!selectors?.length) return false;
+  if (!selectors?.length) {
+    return false;
+  }
 
   for (const selector of selectors) {
     if (isToolTag(selector)) {
-      if (toolMatchesTag(selector, annotations)) return true;
+      if (toolMatchesTag(selector, annotations)) {
+        return true;
+      }
     } else if (selector === toolName) {
       return true;
     }
@@ -84,7 +88,9 @@ export function toolRequiresApproval(
   annotations: ToolAnnotations | undefined,
   selectors: readonly string[] | undefined,
 ): boolean {
-  if (!selectors?.length) return false;
+  if (!selectors?.length) {
+    return false;
+  }
   return toolMatchesAnySelector(toolName, annotations, selectors);
 }
 
@@ -96,14 +102,20 @@ export function isToolAllowed(params: {
   disableSelectors: readonly string[];
 }): boolean {
   const { toolName, annotations, enableSelectors, disableSelectors } = params;
-  if (!toolMatchesAnySelector(toolName, annotations, enableSelectors)) return false;
-  if (toolMatchesAnySelector(toolName, annotations, disableSelectors)) return false;
+  if (!toolMatchesAnySelector(toolName, annotations, enableSelectors)) {
+    return false;
+  }
+  if (toolMatchesAnySelector(toolName, annotations, disableSelectors)) {
+    return false;
+  }
   return true;
 }
 
 /** Non-tag names from a selector list (for upfront validation / sandbox allow-lists). */
 export function literalToolNames(selectors: readonly string[] | undefined): string[] {
-  if (!selectors) return [];
+  if (!selectors) {
+    return [];
+  }
   return selectors.filter(s => !isToolTag(s));
 }
 

--- a/packages/trueforge-core/src/core/runtime/AgentThread.ts
+++ b/packages/trueforge-core/src/core/runtime/AgentThread.ts
@@ -120,7 +120,9 @@ function assertValidTransition(from: AgentThreadState, to: AgentThreadState): vo
 
 function deriveAgentThreadState(context: ContextMessage[]): AgentThreadState {
   const openToolCallIds = getOpenToolCallIds(context);
-  if (openToolCallIds.size === 0) return 'llm-call-required';
+  if (openToolCallIds.size === 0) {
+    return 'llm-call-required';
+  }
 
   const assistant = lastAssistantInContext(context);
   const decisions = scanApprovalDecisions(context);
@@ -146,15 +148,23 @@ function getOpenToolCallIds(context: ContextMessage[]): Set<string> {
   const openToolCallIds = new Set<string>();
   for (let i = context.length - 1; i >= 0; i--) {
     const msg = context[i];
-    if (msg === undefined) continue;
-    if (!isLLMContextMessage(msg)) continue;
+    if (msg === undefined) {
+      continue;
+    }
+    if (!isLLMContextMessage(msg)) {
+      continue;
+    }
     if (msg.role === 'tool') {
       resolvedToolCallIds.add(msg.tool_call_id);
       continue;
     }
     if (msg.role === 'assistant') {
-      for (const tc of msg.tool_calls ?? []) openToolCallIds.add(tc.id);
-      for (const id of resolvedToolCallIds) openToolCallIds.delete(id);
+      for (const tc of msg.tool_calls ?? []) {
+        openToolCallIds.add(tc.id);
+      }
+      for (const id of resolvedToolCallIds) {
+        openToolCallIds.delete(id);
+      }
       break;
     }
   }
@@ -312,7 +322,9 @@ function validateInputMessageTypesGivenContext(
 
   for (let i = 0; i < messages.length; i++) {
     const m = messages[i];
-    if (m === undefined) continue;
+    if (m === undefined) {
+      continue;
+    }
     if (isApprovalDecisionMessage(m)) {
       validateApprovalMessage(m, pendingApprovalIds, i);
       pendingApprovalIds.delete(m.tool_call_id);
@@ -441,7 +453,9 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
 // Args are only used by DeferredTool to delegate to the underlying server.
 // Defensive parse — hallucinated JSON shouldn't crash assistant-message construction.
 function tryParseToolArgs(args: string | undefined): Record<string, unknown> {
-  if (!args) return {};
+  if (!args) {
+    return {};
+  }
   try {
     const parsed: unknown = JSON.parse(args);
     return isJsonObject(parsed) ? parsed : {};
@@ -528,7 +542,9 @@ export class AgentThread {
       capabilities.map(c => c.state?.key).filter((k): k is string => typeof k === 'string'),
     );
     for (const capability of capabilities) {
-      if (!capability.state) continue;
+      if (!capability.state) {
+        continue;
+      }
       const value = claimed[capability.state.key];
       if (value !== undefined) {
         capability.state.load(value);
@@ -1318,7 +1334,9 @@ export class AgentThread {
       for (;;) {
         for (;;) {
           const sandboxCreatedEvent = this.pendingSandboxCreatedEvents.shift();
-          if (sandboxCreatedEvent === undefined) break;
+          if (sandboxCreatedEvent === undefined) {
+            break;
+          }
           yield sandboxCreatedEvent;
         }
 
@@ -1327,7 +1345,9 @@ export class AgentThread {
         switch (state) {
           case 'llm-call-required': {
             // Cancel only before network/side-effecting steps (LLM call, tool execution), never before 'user-input-required', so the required event is always emitted once the assistant message is committed.
-            if (signal?.aborted) return;
+            if (signal?.aborted) {
+              return;
+            }
             if (this.metrics.iterations >= iterationLimit) {
               yield this.generateErrorEvent(
                 `You have reached iteration limit of ${String(iterationLimit)}, please request again`,
@@ -1342,7 +1362,9 @@ export class AgentThread {
             break;
           }
           case 'tool-response-required': {
-            if (signal?.aborted) return;
+            if (signal?.aborted) {
+              return;
+            }
             outcome = yield* this.stepToolResponse(toolMapping);
             break;
           }
@@ -1356,7 +1378,9 @@ export class AgentThread {
             throw new Error('unreachable');
           }
         }
-        if (outcome === 'exit') return;
+        if (outcome === 'exit') {
+          return;
+        }
       }
     } catch (error) {
       // Providers / transports often reject with plain objects; instanceof Error would
@@ -1373,7 +1397,9 @@ function assertUniqueStateKeys(capabilities: readonly AgentCapability[]): void {
   const seen = new Set<string>();
   for (const capability of capabilities) {
     const key = capability.state?.key;
-    if (!key) continue;
+    if (!key) {
+      continue;
+    }
     if (seen.has(key)) {
       throw new AgentHarnessError(
         'capability_state_error',
@@ -1389,7 +1415,9 @@ function claimCapabilityState(
   input: CapabilityState | undefined,
   logger: Logger,
 ): CapabilityState {
-  if (!input) return {};
+  if (!input) {
+    return {};
+  }
   const claimedKeys = new Set(capabilities.map(c => c.state?.key).filter((k): k is string => typeof k === 'string'));
   const claimed: CapabilityState = {};
   for (const [key, value] of Object.entries(input)) {

--- a/packages/trueforge-core/src/core/runtime/AgentThreadOrchestrator.ts
+++ b/packages/trueforge-core/src/core/runtime/AgentThreadOrchestrator.ts
@@ -42,8 +42,12 @@ function agentThreadEventToTerminalFields(event: AgentThreadExecutionEvent): {
 } {
   switch (event.type) {
     case InternalEventType.AGENT_DONE: {
-      if ('parent' in event && event.parent) return {};
-      if (event.status === 'error') return {};
+      if ('parent' in event && event.parent) {
+        return {};
+      }
+      if (event.status === 'error') {
+        return {};
+      }
       return { output: event.output };
     }
     case EventType.TOOL_APPROVAL_REQUIRED:
@@ -65,7 +69,9 @@ function isUserToolApprovalOrResponseBatch(
 
 function getMainThreadId(agentThreads: Map<string, AgentThread>): string {
   for (const thread of agentThreads.values()) {
-    if (!thread.parent) return thread.threadId;
+    if (!thread.parent) {
+      return thread.threadId;
+    }
   }
   throw new Error('Unreachable: no root thread found');
 }
@@ -81,7 +87,9 @@ function getActiveAgentThreads(agentThreads: Map<string, AgentThread>): AgentThr
   }
   return leaves.map(id => {
     const agentThread = agentThreads.get(id);
-    if (!agentThread) throw new Error('unreachable');
+    if (!agentThread) {
+      throw new Error('unreachable');
+    }
     return agentThread;
   });
 }
@@ -344,9 +352,13 @@ export class AgentThreadOrchestrator {
         return { shouldStopExecution: true };
       case InternalEventType.AGENT_DONE: {
         if (chunk.parent) {
-          if (!chunk.send_to_parent) throw new Error('unreachable');
+          if (!chunk.send_to_parent) {
+            throw new Error('unreachable');
+          }
           const parentThread = this.agentThreads.get(chunk.parent.thread_id);
-          if (!parentThread) throw new Error('unreachable: parent thread missing');
+          if (!parentThread) {
+            throw new Error('unreachable: parent thread missing');
+          }
           const subAgentToolIsOpen = parentThread.hasOpenToolCallId(chunk.parent.tool_call_id);
           if (subAgentToolIsOpen) {
             const parentToolResponse: ToolResponseEvent = {
@@ -432,7 +444,9 @@ export class AgentThreadOrchestrator {
 
     try {
       while (agentThreads.size > 0) {
-        if (shouldStopExecution) break;
+        if (shouldStopExecution) {
+          break;
+        }
 
         const activeThreads = getActiveAgentThreads(agentThreads);
 
@@ -470,8 +484,12 @@ export class AgentThreadOrchestrator {
               }
               if (chunk.type !== InternalEventType.PASSTHROUGH) {
                 const { output: outputContribution, requiredAction } = agentThreadEventToTerminalFields(chunk);
-                if (outputContribution) output = outputContribution;
-                if (requiredAction) requiredActions.push(requiredAction);
+                if (outputContribution) {
+                  output = outputContribution;
+                }
+                if (requiredAction) {
+                  requiredActions.push(requiredAction);
+                }
               }
             }
           }

--- a/packages/trueforge-core/src/core/runtime/DeferredTool.ts
+++ b/packages/trueforge-core/src/core/runtime/DeferredTool.ts
@@ -86,7 +86,9 @@ export class DeferredTool extends LocalToolMCP {
     // `hasPreloadedTools` must not hide a server from deferred discovery instructions.
     const deferredServers = servers.filter(s => !s.preload);
 
-    if (deferredServers.length === 0) return;
+    if (deferredServers.length === 0) {
+      return;
+    }
 
     const deferredList = deferredServers
       .map(s => (s.description ? `- ${s.name}: "${s.description.slice(0, MAX_DESCRIPTION_LENGTH)}"` : `- ${s.name}`))
@@ -176,7 +178,9 @@ export class DeferredTool extends LocalToolMCP {
       handler: async (input: { mcp_server: string }) => {
         try {
           const resolved = await this.resolveServerTools(input.mcp_server);
-          if (!isResolvedServerTools(resolved)) return resolved;
+          if (!isResolvedServerTools(resolved)) {
+            return resolved;
+          }
           const { server, tools, metadata } = resolved;
           return toolResultResponse({
             text: `${server.name}:\n  ${tools.map(t => t.name).join(', ')}`,
@@ -207,7 +211,9 @@ export class DeferredTool extends LocalToolMCP {
       handler: async (input: { mcp_server: string; tool_name: string }) => {
         try {
           const resolved = await this.resolveServerTools(input.mcp_server);
-          if (!isResolvedServerTools(resolved)) return resolved;
+          if (!isResolvedServerTools(resolved)) {
+            return resolved;
+          }
           const { tools, metadata } = resolved;
           const tool = tools.find(t => t.name === input.tool_name);
           if (!tool) {
@@ -255,7 +261,9 @@ export class DeferredTool extends LocalToolMCP {
       handler: async (input: { mcp_server: string; tool_name: string }) => {
         try {
           const resolved = await this.resolveServerTools(input.mcp_server);
-          if (!isResolvedServerTools(resolved)) return resolved;
+          if (!isResolvedServerTools(resolved)) {
+            return resolved;
+          }
           const { tools, metadata } = resolved;
           const tool = tools.find(t => t.name === input.tool_name);
           if (!tool) {
@@ -315,7 +323,9 @@ export class DeferredTool extends LocalToolMCP {
             return response;
           }
 
-          if (isApprovalRequiredResponse(response)) return response;
+          if (isApprovalRequiredResponse(response)) {
+            return response;
+          }
 
           if (!isCallToolResponseResult(response)) {
             throw new Error('Tool call returned an unexpected sub-agent response');

--- a/packages/trueforge-core/src/core/runtime/contextUtils.ts
+++ b/packages/trueforge-core/src/core/runtime/contextUtils.ts
@@ -46,7 +46,9 @@ export function isLLMContextMessage(msg: ContextMessage): msg is LLMContextMessa
 }
 
 export function isInternalSystemMessage(m: ContextMessage): boolean {
-  if (!isLLMContextMessage(m)) return false;
+  if (!isLLMContextMessage(m)) {
+    return false;
+  }
   return m.role === 'user' && typeof m.content === 'string' && m.content.startsWith(SYSTEM_TAG_START);
 }
 

--- a/packages/trueforge-core/src/core/sandbox/Sandbox.ts
+++ b/packages/trueforge-core/src/core/sandbox/Sandbox.ts
@@ -127,8 +127,12 @@ function injectTraceContextEnv(): Record<string, string> {
   const carrier: Record<string, string> = {};
   propagation.inject(context.active(), carrier);
   const env: Record<string, string> = {};
-  if (carrier['traceparent']) env['TFY_TRACEPARENT'] = carrier['traceparent'];
-  if (carrier['tracestate']) env['TFY_TRACESTATE'] = carrier['tracestate'];
+  if (carrier['traceparent']) {
+    env['TFY_TRACEPARENT'] = carrier['traceparent'];
+  }
+  if (carrier['tracestate']) {
+    env['TFY_TRACESTATE'] = carrier['tracestate'];
+  }
   return env;
 }
 
@@ -354,7 +358,9 @@ export class Sandbox extends LocalToolMCP {
 
   private buildMCPSection(builder: InstructionBuilder): void {
     const toolSetNames = this.codeExecToolSets.map(m => m.name).join(',');
-    if (!toolSetNames) return;
+    if (!toolSetNames) {
+      return;
+    }
 
     builder.addSection(
       SANDBOX_MCP_REMINDER_TAG,
@@ -657,7 +663,9 @@ export class Sandbox extends LocalToolMCP {
     this.codeModeDispatcher = undefined;
     const transport = this.codeModeTransport;
     this.codeModeTransport = undefined;
-    if (transport === undefined) return;
+    if (transport === undefined) {
+      return;
+    }
     try {
       await transport.stop();
     } catch (e) {

--- a/packages/trueforge-core/src/core/sandbox/codeMode/CodeModeDispatcher.ts
+++ b/packages/trueforge-core/src/core/sandbox/codeMode/CodeModeDispatcher.ts
@@ -30,9 +30,15 @@ function isHttpClientError(error: unknown): error is { status: number } {
 }
 
 function classifyErrorSource(e: unknown): CodeModeErrorSource {
-  if (e instanceof InvalidMCPUsageError) return 'caller';
-  if (isHttpClientError(e)) return 'caller';
-  if (e instanceof McpConnectionError && e.statusCode >= 400 && e.statusCode < 500) return 'caller';
+  if (e instanceof InvalidMCPUsageError) {
+    return 'caller';
+  }
+  if (isHttpClientError(e)) {
+    return 'caller';
+  }
+  if (e instanceof McpConnectionError && e.statusCode >= 400 && e.statusCode < 500) {
+    return 'caller';
+  }
   return 'internal';
 }
 

--- a/packages/trueforge-core/src/core/sandbox/codeMode/nats/CodeModeNatsTransport.ts
+++ b/packages/trueforge-core/src/core/sandbox/codeMode/nats/CodeModeNatsTransport.ts
@@ -71,7 +71,9 @@ export class CodeModeNatsTransport implements CodeModeTransport {
     }
     const nc = this.nc;
     this.nc = undefined;
-    if (nc === undefined) return;
+    if (nc === undefined) {
+      return;
+    }
     try {
       await withTimeout(nc.drain(), NATS_DRAIN_TIMEOUT_MS);
     } catch (e) {
@@ -163,8 +165,12 @@ export class CodeModeNatsTransport implements CodeModeTransport {
     const carrier: Record<string, string> = {};
     const traceparent = msg.headers?.get('traceparent');
     const tracestate = msg.headers?.get('tracestate');
-    if (traceparent) carrier['traceparent'] = traceparent;
-    if (tracestate) carrier['tracestate'] = tracestate;
+    if (traceparent) {
+      carrier['traceparent'] = traceparent;
+    }
+    if (tracestate) {
+      carrier['tracestate'] = tracestate;
+    }
 
     let request: CodeModeRequest;
     try {

--- a/packages/trueforge-core/src/core/sandbox/provider/DaytonaProvider.ts
+++ b/packages/trueforge-core/src/core/sandbox/provider/DaytonaProvider.ts
@@ -60,8 +60,11 @@ function isFailedBuildState(state: Snapshot['state']): boolean {
 /** Convert Daytona https preview URLs to wss for the NATS client. */
 function httpUrlToWsUrl(url: string): string {
   const parsed = new URL(url);
-  if (parsed.protocol === 'https:') parsed.protocol = 'wss:';
-  else if (parsed.protocol === 'http:') parsed.protocol = 'ws:';
+  if (parsed.protocol === 'https:') {
+    parsed.protocol = 'wss:';
+  } else if (parsed.protocol === 'http:') {
+    parsed.protocol = 'ws:';
+  }
   return parsed.toString();
 }
 
@@ -137,7 +140,9 @@ export class DaytonaSandboxProvider implements SandboxProvider {
   private async getOrCreateSandbox(sandboxId?: string): Promise<{ sandbox: Sandbox; defaultTimeoutMs: number }> {
     if (sandboxId) {
       const cached = DaytonaSandboxProvider.cachedSandboxes.get(sandboxId);
-      if (cached) return cached;
+      if (cached) {
+        return cached;
+      }
     }
 
     const sandbox = sandboxId
@@ -158,15 +163,21 @@ export class DaytonaSandboxProvider implements SandboxProvider {
   // Returns true iff the caller should retry: either we restarted a stopped sandbox, or the cache entry is missing and the retry will rebuild it via the cold path.
   private static recoverSandboxIfStopped(sandboxId: string): Promise<boolean> {
     const existing = DaytonaSandboxProvider.inFlightRecoveries.get(sandboxId);
-    if (existing) return existing;
+    if (existing) {
+      return existing;
+    }
 
     const cached = DaytonaSandboxProvider.cachedSandboxes.get(sandboxId);
     // Cache may have been evicted by a concurrent error path; signal retry so getOrCreateSandbox rebuilds via restoreExistingSandbox.
-    if (!cached) return Promise.resolve(true);
+    if (!cached) {
+      return Promise.resolve(true);
+    }
 
     const recovery = (async () => {
       await cached.sandbox.refreshData();
-      if (cached.sandbox.state === SANDBOX_STATE_STARTED) return false;
+      if (cached.sandbox.state === SANDBOX_STATE_STARTED) {
+        return false;
+      }
       // start() covers both stopped and archived per Daytona; throws on unrecoverable states (error/destroyed).
       await cached.sandbox.start();
       return true;
@@ -183,7 +194,9 @@ export class DaytonaSandboxProvider implements SandboxProvider {
       return await operation();
     } catch (originalError) {
       // TODO: Narrow to a specific Daytona error code once @daytona/sdk exposes one for "sandbox not running".
-      if (!(originalError instanceof DaytonaError)) throw originalError;
+      if (!(originalError instanceof DaytonaError)) {
+        throw originalError;
+      }
 
       let recovered: boolean;
       try {
@@ -196,7 +209,9 @@ export class DaytonaSandboxProvider implements SandboxProvider {
         throw new Error('Sandbox is unavailable; recovery attempt failed.', { cause: recoveryError });
       }
 
-      if (!recovered) throw originalError;
+      if (!recovered) {
+        throw originalError;
+      }
 
       try {
         return await operation();
@@ -410,7 +425,9 @@ export class DaytonaSandboxProvider implements SandboxProvider {
           return await sandbox.fs.downloadFile(params.path);
         });
       } catch (e: unknown) {
-        if (e instanceof SandboxPathIsDirectoryError || e instanceof SandboxFileTooLargeError) throw e;
+        if (e instanceof SandboxPathIsDirectoryError || e instanceof SandboxFileTooLargeError) {
+          throw e;
+        }
         if (e instanceof DaytonaError && e.statusCode === SANDBOX_NOT_FOUND_STATUS) {
           throw new SandboxFileNotFoundError(params.path);
         }

--- a/packages/trueforge-core/src/core/sandbox/provider/TFYSandboxProvider.ts
+++ b/packages/trueforge-core/src/core/sandbox/provider/TFYSandboxProvider.ts
@@ -134,8 +134,12 @@ export class TFYSandboxProvider implements SandboxProvider {
       command: `stat -L --printf='{"size":%s,"type":"%F"}' ${shellEscape(params.path)}`,
     });
 
-    if (!result.success) throw new Error(`Failed to stat file: ${result.error}`);
-    if (result.response.exitCode !== 0) throw new SandboxFileNotFoundError(params.path);
+    if (!result.success) {
+      throw new Error(`Failed to stat file: ${result.error}`);
+    }
+    if (result.response.exitCode !== 0) {
+      throw new SandboxFileNotFoundError(params.path);
+    }
 
     const parsed = JSON.parse(result.response.result) as StatResult;
     return { size: parsed.size, isDir: parsed.type === 'directory' };
@@ -155,8 +159,12 @@ export class TFYSandboxProvider implements SandboxProvider {
       command: `base64 -w0 ${shellEscape(params.path)}`,
     });
 
-    if (!result.success) throw new Error(`Failed to download file: ${result.error}`);
-    if (result.response.exitCode !== 0) throw new SandboxFileNotFoundError(params.path);
+    if (!result.success) {
+      throw new Error(`Failed to download file: ${result.error}`);
+    }
+    if (result.response.exitCode !== 0) {
+      throw new SandboxFileNotFoundError(params.path);
+    }
 
     return Buffer.from(result.response.result.trim(), 'base64');
   }

--- a/packages/trueforge-core/src/core/sandbox/skills/SkillMounter.ts
+++ b/packages/trueforge-core/src/core/sandbox/skills/SkillMounter.ts
@@ -39,7 +39,9 @@ export class SkillMounter implements ISkillMounter {
   }
 
   instruction(builder: InstructionBuilder): void {
-    if (this.skills.length === 0) return;
+    if (this.skills.length === 0) {
+      return;
+    }
     builder.addContent(SKILLS_PREAMBLE);
     for (const skill of this.skills) {
       builder.addSection(

--- a/packages/trueforge-core/src/core/util/abort.ts
+++ b/packages/trueforge-core/src/core/util/abort.ts
@@ -1,5 +1,7 @@
 export function onSignalAbort(signal: AbortSignal | undefined, callback: () => void): void {
-  if (!signal) return;
+  if (!signal) {
+    return;
+  }
   if (signal.aborted) {
     callback();
     return;

--- a/packages/trueforge-core/tests/agent-session/store/storeContractSuite.ts
+++ b/packages/trueforge-core/tests/agent-session/store/storeContractSuite.ts
@@ -701,7 +701,9 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
         end_timestamp: undefined,
       });
       const middleSession = all.data[1];
-      if (!middleSession) throw new Error('expected middle session in list');
+      if (!middleSession) {
+        throw new Error('expected middle session in list');
+      }
       const middleCreatedAt = middleSession.created_at;
       const bounded = await store.listSessions({
         agent_id: undefined,

--- a/packages/trueforge-core/tests/core/harnessMocks.ts
+++ b/packages/trueforge-core/tests/core/harnessMocks.ts
@@ -81,14 +81,22 @@ export function makeStubPublicSandbox(tenantName = 'test-tenant'): Sandbox {
 
 /** Extract `mcp server: <name>` labels from an LLM tools array (public create() body). */
 export function mcpServerNamesFromTools(tools: unknown): string[] {
-  if (!Array.isArray(tools)) return [];
+  if (!Array.isArray(tools)) {
+    return [];
+  }
   const names: string[] = [];
   for (const tool of tools) {
-    if (!tool || typeof tool !== 'object' || !('function' in tool)) continue;
+    if (!tool || typeof tool !== 'object' || !('function' in tool)) {
+      continue;
+    }
     const fn = (tool as { function?: unknown }).function;
-    if (!fn || typeof fn !== 'object' || !('description' in fn)) continue;
+    if (!fn || typeof fn !== 'object' || !('description' in fn)) {
+      continue;
+    }
     const description = (fn as { description?: unknown }).description;
-    if (typeof description !== 'string') continue;
+    if (typeof description !== 'string') {
+      continue;
+    }
     const match = /^mcp server: ([^\n]+)/.exec(description);
     const serverName = match?.[1];
     if (serverName !== undefined && !names.includes(serverName)) {

--- a/packages/trueforge-core/tests/core/sandbox/codeMode/codeModeTransportContractSuite.ts
+++ b/packages/trueforge-core/tests/core/sandbox/codeMode/codeModeTransportContractSuite.ts
@@ -64,7 +64,9 @@ export function runCodeModeTransportContractSuite(
       });
 
       expect(reply.ok).toBe(true);
-      if (!reply.ok) throw new Error('unreachable');
+      if (!reply.ok) {
+        throw new Error('unreachable');
+      }
       expect(reply.result).toBeDefined();
     });
 

--- a/packages/trueforge-core/tests/core/sandbox/provider/sandboxProviderContractSuite.ts
+++ b/packages/trueforge-core/tests/core/sandbox/provider/sandboxProviderContractSuite.ts
@@ -37,7 +37,9 @@ export function runSandboxProviderContractSuite(
         command: 'cat persist.txt',
       });
       ensureExecSuccess(read);
-      if (!read.success) throw new Error('unreachable');
+      if (!read.success) {
+        throw new Error('unreachable');
+      }
       expect(read.response.result).toBe('persist-ok\n');
     });
 
@@ -57,7 +59,9 @@ export function runSandboxProviderContractSuite(
         command: 'cat secret.txt',
       });
       expect(readRelative.success).toBe(true);
-      if (!readRelative.success) throw new Error('unreachable');
+      if (!readRelative.success) {
+        throw new Error('unreachable');
+      }
       expect(readRelative.response.exitCode).not.toBe(0);
       expect(readRelative.response.result).not.toMatch(/only-in-a/);
 
@@ -69,7 +73,9 @@ export function runSandboxProviderContractSuite(
           command: `cat ${JSON.stringify(siblingRelative)}`,
         });
         expect(readSiblingRelative.success).toBe(true);
-        if (!readSiblingRelative.success) throw new Error('unreachable');
+        if (!readSiblingRelative.success) {
+          throw new Error('unreachable');
+        }
         expect(readSiblingRelative.response.exitCode).not.toBe(0);
         expect(readSiblingRelative.response.result).not.toMatch(/only-in-a/);
 
@@ -78,7 +84,9 @@ export function runSandboxProviderContractSuite(
           command: `cat ${JSON.stringify(join(a.sandboxId, 'secret.txt'))}`,
         });
         expect(readAbsolute.success).toBe(true);
-        if (!readAbsolute.success) throw new Error('unreachable');
+        if (!readAbsolute.success) {
+          throw new Error('unreachable');
+        }
         expect(readAbsolute.response.exitCode).not.toBe(0);
         expect(readAbsolute.response.result).not.toMatch(/only-in-a/);
 
@@ -87,7 +95,9 @@ export function runSandboxProviderContractSuite(
           command: `printf 'cross-write\\n' > ${JSON.stringify(join(a.sandboxId, 'cross-write.txt'))}`,
         });
         expect(writeAbsolute.success).toBe(true);
-        if (!writeAbsolute.success) throw new Error('unreachable');
+        if (!writeAbsolute.success) {
+          throw new Error('unreachable');
+        }
         expect(writeAbsolute.response.exitCode).not.toBe(0);
 
         const writeSiblingRelative = await fixture.provider.exec({
@@ -95,7 +105,9 @@ export function runSandboxProviderContractSuite(
           command: `printf 'cross-write\\n' > ${JSON.stringify(join('..', basename(a.sandboxId), 'cross-write.txt'))}`,
         });
         expect(writeSiblingRelative.success).toBe(true);
-        if (!writeSiblingRelative.success) throw new Error('unreachable');
+        if (!writeSiblingRelative.success) {
+          throw new Error('unreachable');
+        }
         expect(writeSiblingRelative.response.exitCode).not.toBe(0);
 
         const leaked = await fixture.provider.exec({
@@ -103,7 +115,9 @@ export function runSandboxProviderContractSuite(
           command: 'test -e cross-write.txt',
         });
         expect(leaked.success).toBe(true);
-        if (!leaked.success) throw new Error('unreachable');
+        if (!leaked.success) {
+          throw new Error('unreachable');
+        }
         expect(leaked.response.exitCode).not.toBe(0);
       }
     });

--- a/packages/trueforge/scripts/write-openapi.ts
+++ b/packages/trueforge/scripts/write-openapi.ts
@@ -38,8 +38,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * position carries meaning in `required`, `enum` and `anyOf`.
  */
 function canonicalise(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalise);
-  if (!isRecord(value)) return value;
+  if (Array.isArray(value)) {
+    return value.map(canonicalise);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
   return Object.fromEntries(
     Object.keys(value)
       .sort()

--- a/packages/trueforge/src/config.ts
+++ b/packages/trueforge/src/config.ts
@@ -116,8 +116,12 @@ function parseBoolean(options: { envKey: string; raw: string | undefined; defaul
     return defaultValue;
   }
   const value = raw.trim().toLowerCase();
-  if (value === 'true') return true;
-  if (value === 'false') return false;
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
   throw new Error(`Environment variable ${envKey} must be "true" or "false", got "${raw}"`);
 }
 

--- a/packages/trueforge/src/db/postgres/session-store/queries/events.ts
+++ b/packages/trueforge/src/db/postgres/session-store/queries/events.ts
@@ -26,7 +26,9 @@ import { unnestWithOrdinality, values } from '../sqlExpressions';
 import { classifyTurnFenceWriteFailure, turnRunningFence } from './turns';
 
 export async function appendToEvents(db: Kysely<Database>, input: AppendToEventsInput): Promise<void> {
-  if (input.events.length === 0) return;
+  if (input.events.length === 0) {
+    return;
+  }
 
   const keys = {
     session_id: input.session_id,
@@ -188,11 +190,17 @@ export async function resolveAncestorChain(
       .where('session_id', '=', sessionId)
       .where('turn_id', '=', oldestId)
       .executeTakeFirst();
-    if (!oldest) break;
+    if (!oldest) {
+      break;
+    }
     const older = oldest.ancestor_ids.filter(id => !seen.has(id));
-    if (older.length === 0) break;
+    if (older.length === 0) {
+      break;
+    }
     chain.unshift(...older);
-    for (const id of older) seen.add(id);
+    for (const id of older) {
+      seen.add(id);
+    }
     oldestId = older[0];
   }
   return chain;

--- a/packages/trueforge/src/db/postgres/session-store/queries/turns.ts
+++ b/packages/trueforge/src/db/postgres/session-store/queries/turns.ts
@@ -212,7 +212,9 @@ async function assembleTurnRecord(
     .where('turn_id', '=', args.turn_id)
     .executeTakeFirst();
 
-  if (!turn) return undefined;
+  if (!turn) {
+    return undefined;
+  }
 
   // LEFT JOIN LATERAL unnest so empty-context threads still appear; LEFT JOIN log
   // because a null lateral append_id (empty array) must not drop the turn_thread row.
@@ -373,7 +375,9 @@ export async function createTurn(db: Kysely<Database>, input: CreateTurnInput): 
         .forUpdate()
         .executeTakeFirst();
 
-      if (!locked) throw new SessionNotFoundError(input.session_id);
+      if (!locked) {
+        throw new SessionNotFoundError(input.session_id);
+      }
 
       await trx
         .updateTable('session')
@@ -431,7 +435,9 @@ export async function createTurn(db: Kysely<Database>, input: CreateTurnInput): 
           prevCheckpoint = first.turn_checkpoint;
 
           for (const row of prevRows) {
-            if (row.thread_id === null) continue;
+            if (row.thread_id === null) {
+              continue;
+            }
             if (row.thread_checkpoint === null || row.current_context_usage === null || row.context_ids === null) {
               throw new SessionStoreInvariantError(`previous turn_thread row for ${row.thread_id} is incomplete`);
             }
@@ -560,7 +566,9 @@ export async function createTurn(db: Kysely<Database>, input: CreateTurnInput): 
       // Complete per-turn capability maps (thread coverage asserted above).
       const capabilityStateRows: CapabilityStateInsertRow[] = [];
       for (const capability of input.capability_states) {
-        if (capability.capability_state === null) continue;
+        if (capability.capability_state === null) {
+          continue;
+        }
         for (const [key, state] of Object.entries(capability.capability_state)) {
           capabilityStateRows.push({
             session_id: input.session_id,
@@ -578,8 +586,12 @@ export async function createTurn(db: Kysely<Database>, input: CreateTurnInput): 
       }
     });
   } catch (err) {
-    if (err instanceof SessionStoreNotFoundError || err instanceof SessionStoreConflictError) throw err;
-    if (isUniqueViolation(err)) throw new TurnAlreadyExistsError(input.turn.turn_id, { cause: err });
+    if (err instanceof SessionStoreNotFoundError || err instanceof SessionStoreConflictError) {
+      throw err;
+    }
+    if (isUniqueViolation(err)) {
+      throw new TurnAlreadyExistsError(input.turn.turn_id, { cause: err });
+    }
     throw err;
   }
 }
@@ -623,7 +635,9 @@ export async function freezeAndGetTurn(db: Kysely<Database>, input: FreezeAndGet
     }
 
     const record = await assembleTurnRecord(trx, input);
-    if (!record) throw new TurnNotFoundError(input.turn_id);
+    if (!record) {
+      throw new TurnNotFoundError(input.turn_id);
+    }
     return record;
   });
 }
@@ -704,7 +718,9 @@ export async function updateTurnState(db: Kysely<Database>, input: UpdateTurnSta
         .where('turn_id', '=', input.turn_id)
         .executeTakeFirst();
 
-      if (!existing) throw new TurnNotFoundError(input.turn_id);
+      if (!existing) {
+        throw new TurnNotFoundError(input.turn_id);
+      }
       throw new TurnNotRunningError(input.turn_id, terminalTurnState(existing.state, input.turn_id));
     }
 

--- a/packages/trueforge/src/db/sqlite/session-store/queries/events.ts
+++ b/packages/trueforge/src/db/sqlite/session-store/queries/events.ts
@@ -24,7 +24,9 @@ import type { Database } from '../../types';
 import { classifyTurnFenceWriteFailure, type TurnKeys } from './turns';
 
 export async function appendToEvents(db: Kysely<Database>, input: AppendToEventsInput): Promise<void> {
-  if (input.events.length === 0) return;
+  if (input.events.length === 0) {
+    return;
+  }
 
   const keys: TurnKeys = {
     session_id: input.session_id,
@@ -130,11 +132,17 @@ export async function resolveAncestorChain(
       .where('session_id', '=', sessionId)
       .where('turn_id', '=', oldestId)
       .executeTakeFirst();
-    if (!oldest) break;
+    if (!oldest) {
+      break;
+    }
     const older = oldest.ancestor_ids.filter(id => !seen.has(id));
-    if (older.length === 0) break;
+    if (older.length === 0) {
+      break;
+    }
     chain.unshift(...older);
-    for (const id of older) seen.add(id);
+    for (const id of older) {
+      seen.add(id);
+    }
     oldestId = older[0];
   }
   return chain;

--- a/packages/trueforge/src/db/sqlite/session-store/queries/turns.ts
+++ b/packages/trueforge/src/db/sqlite/session-store/queries/turns.ts
@@ -192,7 +192,9 @@ async function assembleTurnRecord(
     .where('turn_id', '=', args.turn_id)
     .executeTakeFirst();
 
-  if (!turn) return undefined;
+  if (!turn) {
+    return undefined;
+  }
 
   // LEFT JOIN turn_thread + turn_thread_context ORDER BY pos to assemble context per thread.
   // Empty-context threads emit one row with null pos/append_id from the LEFT JOIN.
@@ -322,7 +324,9 @@ export async function createTurn(db: Kysely<Database>, input: CreateTurnInput): 
         .where('session_id', '=', input.session_id)
         .executeTakeFirst();
 
-      if (!locked) throw new SessionNotFoundError(input.session_id);
+      if (!locked) {
+        throw new SessionNotFoundError(input.session_id);
+      }
 
       // Step 2: bump session tip + optional title coalesce.
       let sessionUpdate = trx
@@ -392,7 +396,9 @@ export async function createTurn(db: Kysely<Database>, input: CreateTurnInput): 
           prevCheckpoint = first.turn_checkpoint;
 
           for (const row of prevRows) {
-            if (row.thread_id === null) continue;
+            if (row.thread_id === null) {
+              continue;
+            }
             if (row.thread_checkpoint === null || row.current_context_usage === null) {
               throw new SessionStoreInvariantError(`previous turn_thread row for ${row.thread_id} is incomplete`);
             }
@@ -613,7 +619,9 @@ export async function createTurn(db: Kysely<Database>, input: CreateTurnInput): 
       }[] = [];
 
       for (const capability of input.capability_states) {
-        if (capability.capability_state === null) continue;
+        if (capability.capability_state === null) {
+          continue;
+        }
         for (const [key, state] of Object.entries(capability.capability_state)) {
           capabilityStateRows.push({
             session_id: input.session_id,
@@ -631,8 +639,12 @@ export async function createTurn(db: Kysely<Database>, input: CreateTurnInput): 
       }
     });
   } catch (err) {
-    if (err instanceof SessionStoreNotFoundError || err instanceof SessionStoreConflictError) throw err;
-    if (isUniqueViolation(err)) throw new TurnAlreadyExistsError(input.turn.turn_id, { cause: err });
+    if (err instanceof SessionStoreNotFoundError || err instanceof SessionStoreConflictError) {
+      throw err;
+    }
+    if (isUniqueViolation(err)) {
+      throw new TurnAlreadyExistsError(input.turn.turn_id, { cause: err });
+    }
     throw err;
   }
 }
@@ -674,7 +686,9 @@ export async function freezeAndGetTurn(db: Kysely<Database>, input: FreezeAndGet
     }
 
     const record = await assembleTurnRecord(trx, input);
-    if (!record) throw new TurnNotFoundError(input.turn_id);
+    if (!record) {
+      throw new TurnNotFoundError(input.turn_id);
+    }
     return record;
   });
 }
@@ -764,7 +778,9 @@ export async function updateTurnState(db: Kysely<Database>, input: UpdateTurnSta
         .where('turn_id', '=', input.turn_id)
         .executeTakeFirst();
 
-      if (!existing) throw new TurnNotFoundError(input.turn_id);
+      if (!existing) {
+        throw new TurnNotFoundError(input.turn_id);
+      }
       throw new TurnNotRunningError(input.turn_id, terminalTurnState(existing.state, input.turn_id));
     }
 

--- a/packages/trueforge/src/frontend.ts
+++ b/packages/trueforge/src/frontend.ts
@@ -53,8 +53,12 @@ export function mountFrontend(app: OpenAPIHono, dir: string): boolean {
   const serveCompressed = every(compress(), serveWithCacheHeaders);
 
   const serveBuild: MiddlewareHandler = async (c, next) => {
-    if (isServerPath(c.req.path)) return next();
-    if (c.req.method !== 'GET' && c.req.method !== 'HEAD') return next();
+    if (isServerPath(c.req.path)) {
+      return next();
+    }
+    if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
+      return next();
+    }
     return serveCompressed(c, next);
   };
 

--- a/packages/trueforge/src/main.ts
+++ b/packages/trueforge/src/main.ts
@@ -310,7 +310,9 @@ try {
   if (configuration.NODE_ENV !== 'development') {
     let shuttingDown = false;
     const shutdown = async (signal: NodeJS.Signals) => {
-      if (shuttingDown) return;
+      if (shuttingDown) {
+        return;
+      }
       shuttingDown = true;
       logger.info(`Received ${signal}, draining connections before shutdown`);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Style-only ESLint enforcement and brace formatting; no logic or security behavior is intended to change.
> 
> **Overview**
> Enforces **braces on every control statement** (`if`, `else`, loops, etc.) by adding ESLint `curly: ['error', 'all']` in `eslint.config.mjs`.
> 
> The rest of the diff is **mechanical formatting** across frontend, local-sandbox, trueforge-core, trueforge DB/session code, and tests so existing single-line `if` bodies use block form. **No intended behavior changes.**
> 
> Also normalizes `NPM_CONFIG_PROVENANCE` in the release workflow to single quotes (style only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1122d356141d644f72afbdef1d88b5d159912c43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->