### PR TITLE
Exclude some apis from api reference docs

### DIFF
--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -4516,6 +4516,7 @@
         "tags": [
           "Auth"
         ],
+        "x-excluded": true,
         "x-fern-ignore": true
       }
     },
@@ -4543,6 +4544,7 @@
         "tags": [
           "Auth"
         ],
+        "x-excluded": true,
         "x-fern-ignore": true
       }
     },
@@ -4558,6 +4560,7 @@
         "tags": [
           "Auth"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "auth"
         ],
@@ -4593,6 +4596,7 @@
         "tags": [
           "Auth"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "auth"
         ],
@@ -4628,6 +4632,7 @@
         "tags": [
           "Capabilities"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "server"
         ],
@@ -4663,9 +4668,10 @@
         "tags": [
           "Catalog"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "catalog",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "list"
       }
@@ -4699,9 +4705,10 @@
         "tags": [
           "Catalog"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "catalog",
-          "modelProviders"
+          "model_providers"
         ],
         "x-fern-sdk-method-name": "list"
       }
@@ -4735,9 +4742,10 @@
         "tags": [
           "Catalog"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "catalog",
-          "sandboxProviders"
+          "sandbox_providers"
         ],
         "x-fern-sdk-method-name": "list"
       }
@@ -4771,6 +4779,7 @@
         "tags": [
           "Catalog"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "catalog",
           "skills"
@@ -4808,7 +4817,7 @@
           "MCP Servers"
         ],
         "x-fern-sdk-group-name": [
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "list"
       }
@@ -4911,6 +4920,7 @@
         "tags": [
           "MCP OAuth"
         ],
+        "x-excluded": true,
         "x-fern-ignore": true
       }
     },
@@ -4956,8 +4966,9 @@
         "tags": [
           "MCP Servers"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "delete_authorize"
       },
@@ -5053,8 +5064,9 @@
         "tags": [
           "MCP Servers"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "authorize"
       }
@@ -5084,7 +5096,7 @@
             "description": "OIDC is configured and the request has no valid session cookie."
           }
         },
-        "summary": "List models",
+        "summary": "List models for chat",
         "tags": [
           "Models"
         ],
@@ -6325,7 +6337,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "list"
       },
@@ -6389,7 +6401,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "create"
       },
@@ -6443,7 +6455,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "upsert"
       }
@@ -6492,7 +6504,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "get"
       }
@@ -6569,9 +6581,10 @@
         "tags": [
           "MCP Servers"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "settings",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "list_tools"
       }
@@ -6617,7 +6630,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "modelProviders"
+          "model_providers"
         ],
         "x-fern-sdk-method-name": "list"
       },
@@ -6671,7 +6684,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "modelProviders"
+          "model_providers"
         ],
         "x-fern-sdk-method-name": "create"
       },
@@ -6715,7 +6728,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "modelProviders"
+          "model_providers"
         ],
         "x-fern-sdk-method-name": "upsert"
       }
@@ -6751,7 +6764,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "sandboxProviders"
+          "sandbox_providers"
         ],
         "x-fern-sdk-method-name": "get"
       },
@@ -6805,7 +6818,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "sandboxProviders"
+          "sandbox_providers"
         ],
         "x-fern-sdk-method-name": "upsert"
       }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4516,6 +4516,7 @@
         "tags": [
           "Auth"
         ],
+        "x-excluded": true,
         "x-fern-ignore": true
       }
     },
@@ -4543,6 +4544,7 @@
         "tags": [
           "Auth"
         ],
+        "x-excluded": true,
         "x-fern-ignore": true
       }
     },
@@ -4558,6 +4560,7 @@
         "tags": [
           "Auth"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "auth"
         ],
@@ -4593,6 +4596,7 @@
         "tags": [
           "Auth"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "auth"
         ],
@@ -4628,6 +4632,7 @@
         "tags": [
           "Capabilities"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "server"
         ],
@@ -4663,9 +4668,10 @@
         "tags": [
           "Catalog"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "catalog",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "list"
       }
@@ -4699,9 +4705,10 @@
         "tags": [
           "Catalog"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "catalog",
-          "modelProviders"
+          "model_providers"
         ],
         "x-fern-sdk-method-name": "list"
       }
