### PR TITLE
chore: Clean up MCP server tokens when URL is updated

### DIFF
--- a/.changeset/20260818112000-clear-mcp-dcr-on-url-change.md
+++ b/.changeset/20260818112000-clear-mcp-dcr-on-url-change.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge': patch
+---
+
+Clear DCR OAuth tokens and pending authorizations when an MCP server URL changes, since the URL is the token audience.

--- a/packages/trueforge/src/apis/mcpServers.ts
+++ b/packages/trueforge/src/apis/mcpServers.ts
@@ -279,8 +279,9 @@ export function createSettingsMcpServersRouter<TTransaction>(deps: McpServersRou
           await deps.mcpServerStore.saveClient({ id: saved.id, record: dcrClientToSave }, transaction);
         }
         if (urlChanged) {
-          // URL is the OAuth resource/audience — drop every user's tokens for this server.
+          // URL is the OAuth resource/audience — drop every user's tokens and in-flight authorizes.
           await deps.tokenStore.deleteTokensForServer({ id: saved.id }, transaction);
+          await deps.tokenStore.deletePendingAuthorizationsForServer({ id: saved.id }, transaction);
         }
         return saved;
       });

--- a/packages/trueforge/src/apis/mcpServers.ts
+++ b/packages/trueforge/src/apis/mcpServers.ts
@@ -247,14 +247,14 @@ export function createSettingsMcpServersRouter<TTransaction>(deps: McpServersRou
         });
 
         let dcrClientToSave: OAuthClientRecord | undefined;
-        let clearTokensForServerId: string | undefined;
+        const urlChanged =
+          existing !== undefined && existing.manifest.url !== manifest.url && manifest.auth?.type === 'dcr';
         if (manifest.auth?.type === 'dcr') {
           const existingClient = existing
             ? await deps.mcpServerStore.getClient({ id: existing.id }, transaction)
             : undefined;
           // Register when: brand-new server, client was cleared (e.g. invalid_client), or MCP URL changed
           // (resource/AS may differ; reuse would keep stale oauth_server/client for the old AS).
-          const urlChanged = existing !== undefined && existing.manifest.url !== manifest.url;
           const needsDcr = existingClient === undefined || urlChanged;
           if (needsDcr) {
             dcrClientToSave = await createMcpOAuthClient({
@@ -263,10 +263,6 @@ export function createSettingsMcpServersRouter<TTransaction>(deps: McpServersRou
               redirectUri: mcpOAuthCallbackUrl(),
               clientName: configuration.MCP_DCR_OAUTH_CLIENT_NAME,
             });
-          }
-          // URL is the OAuth resource/audience — drop every user's tokens for this server.
-          if (urlChanged) {
-            clearTokensForServerId = existing.id;
           }
         }
 
@@ -282,8 +278,9 @@ export function createSettingsMcpServersRouter<TTransaction>(deps: McpServersRou
           // New DCR registration (create, missing client, or URL change): replace the shared client.
           await deps.mcpServerStore.saveClient({ id: saved.id, record: dcrClientToSave }, transaction);
         }
-        if (clearTokensForServerId) {
-          await deps.tokenStore.deleteTokensForServer({ id: clearTokensForServerId }, transaction);
+        if (urlChanged) {
+          // URL is the OAuth resource/audience — drop every user's tokens for this server.
+          await deps.tokenStore.deleteTokensForServer({ id: saved.id }, transaction);
         }
         return saved;
       });

--- a/packages/trueforge/src/apis/mcpServers.ts
+++ b/packages/trueforge/src/apis/mcpServers.ts
@@ -247,14 +247,14 @@ export function createSettingsMcpServersRouter<TTransaction>(deps: McpServersRou
         });
 
         let dcrClientToSave: OAuthClientRecord | undefined;
