### PR TITLE
[docs]: ui-chat overview update

### DIFF
--- a/docs/chat-ui.mdx
+++ b/docs/chat-ui.mdx
@@ -15,6 +15,7 @@ Key Features:
 - **Integration Settings** - Configure models, MCP servers, skills, and sandbox environments.
 - **Server Configuration** - Choose between TrueForge, a fully custom server, or TrueFoundry.
 
+{/* 
 ## Bundled UI
 
 When you run TrueForge ([Quickstart](/quickstart)), open the app URL (for example `http://localhost:8790`). You get:
@@ -37,6 +38,8 @@ When you run TrueForge ([Quickstart](/quickstart)), open the app URL (for exampl
 | **Themes** | Built-in Claude, ChatGPT, Gemini, TrueFoundry — or your own theme |
 | **Slots** | Override individual UI regions without forking the whole app |
 | **Server** | TrueForge server, TrueFoundry-backed, or a custom server that implements the contract |
+
+*/}
 
 ## Interactive controls & code examples
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security impact.
> 
> **Overview**
> The **Overview** page for TrueForge UI SDK (`chat-ui.mdx`) no longer renders the **Bundled UI** section (quickstart URL, feature bullets, screenshot) or the **What you can customize** table. Those blocks are wrapped in an MDX comment so they stay in the source but disappear from the published doc.
> 
> **Key Features** and **Interactive controls & code examples** (link to `ui.trueforge.dev`) remain the primary on-page content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783905843f4344611802b8299f583a9885490324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->