@@ -4735,9 +4742,10 @@
         "tags": [
           "Catalog"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "catalog",
-          "sandboxProviders"
+          "sandbox_providers"
         ],
         "x-fern-sdk-method-name": "list"
       }
@@ -4771,6 +4779,7 @@
         "tags": [
           "Catalog"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "catalog",
           "skills"
@@ -4808,7 +4817,7 @@
           "MCP Servers"
         ],
         "x-fern-sdk-group-name": [
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "list"
       }
@@ -4911,6 +4920,7 @@
         "tags": [
           "MCP OAuth"
         ],
+        "x-excluded": true,
         "x-fern-ignore": true
       }
     },
@@ -4956,8 +4966,9 @@
         "tags": [
           "MCP Servers"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "delete_authorize"
       },
@@ -5053,8 +5064,9 @@
         "tags": [
           "MCP Servers"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "authorize"
       }
@@ -5084,7 +5096,7 @@
             "description": "OIDC is configured and the request has no valid session cookie."
           }
         },
-        "summary": "List models",
+        "summary": "List models for chat",
         "tags": [
           "Models"
         ],
@@ -6325,7 +6337,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "list"
       },
@@ -6389,7 +6401,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "create"
       },
@@ -6443,7 +6455,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "upsert"
       }
@@ -6492,7 +6504,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "get"
       }
@@ -6569,9 +6581,10 @@
         "tags": [
           "MCP Servers"
         ],
+        "x-excluded": true,
         "x-fern-sdk-group-name": [
           "settings",
-          "mcpServers"
+          "mcp_servers"
         ],
         "x-fern-sdk-method-name": "list_tools"
       }
@@ -6617,7 +6630,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "modelProviders"
+          "model_providers"
         ],
         "x-fern-sdk-method-name": "list"
       },
@@ -6671,7 +6684,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "modelProviders"
+          "model_providers"
         ],
         "x-fern-sdk-method-name": "create"
       },
@@ -6715,7 +6728,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "modelProviders"
+          "model_providers"
         ],
         "x-fern-sdk-method-name": "upsert"
       }
@@ -6751,7 +6764,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "sandboxProviders"
+          "sandbox_providers"
         ],
         "x-fern-sdk-method-name": "get"
       },
@@ -6805,7 +6818,7 @@
         ],
         "x-fern-sdk-group-name": [
           "settings",
-          "sandboxProviders"
+          "sandbox_providers"
         ],
         "x-fern-sdk-method-name": "upsert"
       }