+        let clearTokensForServerId: string | undefined;
         if (manifest.auth?.type === 'dcr') {
           const existingClient = existing
             ? await deps.mcpServerStore.getClient({ id: existing.id }, transaction)
             : undefined;
           // Register when: brand-new server, client was cleared (e.g. invalid_client), or MCP URL changed
           // (resource/AS may differ; reuse would keep stale oauth_server/client for the old AS).
-          // TODO: make manifest URL immutable after create so re-DCR / stale OAuth tokens are not possible via PUT.
-          const urlChanged = existing && existing.manifest.url !== manifest.url;
+          const urlChanged = existing !== undefined && existing.manifest.url !== manifest.url;
           const needsDcr = existingClient === undefined || urlChanged;
           if (needsDcr) {
             dcrClientToSave = await createMcpOAuthClient({
@@ -263,6 +263,10 @@ export function createSettingsMcpServersRouter<TTransaction>(deps: McpServersRou
               redirectUri: mcpOAuthCallbackUrl(),
               clientName: configuration.MCP_DCR_OAUTH_CLIENT_NAME,
             });
+          }
+          // URL is the OAuth resource/audience — drop every user's tokens for this server.
+          if (urlChanged) {
+            clearTokensForServerId = existing.id;
           }
         }
 
@@ -275,15 +279,17 @@ export function createSettingsMcpServersRouter<TTransaction>(deps: McpServersRou
           transaction,
         );
         if (dcrClientToSave !== undefined) {
-          // New DCR registration (create, missing client, or URL change): replace the shared client only.
-          // Existing per-user tokens are left in place; resolve/refresh fails them if they no longer
-          // match the new resource/AS, and users re-authorize from there.
+          // New DCR registration (create, missing client, or URL change): replace the shared client.
           await deps.mcpServerStore.saveClient({ id: saved.id, record: dcrClientToSave }, transaction);
+        }
+        if (clearTokensForServerId) {
+          await deps.tokenStore.deleteTokensForServer({ id: clearTokensForServerId }, transaction);
         }
         return saved;
       });
 
-      // A re-upsert preserves `id`, so a DCR server may already carry a token from a prior authorize.
+      // A re-upsert preserves `id`, so a DCR server may already carry a token from a prior authorize
+      // (unless this PUT changed the URL and cleared all tokens above).
       const token =
         record.manifest.auth?.type === 'dcr' ? await deps.tokenStore.getToken({ id: record.id, userRef }) : undefined;
       return c.json({ data: toConfiguredMcpServer({ record, token }) }, 200);

--- a/packages/trueforge/src/db/postgres/token-store/PostgresOAuthTokenStore.ts
+++ b/packages/trueforge/src/db/postgres/token-store/PostgresOAuthTokenStore.ts
@@ -3,7 +3,7 @@ import type { IOAuthTokenStore, OAuthPendingAuthorization, OAuthToken, OAuthToke
 import { fromStoredOAuthToken, toStoredOAuthToken } from '../../mcpServerStore';
 import type { Database } from '../types';
 import { consumePendingAuthorization, savePendingAuthorization } from './queries/pendingAuthorization';
-import { deleteToken, getToken, getTokens, saveToken } from './queries/token';
+import { deleteToken, deleteTokensForServer, getToken, getTokens, saveToken } from './queries/token';
 
 export class PostgresOAuthTokenStore implements IOAuthTokenStore<Transaction<Database>> {
   constructor(private readonly db: Kysely<Database>) {}
@@ -42,5 +42,9 @@ export class PostgresOAuthTokenStore implements IOAuthTokenStore<Transaction<Dat
 
   deleteToken(params: OAuthTokenKey, transaction?: Transaction<Database>): Promise<void> {
     return deleteToken(transaction ?? this.db, params);
+  }
+
+  deleteTokensForServer(params: { id: string }, transaction?: Transaction<Database>): Promise<void> {
+    return deleteTokensForServer(transaction ?? this.db, params);
   }
 }

--- a/packages/trueforge/src/db/postgres/token-store/PostgresOAuthTokenStore.ts
+++ b/packages/trueforge/src/db/postgres/token-store/PostgresOAuthTokenStore.ts
@@ -2,7 +2,11 @@ import type { Kysely, Transaction } from 'kysely';
 import type { IOAuthTokenStore, OAuthPendingAuthorization, OAuthToken, OAuthTokenKey } from '../../../mcp/auth/types';
 import { fromStoredOAuthToken, toStoredOAuthToken } from '../../mcpServerStore';
 import type { Database } from '../types';
-import { consumePendingAuthorization, savePendingAuthorization } from './queries/pendingAuthorization';
+import {
+  consumePendingAuthorization,
+  deletePendingAuthorizationsForServer,
+  savePendingAuthorization,
+} from './queries/pendingAuthorization';
 import { deleteToken, deleteTokensForServer, getToken, getTokens, saveToken } from './queries/token';
 
 export class PostgresOAuthTokenStore implements IOAuthTokenStore<Transaction<Database>> {
@@ -46,5 +50,9 @@ export class PostgresOAuthTokenStore implements IOAuthTokenStore<Transaction<Dat
 
   deleteTokensForServer(params: { id: string }, transaction?: Transaction<Database>): Promise<void> {
     return deleteTokensForServer(transaction ?? this.db, params);
+  }
+
+  deletePendingAuthorizationsForServer(params: { id: string }, transaction?: Transaction<Database>): Promise<void> {
+    return deletePendingAuthorizationsForServer(transaction ?? this.db, params);
   }
 }

--- a/packages/trueforge/src/db/postgres/token-store/queries/pendingAuthorization.ts
+++ b/packages/trueforge/src/db/postgres/token-store/queries/pendingAuthorization.ts
@@ -52,3 +52,10 @@ export async function consumePendingAuthorization(
     ...fromStoredOAuthPendingAuthorizationData(row.auth_data),
   };
 }
