### PR TITLE
chore: update .prettierignore to exclude .changeset directory and fix format in changeset-sandbox-image.sh

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.changeset/
 # Fern-generated: formatted by the generator, not by this repo's config.
 packages/trueforge-sdk/
 .github/fern/openapi/

--- a/scripts/changeset-sandbox-image.sh
+++ b/scripts/changeset-sandbox-image.sh
@@ -7,7 +7,7 @@ slug="update-sandbox-image"
 outfile=".changeset/$(date -u +%Y%m%d%H%M%S)-${slug}.md"
 cat >"$outfile" <<'EOF'
 ---
-"@truefoundry/trueforge-core": patch
+'@truefoundry/trueforge-core': patch
 ---
 
 Update SANDBOX_IMAGE_URI to the image pushed by CI.


### PR DESCRIPTION
## Summary

chore: update .prettierignore to exclude .changeset directory and fix format in changeset-sandbox-image.sh

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8e72771d3ac17da96d11107377ad565285641070. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->