--- a/packages/trueforge/src/routes/authRoutes.ts
+++ b/packages/trueforge/src/routes/authRoutes.ts
@@ -20,6 +20,7 @@ export const authLoginRoute = createRoute({
     'Redirects the browser to the configured identity provider. In local/single-binary mode, redirects straight ' +
     'back into the app — there is nothing to log into.',
   'x-fern-ignore': true,
+  'x-excluded': true,
   request: { query: AuthLoginQuerySchema },
   responses: {
     302: { description: 'Redirect to the IdP authorization endpoint.' },
@@ -35,6 +36,7 @@ export const oAuthCallbackRoute = createRoute({
     'Browser-redirect target hit by the identity provider after login, never called directly by SDK consumers. ' +
     'In local/single-binary mode, redirects straight back into the app.',
   'x-fern-ignore': true,
+  'x-excluded': true,
   request: { query: OAuthCallbackQuerySchema },
   responses: {
     302: { description: 'Redirect back into the app on success, or to /?error=<reason> on failure.' },
@@ -51,6 +53,7 @@ export const authLogoutRoute = createRoute({
     'mode, since there is no real session to clear.',
   'x-fern-sdk-group-name': ['auth'],
   'x-fern-sdk-method-name': 'logout',
+  'x-excluded': true,
   responses: {
     204: { description: 'Session cookie cleared.' },
   },
@@ -67,6 +70,7 @@ export const meRoute = createRoute({
     'returns the default identity.',
   'x-fern-sdk-group-name': ['auth'],
   'x-fern-sdk-method-name': 'me',
+  'x-excluded': true,
   responses: {
     200: {
       content: { 'application/json': { schema: MeResponseSchema } },

--- a/packages/trueforge/src/routes/capabilityRoutes.ts
+++ b/packages/trueforge/src/routes/capabilityRoutes.ts
@@ -27,6 +27,7 @@ export const getCapabilitiesRoute = createRoute({
   summary: 'Get server capabilities',
   'x-fern-sdk-group-name': ['server'],
   'x-fern-sdk-method-name': 'get_capabilities',
+  'x-excluded': true,
   description: 'Report optional runtime capabilities available for this tenant.',
   responses: {
     200: {

--- a/packages/trueforge/src/routes/catalogRoutes.ts
+++ b/packages/trueforge/src/routes/catalogRoutes.ts
@@ -19,8 +19,9 @@ export const listModelProviderCatalogRoute = createRoute({
   description:
     'Shipped model-provider presets (discovery-only). Copy into PUT /settings/model-providers to configure. ' +
     'Includes a `custom` sentinel with `supported_reasoning_efforts`.',
-  'x-fern-sdk-group-name': ['catalog', 'modelProviders'],
+  'x-fern-sdk-group-name': ['catalog', 'model_providers'],
   'x-fern-sdk-method-name': 'list',
+  'x-excluded': true,
   responses: {
     200: {
       content: { 'application/json': { schema: GetModelProviderCatalogResponseSchema } },
@@ -39,8 +40,9 @@ export const listMcpServerCatalogRoute = createRoute({
   tags: [CATALOG_TAG],
   summary: 'Get the MCP catalog',
   description: 'Shipped MCP server presets (discovery-only). Copy into PUT /settings/mcp-servers to configure.',
-  'x-fern-sdk-group-name': ['catalog', 'mcpServers'],
+  'x-fern-sdk-group-name': ['catalog', 'mcp_servers'],
   'x-fern-sdk-method-name': 'list',
+  'x-excluded': true,
   responses: {
     200: {
       content: { 'application/json': { schema: GetMcpServerCatalogResponseSchema } },
@@ -61,6 +63,7 @@ export const listSkillCatalogRoute = createRoute({
   description: 'Shipped skill presets (discovery-only). Copy into PUT /settings/skills to configure.',
   'x-fern-sdk-group-name': ['catalog', 'skills'],
   'x-fern-sdk-method-name': 'list',
+  'x-excluded': true,
   responses: {
     200: {
       content: { 'application/json': { schema: GetSkillCatalogResponseSchema } },
@@ -80,8 +83,9 @@ export const listSandboxProviderCatalogRoute = createRoute({
   summary: 'Get the sandbox provider catalog',
   description:
     'Shipped sandbox-provider presets (discovery-only). Copy into PUT /settings/sandbox-providers to configure.',
-  'x-fern-sdk-group-name': ['catalog', 'sandboxProviders'],
+  'x-fern-sdk-group-name': ['catalog', 'sandbox_providers'],
   'x-fern-sdk-method-name': 'list',
+  'x-excluded': true,
   responses: {
     200: {
       content: { 'application/json': { schema: GetSandboxProviderCatalogResponseSchema } },

--- a/packages/trueforge/src/routes/mcpOAuthRoutes.ts
+++ b/packages/trueforge/src/routes/mcpOAuthRoutes.ts
@@ -15,6 +15,7 @@ export const mcpOAuthCallbackRoute = createRoute({
     'Not called by the SDK — browsers hit this URL directly.',
   // Browser-redirect target hit directly by the authorization server, never called by SDK.
   'x-fern-ignore': true,
+  'x-excluded': true,
   request: {
     query: OAuthCallbackQuerySchema,
   },

--- a/packages/trueforge/src/routes/mcpServerRoutes.ts
+++ b/packages/trueforge/src/routes/mcpServerRoutes.ts
@@ -23,7 +23,7 @@ export const listAvailableMcpServersRoute = createRoute({
   tags: [MCP_SERVERS_TAG],
   summary: 'List MCP servers for chat',
   description: 'MCP servers as a slim name/url list for the composer. No auth or auth_status.',
-  'x-fern-sdk-group-name': ['mcpServers'],
+  'x-fern-sdk-group-name': ['mcp_servers'],
   'x-fern-sdk-method-name': 'list',
   responses: {
     200: {
@@ -44,7 +44,7 @@ export const listMcpServersRoute = createRoute({
   summary: 'List MCP servers',
   description:
     'All MCP servers with nested auth_status (settings / admin projection). Header auth values are redacted.',
-  'x-fern-sdk-group-name': ['settings', 'mcpServers'],
+  'x-fern-sdk-group-name': ['settings', 'mcp_servers'],
   'x-fern-sdk-method-name': 'list',
   responses: {
     200: {
@@ -73,7 +73,7 @@ export const getMcpServerRoute = createRoute({
   summary: 'Get a single MCP server by name',
   description:
     'A single MCP server by name, with nested auth_status (settings / admin projection). Header auth values are redacted.',
-  'x-fern-sdk-group-name': ['settings', 'mcpServers'],
+  'x-fern-sdk-group-name': ['settings', 'mcp_servers'],
   'x-fern-sdk-method-name': 'get',
   request: {
     params: McpServerNameParamsSchema,
@@ -98,7 +98,7 @@ export const createMcpServerRoute = createRoute({
   description:
     'Creates an MCP server by `name`. Fails if `name` is already taken. Runs DCR registration when `auth.type` is `dcr`. ' +
     'Header secrets: real value required; redacted with no stored value returns 400.',
-  'x-fern-sdk-group-name': ['settings', 'mcpServers'],
+  'x-fern-sdk-group-name': ['settings', 'mcp_servers'],
   'x-fern-sdk-method-name': 'create',
   request: {
     body: {
@@ -134,7 +134,7 @@ export const putMcpServerRoute = createRoute({
   description:
     'Create or replace by `name`. Does not start DCR or change oauth client columns. ' +
     'Header secrets: real value sets/rotates; redacted keeps existing (400 if none).',
-  'x-fern-sdk-group-name': ['settings', 'mcpServers'],
+  'x-fern-sdk-group-name': ['settings', 'mcp_servers'],
   'x-fern-sdk-method-name': 'upsert',
   request: {
     body: {
@@ -172,8 +172,9 @@ export const listMcpServerToolsRoute = createRoute({
   path: '/{name}/tools',
   tags: [MCP_SERVERS_TAG],
   summary: 'List tools of an MCP server',
-  'x-fern-sdk-group-name': ['settings', 'mcpServers'],
+  'x-fern-sdk-group-name': ['settings', 'mcp_servers'],
   'x-fern-sdk-method-name': 'list_tools',
+  'x-excluded': true,
   description: 'All tools exposed by the given MCP server (non-paginated), as returned by the MCP `tools/list` call.',
   request: {
     params: McpServerNameParamsSchema,
@@ -214,8 +215,9 @@ export const authorizeMcpServerRoute = createRoute({
   path: '/{name}/authorize',
   tags: [MCP_SERVERS_TAG],
   summary: 'Start (or short-circuit) the auth flow for an MCP server',
-  'x-fern-sdk-group-name': ['mcpServers'],
+  'x-fern-sdk-group-name': ['mcp_servers'],
   'x-fern-sdk-method-name': 'authorize',
+  'x-excluded': true,
   description:
     'For servers without auth returns not_required, and for header credentials returns authenticated ' +
     '(no browser flow). For auth.type dcr, returns authenticated when a usable (or refreshable) token ' +
@@ -258,8 +260,9 @@ export const deleteAuthorizeMcpServerRoute = createRoute({
   path: '/{name}/authorize',
   tags: [MCP_SERVERS_TAG],
   summary: 'Disconnect OAuth for an MCP server',
-  'x-fern-sdk-group-name': ['mcpServers'],
+  'x-fern-sdk-group-name': ['mcp_servers'],
   'x-fern-sdk-method-name': 'delete_authorize',
+  'x-excluded': true,
   description:
     'For auth.type dcr, deletes the stored OAuth token and returns the server with auth_status ' +
     'auth_required, keeping the dynamically registered OAuth client so the next authorize can reuse it. ' +

--- a/packages/trueforge/src/routes/modelProviderRoutes.ts
+++ b/packages/trueforge/src/routes/modelProviderRoutes.ts
@@ -20,7 +20,7 @@ export const listModelProvidersRoute = createRoute({
   tags: [MODEL_PROVIDERS_TAG],
   summary: 'List configured model providers',
   description: 'All configured providers with nested manifests.',
-  'x-fern-sdk-group-name': ['settings', 'modelProviders'],
+  'x-fern-sdk-group-name': ['settings', 'model_providers'],
   'x-fern-sdk-method-name': 'list',
   responses: {
     200: {
@@ -46,7 +46,7 @@ export const createModelProviderRoute = createRoute({
   description:
     'Creates a provider (models included). Fails if `name` is already taken. Well-known types use `type` as `name` (one each); ' +
     '`custom` is named by the caller. `auth.api_key`: real value required; redacted with no stored secret returns 400.',
-  'x-fern-sdk-group-name': ['settings', 'modelProviders'],
+  'x-fern-sdk-group-name': ['settings', 'model_providers'],
   'x-fern-sdk-method-name': 'create',
   request: {
     body: {
@@ -78,7 +78,7 @@ export const putModelProviderRoute = createRoute({
   description:
     'Create or replace a provider (models included). Well-known types use `type` as `name` (one each); ' +
     '`custom` is named by the caller. `auth.api_key`: real value sets/rotates; redacted keeps existing (400 if none).',
-  'x-fern-sdk-group-name': ['settings', 'modelProviders'],
+  'x-fern-sdk-group-name': ['settings', 'model_providers'],
   'x-fern-sdk-method-name': 'upsert',
   request: {
     body: {

--- a/packages/trueforge/src/routes/modelRoutes.ts
+++ b/packages/trueforge/src/routes/modelRoutes.ts
@@ -6,7 +6,7 @@ export const listModelsRoute = createRoute({
   method: 'get',
   path: '/',
   tags: ['Models'],
-  summary: 'List models',
+  summary: 'List models for chat',
   'x-fern-sdk-group-name': ['models'],
   'x-fern-sdk-method-name': 'list',
   description: 'Models across all configured model providers, addressed by fully qualified name `name/model_name`.',

--- a/packages/trueforge/src/routes/sandboxProviderRoutes.ts
+++ b/packages/trueforge/src/routes/sandboxProviderRoutes.ts
@@ -15,7 +15,7 @@ export const getSandboxProviderRoute = createRoute({
   tags: [SANDBOX_PROVIDERS_TAG],
   summary: 'Get the configured sandbox provider',
   description: 'The single configured sandbox provider for this tenant. `auth.api_key` is redacted.',
-  'x-fern-sdk-group-name': ['settings', 'sandboxProviders'],
+  'x-fern-sdk-group-name': ['settings', 'sandbox_providers'],
   'x-fern-sdk-method-name': 'get',
   responses: {
     200: {
@@ -37,7 +37,7 @@ export const putSandboxProviderRoute = createRoute({
   description:
     'Upserts the single sandbox provider for this tenant: creates it or replaces its entire configuration. ' +
     '`auth.api_key`: real value sets/rotates; redacted keeps existing (400 if none).',
-  'x-fern-sdk-group-name': ['settings', 'sandboxProviders'],
+  'x-fern-sdk-group-name': ['settings', 'sandbox_providers'],
   'x-fern-sdk-method-name': 'upsert',
   request: {
     body: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only OpenAPI/Fern annotations with no server handler or contract changes; main follow-up is regenerating SDKs/docs if consumers relied on old camelCase group names.
> 
> **Overview**
> Marks a set of OpenAPI operations with **`x-excluded: true`** so they drop out of the public API reference while remaining in the spec. Covered areas include **auth** (login/callback/logout/me), **capabilities**, **catalog** discovery endpoints, **MCP OAuth** callback, MCP **authorize** / disconnect flows, and **list MCP server tools**.
> 
> **Fern SDK grouping** is normalized from camelCase to snake_case (`mcp_servers`, `model_providers`, `sandbox_providers`) across route definitions and the generated OpenAPI copies in `docs/` and `.github/fern/`.
> 
> Two operation summaries are clarified: list models is labeled **“List models for chat”** (composer-facing list vs settings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7f8467b6c3a8cd9e6f714c178346a05bf2c6073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->