+
+export async function deletePendingAuthorizationsForServer(
+  db: Kysely<Database>,
+  params: { id: string },
+): Promise<void> {
+  await db.deleteFrom('oauth_pending_authorization').where('oauth_server_id', '=', params.id).execute();
+}

--- a/packages/trueforge/src/db/postgres/token-store/queries/token.ts
+++ b/packages/trueforge/src/db/postgres/token-store/queries/token.ts
@@ -62,3 +62,7 @@ export async function deleteToken(db: Kysely<Database>, params: { id: string; us
     .where('user_id', '=', params.userRef)
     .execute();
 }
+
+export async function deleteTokensForServer(db: Kysely<Database>, params: { id: string }): Promise<void> {
+  await db.deleteFrom('oauth_token').where('oauth_server_id', '=', params.id).execute();
+}

--- a/packages/trueforge/src/db/sqlite/token-store/SqliteOAuthTokenStore.ts
+++ b/packages/trueforge/src/db/sqlite/token-store/SqliteOAuthTokenStore.ts
@@ -3,7 +3,7 @@ import type { IOAuthTokenStore, OAuthPendingAuthorization, OAuthToken, OAuthToke
 import { fromStoredOAuthToken, toStoredOAuthToken } from '../../mcpServerStore';
 import type { Database } from '../types';
 import { consumePendingAuthorization, savePendingAuthorization } from './queries/pendingAuthorization';
-import { deleteToken, getToken, getTokens, saveToken } from './queries/token';
+import { deleteToken, deleteTokensForServer, getToken, getTokens, saveToken } from './queries/token';
 
 export class SqliteOAuthTokenStore implements IOAuthTokenStore<Transaction<Database>> {
   constructor(private readonly db: Kysely<Database>) {}
@@ -42,5 +42,9 @@ export class SqliteOAuthTokenStore implements IOAuthTokenStore<Transaction<Datab
 
   deleteToken(params: OAuthTokenKey, transaction?: Transaction<Database>): Promise<void> {
     return deleteToken(transaction ?? this.db, params);
+  }
+
+  deleteTokensForServer(params: { id: string }, transaction?: Transaction<Database>): Promise<void> {
+    return deleteTokensForServer(transaction ?? this.db, params);
   }
 }

--- a/packages/trueforge/src/db/sqlite/token-store/SqliteOAuthTokenStore.ts
+++ b/packages/trueforge/src/db/sqlite/token-store/SqliteOAuthTokenStore.ts
@@ -2,7 +2,11 @@ import type { Kysely, Transaction } from 'kysely';
 import type { IOAuthTokenStore, OAuthPendingAuthorization, OAuthToken, OAuthTokenKey } from '../../../mcp/auth/types';
 import { fromStoredOAuthToken, toStoredOAuthToken } from '../../mcpServerStore';
 import type { Database } from '../types';
-import { consumePendingAuthorization, savePendingAuthorization } from './queries/pendingAuthorization';
+import {
+  consumePendingAuthorization,
+  deletePendingAuthorizationsForServer,
+  savePendingAuthorization,
+} from './queries/pendingAuthorization';
 import { deleteToken, deleteTokensForServer, getToken, getTokens, saveToken } from './queries/token';
 
 export class SqliteOAuthTokenStore implements IOAuthTokenStore<Transaction<Database>> {
@@ -46,5 +50,9 @@ export class SqliteOAuthTokenStore implements IOAuthTokenStore<Transaction<Datab
 
   deleteTokensForServer(params: { id: string }, transaction?: Transaction<Database>): Promise<void> {
     return deleteTokensForServer(transaction ?? this.db, params);
+  }
+
+  deletePendingAuthorizationsForServer(params: { id: string }, transaction?: Transaction<Database>): Promise<void> {
+    return deletePendingAuthorizationsForServer(transaction ?? this.db, params);
   }
 }

--- a/packages/trueforge/src/db/sqlite/token-store/queries/pendingAuthorization.ts
+++ b/packages/trueforge/src/db/sqlite/token-store/queries/pendingAuthorization.ts
@@ -58,3 +58,10 @@ export async function consumePendingAuthorization(
     ...fromStoredOAuthPendingAuthorizationData(row.auth_data),
   };
 }
+
+export async function deletePendingAuthorizationsForServer(
+  db: Kysely<Database>,
+  params: { id: string },
+): Promise<void> {
+  await db.deleteFrom('oauth_pending_authorization').where('oauth_server_id', '=', params.id).execute();
+}

--- a/packages/trueforge/src/db/sqlite/token-store/queries/token.ts
+++ b/packages/trueforge/src/db/sqlite/token-store/queries/token.ts
@@ -62,3 +62,7 @@ export async function deleteToken(db: Kysely<Database>, params: { id: string; us
     .where('user_id', '=', params.userRef)
     .execute();
 }
+
+export async function deleteTokensForServer(db: Kysely<Database>, params: { id: string }): Promise<void> {
+  await db.deleteFrom('oauth_token').where('oauth_server_id', '=', params.id).execute();
+}

--- a/packages/trueforge/src/mcp/auth/inMemoryStores.ts
+++ b/packages/trueforge/src/mcp/auth/inMemoryStores.ts
@@ -54,6 +54,15 @@ export class InMemoryOAuthTokenStore implements IOAuthTokenStore {
   async deleteToken(params: OAuthTokenKey): Promise<void> {
     this.tokens.delete(tokenMapKey(params));
   }
+
+  async deleteTokensForServer(params: { id: string }): Promise<void> {
+    const prefix = `${params.id}\0`;
+    for (const key of this.tokens.keys()) {
+      if (key.startsWith(prefix)) {
+        this.tokens.delete(key);
+      }
+    }
+  }
 }
 
 /** In-memory OAuth client store for tests and development without a database. */

--- a/packages/trueforge/src/mcp/auth/inMemoryStores.ts
+++ b/packages/trueforge/src/mcp/auth/inMemoryStores.ts
@@ -63,6 +63,14 @@ export class InMemoryOAuthTokenStore implements IOAuthTokenStore {
       }
     }
   }
