### PR TITLE
Pin mcp 1.x in the sandbox image for Code Mode types

### DIFF
--- a/.changeset/sandbox-mcp-types-pin.md
+++ b/.changeset/sandbox-mcp-types-pin.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-core': patch
+---
+
+Pin `mcp==1.29.0` in the sandbox image so Code Mode can import `mcp.types`.

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -4185,7 +4185,7 @@
   "info": {
     "description": "HTTP API for the TrueForge agent server (`/api/v1`). Interactive docs are served at `/api/v1/docs` (OpenAPI JSON at `/api/v1/openapi.json`).\n\n**Authentication:** Standalone deployments (no OIDC) accept requests without credentials — middleware stamps a local default user. When OIDC is configured, protected routes require a valid `id_token` cookie or `Authorization: Bearer` ID token. There is no built-in API-key scheme; pass custom headers only if your reverse proxy or IdP layer requires them.\n\nCovers DB-backed sessions, the agent registry, settings catalogs, and model/MCP/skill/sandbox providers.",
     "title": "TrueForge API",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4185,7 +4185,7 @@
   "info": {
     "description": "HTTP API for the TrueForge agent server (`/api/v1`). Interactive docs are served at `/api/v1/docs` (OpenAPI JSON at `/api/v1/openapi.json`).\n\n**Authentication:** Standalone deployments (no OIDC) accept requests without credentials — middleware stamps a local default user. When OIDC is configured, protected routes require a valid `id_token` cookie or `Authorization: Bearer` ID token. There is no built-in API-key scheme; pass custom headers only if your reverse proxy or IdP layer requires them.\n\nCovers DB-backed sessions, the agent registry, settings catalogs, and model/MCP/skill/sandbox providers.",
     "title": "TrueForge API",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/packages/trueforge-core/scripts/sandbox/sandbox.Dockerfile
+++ b/packages/trueforge-core/scripts/sandbox/sandbox.Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
       && python -m pip install --no-cache-dir \
         aiohttp==3.14.1 \
         genson==1.3.0 \
+        mcp==1.29.0 \
         nats-py==2.15.0 \
         openpyxl==3.1.5 \
         pandas==3.0.5 \

--- a/packages/trueforge-core/src/core/sandbox/scripts/mcp_client.py
+++ b/packages/trueforge-core/src/core/sandbox/scripts/mcp_client.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # /// script
-# dependencies = ["pydantic==2.12.5", "nats-py==2.15.0"]
+# dependencies = ["mcp==1.29.0", "pydantic==2.12.5", "nats-py==2.15.0"]
 # ///
 
 import os


### PR DESCRIPTION
## Summary

Pin `mcp==1.29.0` in the sandbox image so Code Mode can import `mcp.types`. NATS is unchanged (`nats-py`); this only restores the types package FastMCP used to pull in.

Closes [AGE-1884](https://linear.app/truefoundry/issue/AGE-1884/pin-mcp-1x-in-the-sandbox-image-for-code-mode-types)

## Changes

- Add `mcp==1.29.0` to `packages/trueforge-core/scripts/sandbox/sandbox.Dockerfile`
- Match the PEP 723 comment in `mcp_client.py`

## How was this tested?

- Confirmed `mcp==1.29.0` is the 1.x pin (`mcp.types.CallToolResult` / `Tool` / `TextContent`); did not rebuild or push the sandbox image in this PR

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense — N/A (image pin only)
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed — N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change to the sandbox image and script metadata; no API or auth logic changes. Risk is mainly that a rebuilt image is required for the fix to apply in production.
> 
> **Overview**
> Restores **`mcp==1.29.0`** in the sandbox runtime so Code Mode scripts (notably **`mcp_client.py`**) can import **`mcp.types`** (`CallToolResult`, `Tool`, `TextContent`) after those types stopped being pulled in transitively via FastMCP.
> 
> The pin is added to **`sandbox.Dockerfile`** pip installs and aligned with the PEP 723 dependency block in **`mcp_client.py`**. NATS (`nats-py`) is unchanged. OpenAPI metadata bumps to **0.1.2** and a patch changeset for `@truefoundry/trueforge-core` are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f0442a288e706d3363ad1dbc2d5f620a181f17d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->