### PR TITLE
lint fix

### DIFF
--- a/packages/trueforge/src/frontend.ts
+++ b/packages/trueforge/src/frontend.ts
@@ -71,9 +71,15 @@ export function mountFrontend(app: OpenAPIHono, dir: string): boolean {
    * accept HTML keep their 404 rather than getting the shell as a fake asset.
    */
   const serveSpaFallback: MiddlewareHandler = async (c, next) => {
-    if (isServerPath(c.req.path)) return next();
-    if (c.req.method !== 'GET' && c.req.method !== 'HEAD') return next();
-    if (c.req.header('accept')?.includes('text/html') !== true) return next();
+    if (isServerPath(c.req.path)) {
+      return next();
+    }
+    if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
+      return next();
+    }
+    if (c.req.header('accept')?.includes('text/html') !== true) {
+      return next();
+    }
 
     const response = await serveAppShell(c, next);
     if (response instanceof Response) {


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting-only change to middleware guards with no logic or routing changes.
> 
> **Overview**
> Reformats the early-return guards in **`serveSpaFallback`** in `frontend.ts` so each condition uses a braced block instead of a single-line `return next()`, matching **`serveBuild`** in the same file and satisfying the linter. SPA fallback behavior is unchanged: API paths, non-GET/HEAD, and non-HTML requests still skip the shell; HTML navigations still get `index.html` with revalidate cache headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a14278bad33a1c09cd48664a74dc9960e2d07f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->