+
+  async deletePendingAuthorizationsForServer(params: { id: string }): Promise<void> {
+    for (const [state, entry] of this.pending) {
+      if (entry.row.id === params.id) {
+        this.pending.delete(state);
+      }
+    }
+  }
 }
 
 /** In-memory OAuth client store for tests and development without a database. */

--- a/packages/trueforge/src/mcp/auth/types.ts
+++ b/packages/trueforge/src/mcp/auth/types.ts
@@ -34,6 +34,8 @@ export interface IOAuthTokenStore<TTransaction = never> {
   deleteToken(params: OAuthTokenKey, transaction?: TTransaction): Promise<void>;
   /** Deletes every per-user token for one MCP server id (all users). */
   deleteTokensForServer(params: { id: string }, transaction?: TTransaction): Promise<void>;
+  /** Deletes every in-flight authorization for one MCP server id (all users). */
+  deletePendingAuthorizationsForServer(params: { id: string }, transaction?: TTransaction): Promise<void>;
 }
 
 /** Authorization-server endpoints discovered and cached at registration time. */

--- a/packages/trueforge/src/mcp/auth/types.ts
+++ b/packages/trueforge/src/mcp/auth/types.ts
@@ -32,6 +32,8 @@ export interface IOAuthTokenStore<TTransaction = never> {
   getToken(params: OAuthTokenKey, transaction?: TTransaction): Promise<OAuthToken | undefined>;
   getTokens(params: { ids: string[]; userRef: string }, transaction?: TTransaction): Promise<Map<string, OAuthToken>>;
   deleteToken(params: OAuthTokenKey, transaction?: TTransaction): Promise<void>;
+  /** Deletes every per-user token for one MCP server id (all users). */
+  deleteTokensForServer(params: { id: string }, transaction?: TTransaction): Promise<void>;
 }
 
 /** Authorization-server endpoints discovered and cached at registration time. */

