### PR TITLE
Rename MCP SDK method deleteAuthorize to deleteAuthorization

### DIFF
--- a/.changeset/20260818123823-delete-authorization-sdk-method.md
+++ b/.changeset/20260818123823-delete-authorization-sdk-method.md
@@ -1,0 +1,6 @@
+---
+'@truefoundry/trueforge': patch
+'@truefoundry/trueforge-ui': patch
+---
+
+Rename the MCP servers SDK method from `deleteAuthorize` to `deleteAuthorization`.

--- a/.changeset/20260818124401-regenerate-sdk-from-openapi.md
+++ b/.changeset/20260818124401-regenerate-sdk-from-openapi.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-sdk': patch
+---
+
+Regenerate SDK from updated OpenAPI spec.

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -4959,7 +4959,7 @@
         "x-fern-sdk-group-name": [
           "mcpServers"
         ],
-        "x-fern-sdk-method-name": "delete_authorize"
+        "x-fern-sdk-method-name": "delete_authorization"
       },
       "get": {
         "description": "For servers without auth returns not_required, and for header credentials returns authenticated (no browser flow). For auth.type dcr, returns authenticated when a usable (or refreshable) token exists; otherwise runs DCR if needed and returns auth_required with an authorization URL. Optional redirect_url is where the OAuth callback then redirects the browser; without it the callback returns JSON.",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4959,7 +4959,7 @@
         "x-fern-sdk-group-name": [
           "mcpServers"
         ],
-        "x-fern-sdk-method-name": "delete_authorize"
+        "x-fern-sdk-method-name": "delete_authorization"
       },
       "get": {
         "description": "For servers without auth returns not_required, and for header credentials returns authenticated (no browser flow). For auth.type dcr, returns authenticated when a usable (or refreshable) token exists; otherwise runs DCR if needed and returns auth_required with an authorization URL. Optional redirect_url is where the OAuth callback then redirects the browser; without it the callback returns JSON.",

--- a/packages/trueforge-sdk/reference.md
+++ b/packages/trueforge-sdk/reference.md
@@ -622,7 +622,7 @@ await client.mcpServers.authorize("name");
 </dl>
 </details>
 
-<details><summary><code>client.mcpServers.<a href="/src/api/resources/mcpServers/client/Client.ts">deleteAuthorize</a>(name) -> TrueForge.GetMcpServerResponse</code></summary>
+<details><summary><code>client.mcpServers.<a href="/src/api/resources/mcpServers/client/Client.ts">deleteAuthorization</a>(name) -> TrueForge.GetMcpServerResponse</code></summary>
 <dl>
 <dd>
 
@@ -649,7 +649,7 @@ For auth.type dcr, deletes the stored OAuth token and returns the server with au
 <dd>
 
 ```typescript
-await client.mcpServers.deleteAuthorize("name");
+await client.mcpServers.deleteAuthorization("name");
 
 ```
 </dd>

--- a/packages/trueforge-sdk/src/api/resources/mcpServers/client/Client.ts
+++ b/packages/trueforge-sdk/src/api/resources/mcpServers/client/Client.ts
@@ -260,16 +260,16 @@ export class McpServersClient {
      * @throws {@link errors.TrueForgeTimeoutError}
      *
      * @example
-     *     await client.mcpServers.deleteAuthorize("name")
+     *     await client.mcpServers.deleteAuthorization("name")
      */
-    public deleteAuthorize(
+    public deleteAuthorization(
         name: string,
         requestOptions?: McpServersClient.RequestOptions,
     ): core.HttpResponsePromise<TrueForge.GetMcpServerResponse> {
-        return core.HttpResponsePromise.fromPromise(this.__deleteAuthorize(name, requestOptions));
+        return core.HttpResponsePromise.fromPromise(this.__deleteAuthorization(name, requestOptions));
     }
 
-    private async __deleteAuthorize(
+    private async __deleteAuthorization(
         name: string,
         requestOptions?: McpServersClient.RequestOptions,
     ): Promise<core.WithRawResponse<TrueForge.GetMcpServerResponse>> {

--- a/packages/trueforge-sdk/tests/wire/mcpServers.test.ts
+++ b/packages/trueforge-sdk/tests/wire/mcpServers.test.ts
@@ -173,7 +173,7 @@ describe("McpServersClient", () => {
         }).rejects.toThrow(TrueForgeTypes.InternalServerError);
     });
 
-    test("delete_authorize (1)", async () => {
+    test("delete_authorization (1)", async () => {
         const server = mockServerPool.createServer();
         const client = new TrueForge({ maxRetries: 0, token: "test", baseUrl: server.baseUrl });
 
@@ -199,7 +199,7 @@ describe("McpServersClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const response = await client.mcpServers.deleteAuthorize("name");
+        const response = await client.mcpServers.deleteAuthorization("name");
         expect(response).toEqual({
             data: {
                 authStatus: {
@@ -220,7 +220,7 @@ describe("McpServersClient", () => {
         });
     });
 
-    test("delete_authorize (2)", async () => {
+    test("delete_authorization (2)", async () => {
         const server = mockServerPool.createServer();
         const client = new TrueForge({ maxRetries: 0, token: "test", baseUrl: server.baseUrl });
 
@@ -235,7 +235,7 @@ describe("McpServersClient", () => {
             .build();
 
         await expect(async () => {
-            return await client.mcpServers.deleteAuthorize("name");
+            return await client.mcpServers.deleteAuthorization("name");
         }).rejects.toThrow(TrueForgeTypes.NotFoundError);
     });
 });

--- a/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/catalogs/connectorCatalog.ts
+++ b/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/catalogs/connectorCatalog.ts
@@ -225,7 +225,7 @@ export function createConnectorCatalog(
       if (existing.manifest.auth?.type !== 'dcr') {
         throw new Error(`Disconnect is only supported for OAuth MCP servers`);
       }
-      const body = await client.mcpServers.deleteAuthorize(req.id);
+      const body = await client.mcpServers.deleteAuthorization(req.id);
       return toUiConnector(body.data);
     },
   };

--- a/packages/trueforge/src/apis/mcpServers.ts
+++ b/packages/trueforge/src/apis/mcpServers.ts
@@ -11,7 +11,7 @@ import type { IOAuthTokenStore, OAuthClientRecord, OAuthToken } from '../mcp/aut
 import {
   authorizeMcpServerRoute,
   createMcpServerRoute,
-  deleteAuthorizeMcpServerRoute,
+  deleteAuthorizationMcpServerRoute,
   getMcpServerRoute,
   listAvailableMcpServersRoute,
   listMcpServersRoute,
@@ -415,7 +415,7 @@ export function createMcpServersRouter<TTransaction>(deps: McpServersRouterDeps<
     }
   };
 
-  const deleteAuthorizeHandler: RouteHandler<typeof deleteAuthorizeMcpServerRoute> = async c => {
+  const deleteAuthorizationHandler: RouteHandler<typeof deleteAuthorizationMcpServerRoute> = async c => {
     const { name } = c.req.valid('param');
     const userRef = deps.resolveUserContext(c).userRef;
     const record = await deps.mcpServerStore.getServer({ tenant_id: TENANT_ID, name });
@@ -444,6 +444,6 @@ export function createMcpServersRouter<TTransaction>(deps: McpServersRouterDeps<
     );
   });
   router.openapi(authorizeMcpServerRoute, authorizeHandler);
-  router.openapi(deleteAuthorizeMcpServerRoute, deleteAuthorizeHandler);
+  router.openapi(deleteAuthorizationMcpServerRoute, deleteAuthorizationHandler);
   return router;
 }

--- a/packages/trueforge/src/routes/mcpServerRoutes.ts
+++ b/packages/trueforge/src/routes/mcpServerRoutes.ts
@@ -253,13 +253,13 @@ export const authorizeMcpServerRoute = createRoute({
   },
 });
 
-export const deleteAuthorizeMcpServerRoute = createRoute({
+export const deleteAuthorizationMcpServerRoute = createRoute({
   method: 'delete',
   path: '/{name}/authorize',
   tags: [MCP_SERVERS_TAG],
   summary: 'Disconnect OAuth for an MCP server',
   'x-fern-sdk-group-name': ['mcpServers'],
-  'x-fern-sdk-method-name': 'delete_authorize',
+  'x-fern-sdk-method-name': 'delete_authorization',
   description:
     'For auth.type dcr, deletes the stored OAuth token and returns the server with auth_status ' +
     'auth_required, keeping the dynamically registered OAuth client so the next authorize can reuse it. ' +


### PR DESCRIPTION
## Summary

`delete_authorize` reads as “delete the authorize action.” Rename the Fern SDK method to `delete_authorization` so it names the stored OAuth grant, which this `DELETE` actually removes.

revoke_authorization was skipped: this only deletes the stored token locally, it does not revoke it at the authorization server. 

HTTP path stays `DELETE /{name}/authorize`. OpenAPI and `@truefoundry/trueforge-sdk` pick up `deleteAuthorization` on SDK regen.

Closes AGE-1879

## Changes

- Set `x-fern-sdk-method-name` to `delete_authorization` and renamed the matching route/handler symbols
- Pointed the UI connector disconnect path at `client.mcpServers.deleteAuthorization`

## How was this tested?

Existing `DELETE /{name}/authorize` unit tests still cover the unchanged HTTP behavior. SDK wire tests update when Generate SDK regenerates the client.

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for SDK consumers calling `mcpServers.deleteAuthorize`; OAuth disconnect behavior is unchanged but auth-adjacent naming touches UI and API surface.
> 
> **Overview**
> Renames the Fern/OpenAPI SDK method for disconnecting MCP OAuth from **`delete_authorize`** / **`deleteAuthorize`** to **`delete_authorization`** / **`deleteAuthorization`**, so the client name reflects removing the stored OAuth grant rather than “deleting authorize.”
> 
> **HTTP stays** `DELETE /api/v1/mcp-servers/{name}/authorize`; only SDK naming, internal route symbols (`deleteAuthorizationMcpServerRoute`, handler), OpenAPI `x-fern-sdk-method-name`, regenerated **`@truefoundry/trueforge-sdk`**, UI connector **`disconnectConnector`**, and wire tests are updated. Runtime disconnect behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c8015b586ef7e4dbf0cb7a7e1deee6b7cc20c33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->