### PR TITLE
react-router-dom as main dep

### DIFF
--- a/.changeset/20260817184000-trueforge-ui-react-dom-router-deps.md
+++ b/.changeset/20260817184000-trueforge-ui-react-dom-router-deps.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Ship `react-dom` and `react-router-dom` as package dependencies instead of peers so consumers no longer need to install them separately.

--- a/packages/trueforge-ui/package.json
+++ b/packages/trueforge-ui/package.json
@@ -78,8 +78,7 @@
     "@assistant-ui/react": "^0.14.24",
     "@types/react": "*",
     "react": "^18 || ^19",
-    "react-dom": "^18 || ^19",
-    "react-router-dom": "^6 || ^7"
+    "react-dom": "^18 || ^19"
   },
   "peerDependenciesMeta": {
     "@assistant-ui/core": {
@@ -89,9 +88,6 @@
       "optional": true
     },
     "@types/react": {
-      "optional": true
-    },
-    "react-router-dom": {
       "optional": true
     }
   },
@@ -108,6 +104,7 @@
     "monaco-editor": "^0.56.0",
     "partial-json": "^0.1.7",
     "react-markdown": "^10.1.0",
+    "react-router-dom": "^6 || ^7",
     "react-syntax-highlighter": "^16.1.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0",
@@ -133,8 +130,6 @@
     "jsdom": "^24.1.3",
     "prettier": "^3.6.2",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "react-router-dom": "^7.18.2",
     "tailwindcss": "^4.3.2",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,9 +388,15 @@ importers:
       partial-json:
         specifier: ^0.1.7
         version: 0.1.7
+      react-dom:
+        specifier: ^18 || ^19
+        version: 19.2.8(react@19.2.8)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.8)(supports-color@8.1.1)
+      react-router-dom:
+        specifier: ^6 || ^7
+        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-syntax-highlighter:
         specifier: ^16.1.1
         version: 16.1.1(react@19.2.8)
@@ -461,12 +467,6 @@ importers:
       react:
         specifier: ^19.2.4
         version: 19.2.8
-      react-dom:
-        specifier: ^19.2.4
-        version: 19.2.8(react@19.2.8)
-      react-router-dom:
-        specifier: ^7.18.2
-        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.3


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no runtime logic edits; main caveat is possible duplicate `react-router-dom` versions if apps already depend on a different major.
> 
> **Overview**
> **`react-router-dom` is no longer an optional peer** on `@truefoundry/trueforge-ui`. It is a **direct `dependencies` entry** (`^6 || ^7`), and the optional `peerDependenciesMeta` entry for it is removed. Consumers get routing support from the UI package install without adding `react-router-dom` themselves.
> 
> **Dev and lockfile alignment:** `react-dom` and `react-router-dom` are dropped from the package’s `devDependencies` (workspace resolution still pulls them via `dependencies` / peers for tests). `pnpm-lock.yaml` records `react-router-dom` and `react-dom` under the trueforge-ui package’s production dependency tree.
> 
> A patch **changeset** documents the intent that routing (and related) deps are shipped with the package rather than as separate consumer installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d22ba0e2fc0430314ce017cecc9d4b70f02c41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->