--- a/packages/trueforge/tests/db/oauthTokenStoreContractSuite.ts
+++ b/packages/trueforge/tests/db/oauthTokenStoreContractSuite.ts
@@ -186,6 +186,32 @@ export function runOAuthTokenStoreContractSuite(getHarness: () => OAuthTokenStor
     expect(await h.store.consumePendingAuthorization({ state: 'state-2' })).toEqual(other);
   });
 
+  it('deletePendingAuthorizationsForServer removes every pending row for that resource only', async () => {
+    const h = getHarness();
+    await h.seedResource(RESOURCE_ID);
+    await h.seedResource(OTHER_RESOURCE_ID);
+    const otherUser = pending({
+      state: 'state-other-user',
+      userRef: OTHER_USER_REF,
+      codeVerifier: 'verifier-other-user',
+    });
+    const otherServer = pending({
+      state: 'state-other-server',
+      id: OTHER_RESOURCE_ID,
+      userRef: USER_REF,
+      codeVerifier: 'verifier-other-server',
+    });
+    await h.store.savePendingAuthorization(pending());
+    await h.store.savePendingAuthorization(otherUser);
+    await h.store.savePendingAuthorization(otherServer);
+
+    await h.store.deletePendingAuthorizationsForServer({ id: RESOURCE_ID });
+
+    expect(await h.store.consumePendingAuthorization({ state: 'state-1' })).toBeUndefined();
+    expect(await h.store.consumePendingAuthorization({ state: 'state-other-user' })).toBeUndefined();
+    expect(await h.store.consumePendingAuthorization({ state: 'state-other-server' })).toEqual(otherServer);
+  });
+
   it('consumePendingAuthorization drops a row past its TTL', async () => {
     const h = getHarness();
     await h.seedResource(RESOURCE_ID);

--- a/packages/trueforge/tests/db/oauthTokenStoreContractSuite.ts
+++ b/packages/trueforge/tests/db/oauthTokenStoreContractSuite.ts
@@ -129,6 +129,22 @@ export function runOAuthTokenStoreContractSuite(getHarness: () => OAuthTokenStor
     expect(await h.store.getToken({ id: RESOURCE_ID, userRef: OTHER_USER_REF })).toEqual(forB);
   });
 
+  it('deleteTokensForServer removes every user token for that resource only', async () => {
+    const h = getHarness();
+    await h.seedResource(RESOURCE_ID);
+    await h.seedResource(OTHER_RESOURCE_ID);
+    const other = token({ accessToken: 'access-other' });
+    await h.store.saveToken({ id: RESOURCE_ID, userRef: USER_REF, token: token({ accessToken: 'access-a' }) });
+    await h.store.saveToken({ id: RESOURCE_ID, userRef: OTHER_USER_REF, token: token({ accessToken: 'access-b' }) });
+    await h.store.saveToken({ id: OTHER_RESOURCE_ID, userRef: USER_REF, token: other });
+
+    await h.store.deleteTokensForServer({ id: RESOURCE_ID });
+
+    expect(await h.store.getToken({ id: RESOURCE_ID, userRef: USER_REF })).toBeUndefined();
+    expect(await h.store.getToken({ id: RESOURCE_ID, userRef: OTHER_USER_REF })).toBeUndefined();
+    expect(await h.store.getToken({ id: OTHER_RESOURCE_ID, userRef: USER_REF })).toEqual(other);
+  });
+
   it('savePendingAuthorization + consumePendingAuthorization round-trips, including null fields', async () => {
     const h = getHarness();
     await h.seedResource(RESOURCE_ID);

--- a/packages/trueforge/tests/unit/apis/mcpServers.test.ts
+++ b/packages/trueforge/tests/unit/apis/mcpServers.test.ts
@@ -306,7 +306,7 @@ describe('mcp-servers routers', () => {
     await tokenStore.deleteToken({ id: record.id, userRef: LOCAL_USER_CONTEXT.userRef });
   });
 
-  it('PUT URL change re-registers DCR and clears all tokens', async () => {
+  it('PUT URL change re-registers DCR and clears tokens and pending authorizations', async () => {
     const record = await seedDcrServerWithClient();
     await tokenStore.saveToken({
       id: record.id,
@@ -327,6 +327,14 @@ describe('mcp-servers routers', () => {
         expiresAt: '2099-01-01T00:00:00.000Z',
         scope: null,
       },
+    });
+    await tokenStore.savePendingAuthorization({
+      state: 'stale-pending-state',
+      id: record.id,
+      userRef: LOCAL_USER_CONTEXT.userRef,
+      mcpServerUrl: putBodyWithDcr.url,
+      codeVerifier: 'stale-verifier',
+      redirectUrl: null,
     });
 
     const newUrl = 'https://mcp.linear.app/v2/mcp';
@@ -388,6 +396,7 @@ describe('mcp-servers routers', () => {
       });
       expect(await tokenStore.getToken({ id: record.id, userRef: LOCAL_USER_CONTEXT.userRef })).toBeUndefined();
       expect(await tokenStore.getToken({ id: record.id, userRef: 'other-user' })).toBeUndefined();
+      expect(await tokenStore.consumePendingAuthorization({ state: 'stale-pending-state' })).toBeUndefined();
       expect(await mcpServerStore.getClient({ id: record.id })).toMatchObject({
         client: { clientId: 'new-url-client' },
       });

--- a/packages/trueforge/tests/unit/apis/mcpServers.test.ts
+++ b/packages/trueforge/tests/unit/apis/mcpServers.test.ts
@@ -306,7 +306,7 @@ describe('mcp-servers routers', () => {
     await tokenStore.deleteToken({ id: record.id, userRef: LOCAL_USER_CONTEXT.userRef });
   });
 
-  it('PUT URL change re-registers DCR and keeps existing tokens', async () => {
+  it('PUT URL change re-registers DCR and clears all tokens', async () => {
     const record = await seedDcrServerWithClient();
     await tokenStore.saveToken({
       id: record.id,
@@ -314,6 +314,16 @@ describe('mcp-servers routers', () => {
       token: {
         accessToken: 'stale-for-old-url',
         refreshToken: 'stale-refresh',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        scope: null,
+      },
+    });
+    await tokenStore.saveToken({
+      id: record.id,
+      userRef: 'other-user',
+      token: {
+        accessToken: 'stale-other-user',
+        refreshToken: 'stale-other-refresh',
         expiresAt: '2099-01-01T00:00:00.000Z',
         scope: null,
       },
@@ -373,13 +383,11 @@ describe('mcp-servers routers', () => {
         ),
       );
       expect(response.status).toBe(200);
-      // List/GET auth_status is presence-based; tokens are not cleared on re-DCR.
       expect(await response.json()).toEqual({
-        data: configured({ ...putBodyWithDcr, url: newUrl }, 'authenticated'),
+        data: configured({ ...putBodyWithDcr, url: newUrl }, 'auth_required'),
       });
-      expect(await tokenStore.getToken({ id: record.id, userRef: LOCAL_USER_CONTEXT.userRef })).toMatchObject({
-        accessToken: 'stale-for-old-url',
-      });
+      expect(await tokenStore.getToken({ id: record.id, userRef: LOCAL_USER_CONTEXT.userRef })).toBeUndefined();
+      expect(await tokenStore.getToken({ id: record.id, userRef: 'other-user' })).toBeUndefined();
       expect(await mcpServerStore.getClient({ id: record.id })).toMatchObject({
         client: { clientId: 'new-url-client' },
       });
@@ -405,7 +413,6 @@ describe('mcp-servers routers', () => {
           },
         },
       });
-      await tokenStore.deleteToken({ id: record.id, userRef: LOCAL_USER_CONTEXT.userRef });
     }
   });
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth token lifecycle on MCP URL updates (auth-critical path); behavior is transactional and covered by updated tests, but users must re-authorize after URL edits.
> 
> **Overview**
> When a **DCR** MCP server’s URL is updated via settings **PUT**, the handler now treats the URL as the OAuth resource/audience and **wipes all stored tokens and in-flight pending authorizations** for that server (every user), in the same transaction as re-DCR and upsert.
> 
> **`IOAuthTokenStore`** gains **`deleteTokensForServer`** and **`deletePendingAuthorizationsForServer`**, implemented for Postgres, SQLite, and in-memory stores, with contract tests. PUT responses and API tests now expect **`auth_required`** after a URL change instead of carrying stale **`authenticated`** status from old tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7568fe0a01697221d4c82c111e85b57baf3df26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->