### PR TITLE
fix: persist model.message with omitted null content and deferred call_tool wrapper tool_info

### DIFF
--- a/.changeset/model-message-event-shape.md
+++ b/.changeset/model-message-event-shape.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-core': patch
+---
+
+Persist `model.message` with omitted null content and deferred `call_tool` wrapper `tool_info`, matching the live stream.

--- a/packages/trueforge-core/src/core/runtime/AgentThread.ts
+++ b/packages/trueforge-core/src/core/runtime/AgentThread.ts
@@ -245,6 +245,9 @@ function buildModelMessageEvent({
   void source;
   const event: ModelMessageEvent = {
     ...rest,
+    // Tool-only completions store content: null on context (OpenAI replay) but the
+    // SSE placeholder omits the field. Drop null/empty here so listTurnEvents JSON
+    // matches a folded stream.
     ...(content && { content }),
     tool_calls: tool_calls?.map(toEnrichedToolCall),
     type: EventType.MODEL_MESSAGE,

--- a/packages/trueforge-core/src/core/runtime/AgentThread.ts
+++ b/packages/trueforge-core/src/core/runtime/AgentThread.ts
@@ -415,10 +415,15 @@ async function buildModelMessageDeltaEvent({
   };
 }
 
-async function buildContextAssistantMessage(
-  assistantMessage: RawAssistantMessage,
-  toolMapping: Map<string, MappedMCPTool>,
-): Promise<InternalEnrichedAssistantMessage> {
+async function enrichAssistantMessage({
+  assistantMessage,
+  toolMapping,
+  resolveUnderlyingTool,
+}: {
+  assistantMessage: RawAssistantMessage;
+  toolMapping: Map<string, MappedMCPTool>;
+  resolveUnderlyingTool: boolean;
+}): Promise<InternalEnrichedAssistantMessage> {
   // Omit tool_calls when empty; OpenAI rejects `tool_calls: []` on replay.
   if (!assistantMessage.tool_calls?.length) {
     const { tool_calls, ...rest } = assistantMessage;
@@ -439,11 +444,9 @@ async function buildContextAssistantMessage(
     const tool_info = await toolInfo.toolSet.toolCallInfo(
       {
         name: toolInfo.originalToolName,
-        arguments: tryParseToolArgs(toolCall.function.arguments),
+        ...(resolveUnderlyingTool ? { arguments: tryParseToolArgs(toolCall.function.arguments) } : {}),
       },
-      // During context persistence, we have the complete message and hence the tool arguments are available.
-      // Hence, we resolve the underlying tool to get the tool information.
-      true /* resolveUnderlyingTool */,
+      resolveUnderlyingTool,
     );
     enrichedToolCalls.push({ ...toolCall, tool_info });
   }
@@ -1067,13 +1070,21 @@ export class AgentThread {
       usage: result.value.usage,
       toolMapping,
     });
-    const assistantMessage: InternalEnrichedAssistantMessage = await buildContextAssistantMessage(
-      result.value.output,
+    const assistantMessage: InternalEnrichedAssistantMessage = await enrichAssistantMessage({
+      assistantMessage: result.value.output,
       toolMapping,
-    );
+      // During context persistence, we have the complete message and hence the tool arguments are available.
+      // Hence, we resolve the underlying tool to get the tool information.
+      resolveUnderlyingTool: true,
+    });
     const finishReason = result.value.finish_reason;
     const agentAssistantMessage = buildModelMessageEvent({
-      assistantMessage,
+      assistantMessage: await enrichAssistantMessage({
+        assistantMessage: result.value.output,
+        toolMapping,
+        // Same unresolved wrapper as SSE deltas so listTurnEvents matches a folded stream.
+        resolveUnderlyingTool: false,
+      }),
       threadId: this.threadId,
       finishReason,
       usage: modelMessageUsage,

--- a/packages/trueforge-core/src/core/runtime/AgentThread.ts
+++ b/packages/trueforge-core/src/core/runtime/AgentThread.ts
@@ -239,12 +239,13 @@ function buildModelMessageEvent({
   id: string;
 }): ModelMessageEvent {
   // `thinking_blocks` / `source` stay on the context message for replay; strip them from the client event.
-  const { role, tool_calls, thinking_blocks, source, ...rest } = assistantMessage;
+  const { role, tool_calls, thinking_blocks, source, content, ...rest } = assistantMessage;
   void role;
   void thinking_blocks;
   void source;
   const event: ModelMessageEvent = {
     ...rest,
+    ...(content && { content }),
     tool_calls: tool_calls?.map(toEnrichedToolCall),
     type: EventType.MODEL_MESSAGE,
     id,

--- a/packages/trueforge-core/src/core/runtime/contextUtils.ts
+++ b/packages/trueforge-core/src/core/runtime/contextUtils.ts
@@ -118,13 +118,6 @@ export function toToolCallInfo(toolInfo: InternalToolCallInfo): ToolInfo {
 
 export function toEnrichedToolCall(toolCall: InternalEnrichedToolCall): EnrichedToolCall {
   const { tool_info, ...rest } = toolCall;
-  // Deltas attach the call_tool wrapper; listTurnEvents must not rewrite to the inner MCP tool.
-  if (tool_info.is_deferred === true) {
-    return {
-      ...rest,
-      tool_info: { type: 'truefoundry-system', name: rest.function.name },
-    };
-  }
   return { ...rest, tool_info: toToolCallInfo(tool_info) };
 }
 

--- a/packages/trueforge-core/src/core/runtime/contextUtils.ts
+++ b/packages/trueforge-core/src/core/runtime/contextUtils.ts
@@ -118,6 +118,13 @@ export function toToolCallInfo(toolInfo: InternalToolCallInfo): ToolInfo {
 
 export function toEnrichedToolCall(toolCall: InternalEnrichedToolCall): EnrichedToolCall {
   const { tool_info, ...rest } = toolCall;
+  // Deltas attach the call_tool wrapper; listTurnEvents must not rewrite to the inner MCP tool.
+  if (tool_info.is_deferred === true) {
+    return {
+      ...rest,
+      tool_info: { type: 'truefoundry-system', name: rest.function.name },
+    };
+  }
   return { ...rest, tool_info: toToolCallInfo(tool_info) };
 }
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Event serialization and enrichment path only; no auth, persistence schema, or execution behavior changes beyond JSON shape parity for clients.
> 
> **Overview**
> **Aligns persisted `model.message` events with what clients see on the live SSE stream** so `listTurnEvents` JSON matches a folded stream.
> 
> In `buildModelMessageEvent`, **tool-only assistant completions** no longer emit `content: null`—the field is omitted when content is null or empty, matching the SSE placeholder behavior.
> 
> Assistant message enrichment is refactored: `buildContextAssistantMessage` becomes `enrichAssistantMessage` with a `resolveUnderlyingTool` flag. **Context replay** still enriches tool calls with full underlying tool info (`resolveUnderlyingTool: true`). The **client-facing `model.message`** uses `resolveUnderlyingTool: false`, so deferred `call_tool` wrapper `tool_info` stays unresolved like SSE deltas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a156795a949583e81366afd306cdc51aa93c06f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->