### PR TITLE
Use harness-scoped JFrog secrets in publish workflows

### DIFF
--- a/.github/workflows/build-and-prepare-chart-release.yml
+++ b/.github/workflows/build-and-prepare-chart-release.yml
@@ -112,8 +112,8 @@ jobs:
       enable_jfrog: true
       enable_public_ecr: false
     secrets:
-      artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
-      artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+      artifactory_username: ${{ secrets.TRUEFORGE_ARTIFACTORY_USERNAME }}
+      artifactory_password: ${{ secrets.TRUEFORGE_ARTIFACTORY_PASSWORD }}
 
   open-chart-pr:
     name: Open chart release PR

--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -30,8 +30,8 @@ jobs:
       enable_jfrog: true
       enable_public_ecr: false
     secrets:
-      artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
-      artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+      artifactory_username: ${{ secrets.TRUEFORGE_ARTIFACTORY_USERNAME }}
+      artifactory_password: ${{ secrets.TRUEFORGE_ARTIFACTORY_PASSWORD }}
 
   summary:
     name: Print image URI

--- a/.github/workflows/push-sandbox-image.yml
+++ b/.github/workflows/push-sandbox-image.yml
@@ -31,8 +31,8 @@ jobs:
       enable_jfrog: true
       enable_public_ecr: false
     secrets:
-      artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
-      artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+      artifactory_username: ${{ secrets.TRUEFORGE_ARTIFACTORY_USERNAME }}
+      artifactory_password: ${{ secrets.TRUEFORGE_ARTIFACTORY_PASSWORD }}
 
   print-uri:
     name: Print pushed image URI

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -132,8 +132,8 @@ jobs:
 
       - name: Helm registry login
         env:
-          HELM_REGISTRY_USERNAME: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
-          HELM_REGISTRY_PASSWORD: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+          HELM_REGISTRY_USERNAME: ${{ secrets.TRUEFORGE_ARTIFACTORY_USERNAME }}
+          HELM_REGISTRY_PASSWORD: ${{ secrets.TRUEFORGE_ARTIFACTORY_PASSWORD }}
         run: |
           printf '%s' "$HELM_REGISTRY_PASSWORD" \
             | helm registry login -u "$HELM_REGISTRY_USERNAME" --password-stdin "$HELM_REGISTRY_URL"


### PR DESCRIPTION
## Summary
Use harness-scoped JFrog secrets in publish workflows

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`)
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong or missing repo secrets will break prod/dev/sandbox image pushes and Helm chart publish until credentials are configured; no application runtime code changes.
> 
> **Overview**
> **JFrog credentials** for image and Helm publish jobs now use `TRUEFORGE_ARTIFACTORY_USERNAME` and `TRUEFORGE_ARTIFACTORY_PASSWORD` instead of the public `TRUEFOUNDRY_ARTIFACTORY_PUBLIC_*` secrets.
> 
> The swap applies to **build-and-prepare-chart-release**, **build-dev-image**, **push-sandbox-image** (shared `build.yml` secrets), and **release-chart** (Helm registry login). Registry URLs and repository vars are unchanged; only which GitHub secrets supply auth changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a19c913a5d34533f78d299453f49462211a2b96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->