### PR TITLE
Pass tenantName on SandboxOptions instead of TFY_TENANT_NAME

### DIFF
--- a/.changeset/sandbox-tenant-name-option.md
+++ b/.changeset/sandbox-tenant-name-option.md
@@ -1,0 +1,6 @@
+---
+'@truefoundry/trueforge-core': patch
+'@truefoundry/trueforge': patch
+---
+
+Pass `tenantName` on `SandboxOptions` instead of injecting `TFY_TENANT_NAME` via exec env.

--- a/packages/trueforge-core/src/core/sandbox/Sandbox.ts
+++ b/packages/trueforge-core/src/core/sandbox/Sandbox.ts
@@ -94,7 +94,7 @@ export interface SandboxOptions {
   /** Used to derive the Code Mode NATS wait as request + connect. */
   mcpRequestTimeoutMs: number;
   mcpConnectTimeoutMs: number;
-  execExtraEnv?: Readonly<Record<string, string>> | undefined;
+  tenantName: string;
   tracing: AgentTracing;
   logger: Logger;
 }
@@ -143,13 +143,11 @@ function injectTraceContextEnv(): Record<string, string> {
 function injectMCPClientEnv(params: {
   env?: Record<string, string> | undefined;
   mcpServers: Record<string, SandboxMcpServerConfig>;
-  execExtraEnv?: Readonly<Record<string, string>> | undefined;
   codeModeEnv?: Record<string, string> | undefined;
 }): Record<string, string> {
   const codeModeEnv = params.codeModeEnv ?? {};
   const hasCodeModeTransport = Object.keys(codeModeEnv).length > 0;
   return {
-    ...(params.execExtraEnv ?? {}),
     ...(params.env ?? {}),
     PYTHONPATH: MCP_CLIENT_DIR,
     ...(Object.keys(params.mcpServers).length > 0 && {
@@ -207,7 +205,6 @@ export class Sandbox extends LocalToolMCP {
   private codeExecToolSets: readonly IToolSet[] = [];
   private readonly fileDownloadEnabled: boolean;
   private readonly requestTimeoutSeconds: number;
-  private readonly execExtraEnv?: Readonly<Record<string, string>> | undefined;
   private readonly skillMounter?: ISkillMounter | undefined;
   private cachedSkillsSection?: string | undefined;
   private readonly mcpClientScriptBase64: string;
@@ -230,12 +227,11 @@ export class Sandbox extends LocalToolMCP {
     super({ tracing: options.tracing });
     this.provider = options.provider;
     this.existingSandboxId = options.existingSandboxId;
-    this.tenantName = options.execExtraEnv?.['TFY_TENANT_NAME'] ?? '';
+    this.tenantName = options.tenantName;
     this.skillMounter = options.skillMounter;
     this.fileDownloadEnabled = options.fileDownloadEnabled ?? false;
     const mcpBoundTimeoutMs = options.mcpRequestTimeoutMs + options.mcpConnectTimeoutMs;
     this.requestTimeoutSeconds = Math.ceil(mcpBoundTimeoutMs / 1000) + NATS_REQUEST_TIMEOUT_BUFFER_SECONDS;
-    this.execExtraEnv = options.execExtraEnv;
     // Scripts are internal to Sandbox: the upload paths, env contract, and prompt
     // text are all hardcoded here, so injecting different content was never a
     // real extension point. Consumers don't see or provide them.
@@ -490,7 +486,6 @@ export class Sandbox extends LocalToolMCP {
     const mcpClientEnv = injectMCPClientEnv({
       env: input.env,
       mcpServers: this.buildMcpServersEnvelope(),
-      execExtraEnv: this.execExtraEnv,
       codeModeEnv,
     });
     const gitAuthEnv =

--- a/packages/trueforge-core/tests/core/harnessMocks.ts
+++ b/packages/trueforge-core/tests/core/harnessMocks.ts
@@ -73,7 +73,7 @@ export function makeStubPublicSandbox(tenantName = 'test-tenant'): Sandbox {
     blockDestructiveToolsInCodeMode: true,
     mcpRequestTimeoutMs: 60_000,
     mcpConnectTimeoutMs: 5_000,
-    execExtraEnv: { TFY_TENANT_NAME: tenantName },
+    tenantName,
     logger: makeSilentLogger(),
     tracing: NOOP_AGENT_TRACING,
   });

--- a/packages/trueforge-core/tests/core/sandbox/sandboxBridgeTimeout.test.ts
+++ b/packages/trueforge-core/tests/core/sandbox/sandboxBridgeTimeout.test.ts
@@ -42,7 +42,7 @@ function makeSandbox(options: {
       blockDestructiveToolsInCodeMode: true,
       mcpRequestTimeoutMs: options.mcpRequestTimeoutMs,
       mcpConnectTimeoutMs: options.mcpConnectTimeoutMs,
-      execExtraEnv: { TFY_TENANT_NAME: 'test-tenant' },
+      tenantName: 'test-tenant',
       logger: makeSilentLogger(),
       tracing: NOOP_AGENT_TRACING,
     }),

--- a/packages/trueforge/src/runtime/sessionResources.ts
+++ b/packages/trueforge/src/runtime/sessionResources.ts
@@ -252,9 +252,7 @@ export function buildTurnSandbox(input: {
     blockDestructiveToolsInCodeMode: true,
     mcpRequestTimeoutMs: configuration.MCP_REQUEST_TIMEOUT_MS,
     mcpConnectTimeoutMs: configuration.MCP_CONNECT_TIMEOUT_MS,
-    // Sandbox reads its tenant from TFY_TENANT_NAME for the ownership check
-    // against provider-created sandbox ids (`<tenant>.<uuid>`).
-    execExtraEnv: { TFY_TENANT_NAME: input.tenantName },
+    tenantName: input.tenantName,
     ...(skillMounter ? { skillMounter } : {}),
     tracing: input.tracing,
     logger: input.logger,


### PR DESCRIPTION
## Summary

Pass `tenantName` on `SandboxOptions` for sandbox ownership checks instead of injecting `TFY_TENANT_NAME` into exec env.

Closes AGE-1853

## Changes

- Add required `tenantName` to `SandboxOptions`; remove `execExtraEnv` / `TFY_TENANT_NAME`

## How was this tested?

Sandbox unit tests updated; `pnpm --filter @truefoundry/trueforge-core test -- tests/core/sandbox/sandboxBridgeTimeout.test.ts`

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tenant ownership validation still depends on the same string, but the configuration surface changed (required field, no exec env); any external Sandbox constructor or reliance on TFY_TENANT_NAME inside the sandbox would break.
> 
> **Overview**
> **Sandbox tenant identity** is now a required `tenantName` field on `SandboxOptions` instead of optional `execExtraEnv` carrying `TFY_TENANT_NAME`.
> 
> The `Sandbox` class still uses that value for `validateSandboxOwnedByTenant` on existing and newly created sandbox IDs (`<tenant>.<uuid>`), but **tenant name is no longer merged into sandbox exec environment** via `injectMCPClientEnv`. Runtime wiring in `buildTurnSandbox` and test helpers pass `tenantName` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50105a385b0d7c796aaf2e14285ac24363dfc4c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->