### PR TITLE
Remove auth.logout from the SDK

### DIFF
--- a/.changeset/20260819074405-omit-auth-logout-from-sdk.md
+++ b/.changeset/20260819074405-omit-auth-logout-from-sdk.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge': patch
+---
+
+Omit POST /api/v1/auth/logout from the SDK; the UI posts the cookie-clearing path directly.

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -4561,10 +4561,7 @@
           "Auth"
         ],
         "x-excluded": true,
-        "x-fern-sdk-group-name": [
-          "auth"
-        ],
-        "x-fern-sdk-method-name": "logout"
+        "x-fern-ignore": true
       }
     },
     "/api/v1/auth/me": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4561,10 +4561,7 @@
           "Auth"
         ],
         "x-excluded": true,
-        "x-fern-sdk-group-name": [
-          "auth"
-        ],
-        "x-fern-sdk-method-name": "logout"
+        "x-fern-ignore": true
       }
     },
     "/api/v1/auth/me": {

--- a/packages/frontend/src/authFetch.ts
+++ b/packages/frontend/src/authFetch.ts
@@ -1,10 +1,13 @@
 /**
- * Browser auth entry points. Login is not an SDK method (302 browser flow).
+ * Browser auth entry points. Login and logout are not SDK methods (cookie session).
  * On any HTTP 401, redirect to OIDC login (session required).
  */
 
 /** Browser entry for OIDC login (not available as an SDK method). */
 export const AUTH_LOGIN_HREF = '/api/v1/auth/login';
+
+/** Clears the local session cookie (not available as an SDK method). */
+export const AUTH_LOGOUT_HREF = '/api/v1/auth/logout';
 
 export function createAuthAwareFetch(baseFetch: typeof fetch = globalThis.fetch.bind(globalThis)): typeof fetch {
   let redirecting = false;

--- a/packages/frontend/src/authSession.ts
+++ b/packages/frontend/src/authSession.ts
@@ -1,9 +1,9 @@
 /**
- * Session helpers: SDK `auth.me()` / `auth.logout()` only.
+ * Session helpers: SDK `auth.me()` plus POST `/api/v1/auth/logout`.
  * Login is not on the SDK (browser redirect to `/api/v1/auth/login`).
  */
 import { TrueForge as TrueForgeClient, type TrueForge, type TrueForgeApi } from '@truefoundry/trueforge-sdk';
-import { createAuthAwareFetch } from './authFetch';
+import { AUTH_LOGOUT_HREF, createAuthAwareFetch } from './authFetch';
 
 export type MeResponse = TrueForgeApi.MeResponse;
 
@@ -50,8 +50,11 @@ export async function isOidcConnectedSession(client: TrueForge = authClient): Pr
   return isConnected;
 }
 
-export async function logout(client: TrueForge = authClient): Promise<void> {
-  await client.auth.logout();
+export async function logout(post: typeof fetch = globalThis.fetch.bind(globalThis)): Promise<void> {
+  const response = await post(AUTH_LOGOUT_HREF, { method: 'POST', credentials: 'include' });
+  if (!response.ok) {
+    throw new Error(`Logout failed (${String(response.status)})`);
+  }
 }
 
 /**

--- a/packages/frontend/tests/authFetch.test.ts
+++ b/packages/frontend/tests/authFetch.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { AUTH_LOGIN_HREF, createAuthAwareFetch } from '../src/authFetch';
+import { AUTH_LOGIN_HREF, AUTH_LOGOUT_HREF, createAuthAwareFetch } from '../src/authFetch';
 import { parseAuthErrorReason } from '../src/authStatusSearch';
 
 describe('createAuthAwareFetch', () => {
@@ -51,8 +51,9 @@ describe('createAuthAwareFetch', () => {
     }
   });
 
-  it('exports browser auth entry path', () => {
+  it('exports browser auth entry paths', () => {
     assert.equal(AUTH_LOGIN_HREF, '/api/v1/auth/login');
+    assert.equal(AUTH_LOGOUT_HREF, '/api/v1/auth/logout');
   });
 });
 

--- a/packages/frontend/tests/authSession.test.ts
+++ b/packages/frontend/tests/authSession.test.ts
@@ -9,11 +9,7 @@ import {
   resetOidcSessionCacheForTests,
 } from '../src/authSession';
 
-function createClient(params: {
-  type?: 'default' | 'oidc-connected';
-  onLogout?: () => void;
-  meError?: Error;
-}): TrueForge {
+function createClient(params: { type?: 'default' | 'oidc-connected'; meError?: Error }): TrueForge {
   return {
     auth: {
       me: async () => {
@@ -23,9 +19,6 @@ function createClient(params: {
           email: 'user@example.com',
           role: 'user',
         };
-      },
-      logout: async () => {
-        params.onLogout?.();
       },
     },
   } as unknown as TrueForge;
@@ -48,16 +41,17 @@ describe('authSession', () => {
     assert.equal(getCachedIsOidcConnectedSession(), true);
   });
 
-  it('delegates logout to auth.logout', async () => {
-    let called = false;
-    await logout(
-      createClient({
-        onLogout: () => {
-          called = true;
-        },
-      }),
-    );
-    assert.equal(called, true);
+  it('POSTs /api/v1/auth/logout with credentials and succeeds on 204', async () => {
+    const calls: { url: string; method: string | undefined; credentials: RequestCredentials | undefined }[] = [];
+    await logout(async (input, init) => {
+      calls.push({ url: String(input), method: init?.method, credentials: init?.credentials });
+      return new Response(null, { status: 204 });
+    });
+    assert.deepEqual(calls, [{ url: '/api/v1/auth/logout', method: 'POST', credentials: 'include' }]);
+  });
+
+  it('throws when logout is not 2xx', async () => {
+    await assert.rejects(() => logout(async () => new Response(null, { status: 500 })), /Logout failed \(500\)/);
   });
 
   it('probeSession reports authenticated when me() resolves', async () => {

--- a/packages/trueforge-sdk/reference.md
+++ b/packages/trueforge-sdk/reference.md
@@ -329,61 +329,6 @@ await client.agents.delete("agent_id");
 </details>
 
 ## Auth
-<details><summary><code>client.auth.<a href="/src/api/resources/auth/client/Client.ts">logout</a>() -> void</code></summary>
-<dl>
-<dd>
-
-#### 📝 Description
-
-<dl>
-<dd>
-
-<dl>
-<dd>
-
-Ends the local harness session only — does not hit the IdP end-session endpoint. A no-op in local/single-binary mode, since there is no real session to clear.
-</dd>
-</dl>
-</dd>
-</dl>
-
-#### 🔌 Usage
-
-<dl>
-<dd>
-
-<dl>
-<dd>
-
-```typescript
-await client.auth.logout();
-
-```
-</dd>
-</dl>
-</dd>
-</dl>
-
-#### ⚙️ Parameters
-
-<dl>
-<dd>
-
-<dl>
-<dd>
-
-**requestOptions:** `AuthClient.RequestOptions` 
-    
-</dd>
-</dl>
-</dd>
-</dl>
-
-
-</dd>
-</dl>
-</details>
-
 <details><summary><code>client.auth.<a href="/src/api/resources/auth/client/Client.ts">me</a>() -> TrueForge.MeResponse</code></summary>
 <dl>
 <dd>

--- a/packages/trueforge-sdk/src/api/resources/auth/client/Client.ts
+++ b/packages/trueforge-sdk/src/api/resources/auth/client/Client.ts
@@ -23,58 +23,6 @@ export class AuthClient {
     }
 
     /**
-     * Ends the local harness session only — does not hit the IdP end-session endpoint. A no-op in local/single-binary mode, since there is no real session to clear.
-     *
-     * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
-     *
-     * @throws {@link errors.TrueForgeError}
-     * @throws {@link errors.TrueForgeTimeoutError}
-     *
-     * @example
-     *     await client.auth.logout()
-     */
-    public logout(requestOptions?: AuthClient.RequestOptions): core.HttpResponsePromise<void> {
-        return core.HttpResponsePromise.fromPromise(this.__logout(requestOptions));
-    }
-
-    private async __logout(requestOptions?: AuthClient.RequestOptions): Promise<core.WithRawResponse<void>> {
-        const _authRequest: core.AuthRequest = await this._options.authProvider.getAuthRequest();
-        const _headers: core.Fetcher.Args["headers"] = mergeHeaders(
-            _authRequest.headers,
-            this._options?.headers,
-            requestOptions?.headers,
-        );
-        const _response = await (this._options.fetcher ?? core.fetcher)({
-            url: core.url.join(
-                (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)),
-                "api/v1/auth/logout",
-            ),
-            method: "POST",
-            headers: _headers,
-            queryString: core.url.queryBuilder().mergeAdditional(requestOptions?.queryParams).build(),
-            timeoutMs: (requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000,
-            maxRetries: requestOptions?.maxRetries ?? this._options?.maxRetries,
-            abortSignal: requestOptions?.abortSignal,
-            fetchFn: this._options?.fetch,
-            logging: this._options.logging,
-        });
-        if (_response.ok) {
-            return { data: undefined, rawResponse: _response.rawResponse };
-        }
-
-        if (_response.error.reason === "status-code") {
-            throw new errors.TrueForgeError({
-                statusCode: _response.error.statusCode,
-                body: _response.error.body,
-                rawResponse: _response.rawResponse,
-            });
-        }
-
-        return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/api/v1/auth/logout");
-    }
-
-    /**
      * Returns the authenticated caller identity. When auth is enabled this requires a valid `id_token` cookie or `Authorization: Bearer` ID token (401 otherwise). When auth is disabled, returns the default identity.
      *
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.

--- a/packages/trueforge-sdk/tests/wire/auth.test.ts
+++ b/packages/trueforge-sdk/tests/wire/auth.test.ts
@@ -5,16 +5,6 @@ import { TrueForge } from "../../src/Client";
 import { mockServerPool } from "../mock-server/MockServerPool";
 
 describe("AuthClient", () => {
-    test("logout", async () => {
-        const server = mockServerPool.createServer();
-        const client = new TrueForge({ maxRetries: 0, token: "test", baseUrl: server.baseUrl });
-
-        server.mockEndpoint().post("/api/v1/auth/logout").respondWith().statusCode(200).build();
-
-        const response = await client.auth.logout();
-        expect(response).toEqual(undefined);
-    });
-
     test("me (1)", async () => {
         const server = mockServerPool.createServer();
         const client = new TrueForge({ maxRetries: 0, token: "test", baseUrl: server.baseUrl });

--- a/packages/trueforge/src/routes/authRoutes.ts
+++ b/packages/trueforge/src/routes/authRoutes.ts
@@ -1,9 +1,9 @@
 /**
  * Auth route definitions (mounted at /api/v1/auth). Handlers in apis/auth.ts.
  *
- * `login`/`callback` are browser-redirect targets, never called by SDK
- * consumers — both carry `x-fern-ignore`, the same convention used for the
- * MCP OAuth callback in mcpOAuthRoutes.ts. `logout` and `me` generate normally.
+ * `login`/`callback`/`logout` are browser-session helpers, never called by SDK
+ * consumers — they carry `x-fern-ignore`, the same convention used for the
+ * MCP OAuth callback in mcpOAuthRoutes.ts. `me` generates normally.
  */
 import { createRoute } from '@hono/zod-openapi';
 import { AuthLoginQuerySchema, MeResponseSchema, OAuthCallbackQuerySchema } from '../schemas/auth';
@@ -50,8 +50,7 @@ export const authLogoutRoute = createRoute({
   description:
     'Ends the local harness session only — does not hit the IdP end-session endpoint. A no-op in local/single-binary ' +
     'mode, since there is no real session to clear.',
-  'x-fern-sdk-group-name': ['auth'],
-  'x-fern-sdk-method-name': 'logout',
+  'x-fern-ignore': true,
   'x-excluded': true,
   responses: {
     204: { description: 'Session cookie cleared.' },


### PR DESCRIPTION
## Summary

Remove `client.auth.logout()` from the SDK. Logout is a cookie-clearing browser POST, same class as login/callback — not an SDK method. The UI posts `/api/v1/auth/logout` directly.

Closes AGE-1879

## Changes

- Mark `POST /api/v1/auth/logout` with `x-fern-ignore` (Mintlify already uses `x-excluded`)
- UI logout POSTs `/api/v1/auth/logout` with credentials and throws on non-2xx
- Do not regenerate `packages/trueforge-sdk` in this PR — CI after merge

## How was this tested?

`pnpm --filter frontend exec tsx --test tests/authSession.test.ts tests/authFetch.test.ts`

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a public SDK method (`auth.logout`), which is a breaking change for any external consumer; session clearing behavior shifts to direct browser POST with cookie credentials.
> 
> **Overview**
> **Removes `client.auth.logout()`** from the TrueForge SDK and treats logout like login/callback: a browser cookie-session helper, not an API client method.
> 
> `POST /api/v1/auth/logout` is marked with **`x-fern-ignore`** on the auth route (and mirrored in OpenAPI JSON), so Fern no longer generates SDK code for it. The generated **`AuthClient.logout`** implementation, wire tests, and SDK reference docs for logout are removed in this PR’s SDK tree.
> 
> The **frontend** clears sessions by posting **`AUTH_LOGOUT_HREF`** (`/api/v1/auth/logout`) with **`credentials: 'include'`** and throws on non-2xx responses, instead of calling the SDK. Tests cover the direct POST behavior.
> 
> A patch **changeset** notes the SDK omission; full SDK regeneration is expected after merge per the PR checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f396c44f90bb23572345a4b569198f6baf21e06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->