### PR TITLE
Add quick local run instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,15 @@ It scales down and up: **local mode** (one process, SQLite) or **hosted mode** (
 
 ## Getting started
 
-Run TrueForge (local, Docker Compose, or Kubernetes), connect a model and tools, and build your first reusable agent in the [Quickstart](https://trueforge.dev/quickstart).
+### Quickstart with `npx`
+
+```
+npx @truefoundry/trueforge
+```
+
+Use the [Quickstart](https://trueforge.dev/quickstart) guide to run TrueForge using various methods (Local, Docker Compose, or Kubernetes). Connect models, tools, skills and build your first reusable agent.
 
 To work on TrueForge from this repository, see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-# Quick local run (no Docker)
-npx @truefoundry/trueforge
-
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Run TrueForge (local, Docker Compose, or Kubernetes), connect a model and tools,
 To work on TrueForge from this repository, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 # Quick local run (no Docker)
-npm create @truefoundry/trueforge@latest
 npx @truefoundry/trueforge
 
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Run TrueForge (local, Docker Compose, or Kubernetes), connect a model and tools,
 
 To work on TrueForge from this repository, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
+# Quick local run (no Docker)
+npm create @truefoundry/trueforge@latest
+npx @truefoundry/trueforge
+
+
 ## Architecture
 
 <p align="center">


### PR DESCRIPTION
Added instructions for a quick local run without Docker.

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change; no code, auth, or runtime behavior is affected.
> 
> **Overview**
> Puts a one-command local start in the README **Getting started** section: `npx @truefoundry/trueforge`.
> 
> The previous single-line pointer to the Quickstart is replaced with that snippet plus a short note that Local, Docker Compose, and Kubernetes still live in the [Quickstart](https://trueforge.dev/quickstart) guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa25e704e60447e91f05c5b2907e67063050b6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->