### PR TITLE
Add validation to settings forms

### DIFF
--- a/.changeset/clean-forms-validate.md
+++ b/.changeset/clean-forms-validate.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Add accessible field-level validation and duplicate-name checks to settings forms.

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/AddMcpServerForm.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/AddMcpServerForm.tsx
@@ -2,11 +2,24 @@
 
 import { useState, type FormEvent } from 'react';
 
+import { cn } from '../../atoms/lib/cn.js';
 import { auiInputClass } from '../../atoms/lib/inputClasses.js';
 import { Button } from '../../atoms/primitives/Button.js';
 import { CenteredModal } from '../../atoms/primitives/CenteredModal.js';
 import { Icon } from '../../icons/Icon.js';
 import type { ConnectorAuth, ConnectorAuthType } from '../../server/types.js';
+import {
+  RequiredMark,
+  SETTINGS_INPUT_ERROR_CLASS_NAME,
+  SettingsFieldError,
+  useTouchedFields,
+} from './SettingsFormField.js';
+import {
+  validateHttpHeaderName,
+  validateHttpUrl,
+  validateRequired,
+  validateResourceName,
+} from './settingsFormValidation.js';
 
 export type McpAuthType = ConnectorAuthType;
 
@@ -23,6 +36,7 @@ type AddMcpServerFormProps = {
   onAdd: (draft: AddMcpServerDraft) => void | Promise<void>;
   busy?: boolean;
   error?: string | null;
+  existingNames?: readonly string[];
 };
 
 const AUTH_OPTIONS: Array<{ value: McpAuthType; label: string }> = [
@@ -33,19 +47,24 @@ const AUTH_OPTIONS: Array<{ value: McpAuthType; label: string }> = [
 
 const inputClassName = auiInputClass('h-11 shadow-sm');
 
-const RequiredMark = () => (
-  <span className="ml-0.5 text-failure-bg" aria-hidden>
-    *
-  </span>
-);
+type AddMcpServerField = 'name' | 'description' | 'url' | 'apiKey' | 'headerName';
+const ADD_MCP_SERVER_FIELDS: readonly AddMcpServerField[] = ['name', 'description', 'url', 'apiKey', 'headerName'];
 
-const AddMcpServerForm = ({ open, onOpenChange, onAdd, busy = false, error }: AddMcpServerFormProps) => {
+const AddMcpServerForm = ({
+  open,
+  onOpenChange,
+  onAdd,
+  busy = false,
+  error,
+  existingNames = [],
+}: AddMcpServerFormProps) => {
   const [name, setName] = useState('');
   const [url, setUrl] = useState('');
   const [description, setDescription] = useState('');
   const [authType, setAuthType] = useState<McpAuthType>('dcr');
   const [apiKey, setApiKey] = useState('');
   const [headerName, setHeaderName] = useState('');
+  const { isTouched, resetTouched, touch, touchAll } = useTouchedFields<AddMcpServerField>();
 
   const resetForm = () => {
     setName('');
@@ -54,6 +73,7 @@ const AddMcpServerForm = ({ open, onOpenChange, onAdd, busy = false, error }: Ad
     setAuthType('dcr');
     setApiKey('');
     setHeaderName('');
+    resetTouched();
   };
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -61,10 +81,16 @@ const AddMcpServerForm = ({ open, onOpenChange, onAdd, busy = false, error }: Ad
     onOpenChange(nextOpen);
   };
 
-  const isValid = !!name.trim() && !!description.trim() && !!url.trim() && (authType !== 'header' || !!apiKey.trim());
+  const nameError = validateResourceName({ value: name, label: 'Connector name', existingNames });
+  const descriptionError = validateRequired({ value: description, label: 'Description' });
+  const urlError = validateHttpUrl({ value: url, label: 'URL' });
+  const apiKeyError = authType === 'header' ? validateRequired({ value: apiKey, label: 'API key' }) : null;
+  const headerNameError = authType === 'header' ? validateHttpHeaderName(headerName) : null;
+  const isValid = !nameError && !descriptionError && !urlError && !apiKeyError && !headerNameError;
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    touchAll(ADD_MCP_SERVER_FIELDS);
     if (!isValid || busy) return;
 
     const auth: ConnectorAuth =
@@ -106,7 +132,7 @@ const AddMcpServerForm = ({ open, onOpenChange, onAdd, busy = false, error }: Ad
         </span>
       }
     >
-      <form className="flex flex-col overflow-y-auto p-5 md:p-6" onSubmit={e => void handleSubmit(e)}>
+      <form className="flex flex-col overflow-y-auto p-5 md:p-6" noValidate onSubmit={e => void handleSubmit(e)}>
         <div className="space-y-4">
           <div>
             <label htmlFor="mcp-server-name" className="mb-1.5 block text-sm font-medium text-text-primary">
@@ -121,10 +147,16 @@ const AddMcpServerForm = ({ open, onOpenChange, onAdd, busy = false, error }: Ad
               onChange={event => {
                 setName(event.target.value);
               }}
+              onBlur={() => touch('name')}
               placeholder="analytics-postgres-mcp"
               autoFocus
-              className={inputClassName}
+              aria-invalid={isTouched('name') && nameError ? true : undefined}
+              aria-describedby={isTouched('name') && nameError ? 'mcp-server-name-error' : undefined}
+              className={cn(inputClassName, isTouched('name') && nameError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
             />
+            {isTouched('name') && nameError ? (
+              <SettingsFieldError id="mcp-server-name-error">{nameError}</SettingsFieldError>
+            ) : null}
           </div>
 
           <div>
@@ -138,11 +170,22 @@ const AddMcpServerForm = ({ open, onOpenChange, onAdd, busy = false, error }: Ad
               onChange={event => {
                 setDescription(event.target.value);
               }}
+              onBlur={() => touch('description')}
               placeholder="Query analytics from Postgres"
               required
               rows={3}
-              className={auiInputClass('resize-y py-2.5 shadow-sm')}
+              aria-invalid={isTouched('description') && descriptionError ? true : undefined}
+              aria-describedby={
+                isTouched('description') && descriptionError ? 'mcp-server-description-error' : undefined
+              }
+              className={cn(
+                auiInputClass('resize-y py-2.5 shadow-sm'),
+                isTouched('description') && descriptionError && SETTINGS_INPUT_ERROR_CLASS_NAME,
+              )}
             />
+            {isTouched('description') && descriptionError ? (
+              <SettingsFieldError id="mcp-server-description-error">{descriptionError}</SettingsFieldError>
+            ) : null}
           </div>
 
           <div>
@@ -158,9 +201,15 @@ const AddMcpServerForm = ({ open, onOpenChange, onAdd, busy = false, error }: Ad
               onChange={event => {
                 setUrl(event.target.value);
               }}
+              onBlur={() => touch('url')}
               placeholder="https://mcp.example.com/mcp"
-              className={inputClassName}
+              aria-invalid={isTouched('url') && urlError ? true : undefined}
+              aria-describedby={isTouched('url') && urlError ? 'mcp-server-url-error' : undefined}
+              className={cn(inputClassName, isTouched('url') && urlError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
             />
+            {isTouched('url') && urlError ? (
+              <SettingsFieldError id="mcp-server-url-error">{urlError}</SettingsFieldError>
+            ) : null}
           </div>
 
           <fieldset>
@@ -219,9 +268,15 @@ const AddMcpServerForm = ({ open, onOpenChange, onAdd, busy = false, error }: Ad
                   onChange={event => {
                     setApiKey(event.target.value);
                   }}
+                  onBlur={() => touch('apiKey')}
                   placeholder="Paste the server token"
-                  className={inputClassName}
+                  aria-invalid={isTouched('apiKey') && apiKeyError ? true : undefined}
+                  aria-describedby={isTouched('apiKey') && apiKeyError ? 'mcp-server-api-key-error' : undefined}
+                  className={cn(inputClassName, isTouched('apiKey') && apiKeyError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
                 />
+                {isTouched('apiKey') && apiKeyError ? (
+                  <SettingsFieldError id="mcp-server-api-key-error">{apiKeyError}</SettingsFieldError>
+                ) : null}
               </div>
 
               <div>
@@ -235,9 +290,20 @@ const AddMcpServerForm = ({ open, onOpenChange, onAdd, busy = false, error }: Ad
                   onChange={event => {
                     setHeaderName(event.target.value);
                   }}
+                  onBlur={() => touch('headerName')}
                   placeholder="Authorization"
-                  className={inputClassName}
+                  aria-invalid={isTouched('headerName') && headerNameError ? true : undefined}
+                  aria-describedby={
+                    isTouched('headerName') && headerNameError ? 'mcp-server-header-name-error' : undefined
+                  }
+                  className={cn(
+                    inputClassName,
+                    isTouched('headerName') && headerNameError && SETTINGS_INPUT_ERROR_CLASS_NAME,
+                  )}
                 />
+                {isTouched('headerName') && headerNameError ? (
+                  <SettingsFieldError id="mcp-server-header-name-error">{headerNameError}</SettingsFieldError>
+                ) : null}
               </div>
             </>
           ) : null}

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/ConfigureModelProviderForm.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/ConfigureModelProviderForm.tsx
@@ -8,6 +8,13 @@ import { Accordion, AccordionDetails, AccordionSummary } from '../../atoms/primi
 import { Button } from '../../atoms/primitives/Button.js';
 import { CenteredModal } from '../../atoms/primitives/CenteredModal.js';
 import { Icon } from '../../icons/Icon.js';
+import {
+  RequiredMark,
+  SETTINGS_INPUT_ERROR_CLASS_NAME,
+  SettingsFieldError,
+  useTouchedFields,
+} from './SettingsFormField.js';
+import { validateHttpUrl, validateRequired } from './settingsFormValidation.js';
 
 export type ModelProviderKeyDraft = { apiKey: string; baseUrl: string };
 
@@ -28,6 +35,8 @@ type ConfigureModelProviderFormProps = {
 };
 
 const inputClassName = auiInputClass('h-11 shadow-sm');
+type ModelProviderField = 'apiKey' | 'baseUrl';
+const MODEL_PROVIDER_FIELDS: readonly ModelProviderField[] = ['apiKey', 'baseUrl'];
 
 const ConfigureModelProviderForm = ({
   open,
@@ -45,11 +54,13 @@ const ConfigureModelProviderForm = ({
   const [apiKey, setApiKey] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const { isTouched, resetTouched, touch, touchAll } = useTouchedFields<ModelProviderField>();
 
   const resetForm = () => {
     setApiKey('');
     setBaseUrl('');
     setAdvancedOpen(false);
+    resetTouched();
   };
 
   // Prefill the endpoint when the modal opens; the API key is always blank (never echoed back).
@@ -58,7 +69,8 @@ const ConfigureModelProviderForm = ({
     setApiKey('');
     setBaseUrl(initialBaseUrl);
     setAdvancedOpen(false);
-  }, [open, initialBaseUrl]);
+    resetTouched();
+  }, [open, initialBaseUrl, resetTouched]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) resetForm();
@@ -66,10 +78,13 @@ const ConfigureModelProviderForm = ({
   };
 
   const trimmedKey = apiKey.trim();
-  const isValid = !requireApiKey || !!trimmedKey;
+  const apiKeyError = requireApiKey ? validateRequired({ value: apiKey, label: 'API key' }) : null;
+  const baseUrlError = validateHttpUrl({ value: baseUrl, label: 'Base URL', required: false });
+  const isValid = !apiKeyError && !baseUrlError;
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    touchAll(MODEL_PROVIDER_FIELDS);
     if (!isValid || busy) return;
     try {
       await onSave({ apiKey: trimmedKey, baseUrl: baseUrl.trim() });
@@ -82,11 +97,12 @@ const ConfigureModelProviderForm = ({
 
   return (
     <CenteredModal open={open} onOpenChange={handleOpenChange} title={title} description={description} contentSized>
-      <form className="flex flex-col overflow-y-auto p-5 md:p-6" onSubmit={handleSubmit}>
+      <form className="flex flex-col overflow-y-auto p-5 md:p-6" noValidate onSubmit={handleSubmit}>
         <div className="space-y-4">
           <div>
             <label htmlFor="model-provider-api-key" className="mb-1.5 block text-sm font-medium text-text-primary">
               API key
+              {requireApiKey ? <RequiredMark /> : null}
               {!requireApiKey ? <span className="font-normal text-text-secondary"> (optional)</span> : null}
             </label>
             <input
@@ -97,11 +113,16 @@ const ConfigureModelProviderForm = ({
               onChange={event => {
                 setApiKey(event.target.value);
               }}
+              onBlur={() => touch('apiKey')}
               placeholder={requireApiKey ? 'Enter API key' : 'Enter a new key'}
               autoFocus
-              className={inputClassName}
+              aria-invalid={isTouched('apiKey') && apiKeyError ? true : undefined}
+              aria-describedby={isTouched('apiKey') && apiKeyError ? 'model-provider-api-key-error' : undefined}
+              className={cn(inputClassName, isTouched('apiKey') && apiKeyError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
             />
-            {!requireApiKey ? (
+            {isTouched('apiKey') && apiKeyError ? (
+              <SettingsFieldError id="model-provider-api-key-error">{apiKeyError}</SettingsFieldError>
+            ) : !requireApiKey ? (
               <p className="mt-1.5 text-xs text-text-secondary">
                 Leave blank to keep the current key; enter a new one to replace it.
               </p>
@@ -136,10 +157,17 @@ const ConfigureModelProviderForm = ({
                 onChange={event => {
                   setBaseUrl(event.target.value);
                 }}
+                onBlur={() => touch('baseUrl')}
                 placeholder={baseUrlPlaceholder}
-                className={inputClassName}
+                aria-invalid={isTouched('baseUrl') && baseUrlError ? true : undefined}
+                aria-describedby={isTouched('baseUrl') && baseUrlError ? 'model-provider-base-url-error' : undefined}
+                className={cn(inputClassName, isTouched('baseUrl') && baseUrlError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
               />
-              <p className="text-xs text-text-secondary">Leave blank unless you use a regional or proxy endpoint.</p>
+              {isTouched('baseUrl') && baseUrlError ? (
+                <SettingsFieldError id="model-provider-base-url-error">{baseUrlError}</SettingsFieldError>
+              ) : (
+                <p className="text-xs text-text-secondary">Leave blank unless you use a regional or proxy endpoint.</p>
+              )}
             </AccordionDetails>
           </Accordion>
         </div>

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/ConfigureSandboxForm.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/ConfigureSandboxForm.tsx
@@ -9,6 +9,13 @@ import { Button } from '../../atoms/primitives/Button.js';
 import { CenteredModal } from '../../atoms/primitives/CenteredModal.js';
 import { Icon } from '../../icons/Icon.js';
 import type { SandboxProviderConfig } from '../../server/types.js';
+import {
+  RequiredMark,
+  SETTINGS_INPUT_ERROR_CLASS_NAME,
+  SettingsFieldError,
+  useTouchedFields,
+} from './SettingsFormField.js';
+import { validateNonNegativeInteger, validatePositiveInteger, validateRequired } from './settingsFormValidation.js';
 
 export type SandboxConfigDraft = SandboxProviderConfig & {
   apiKey: string;
@@ -39,12 +46,14 @@ const EMPTY_CONFIG: SandboxProviderConfig = {
 
 const inputClassName = auiInputClass('h-11 shadow-sm');
 
-function parseNonNegInt(raw: string): number | null {
+function parseInteger(raw: string): number | null {
   if (raw.trim() === '') return null;
   const n = Number(raw);
-  if (!Number.isFinite(n) || n < 0) return null;
-  return n;
+  return Number.isInteger(n) ? n : null;
 }
+
+type SandboxField = 'apiKey' | 'execTimeout' | 'autoStop' | 'autoArchive' | 'autoDelete';
+const SANDBOX_FIELDS: readonly SandboxField[] = ['apiKey', 'execTimeout', 'autoStop', 'autoArchive', 'autoDelete'];
 
 const ConfigureSandboxForm = ({
   open,
@@ -63,6 +72,7 @@ const ConfigureSandboxForm = ({
   const [autoDeleteIntervalInMinutes, setAutoDeleteIntervalInMinutes] = useState('');
   const [apiKey, setApiKey] = useState('');
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const { isTouched, resetTouched, touch, touchAll } = useTouchedFields<SandboxField>();
 
   const resetForm = () => {
     setExecTimeoutMs('');
@@ -71,6 +81,7 @@ const ConfigureSandboxForm = ({
     setAutoDeleteIntervalInMinutes('');
     setApiKey('');
     setAdvancedOpen(false);
+    resetTouched();
   };
 
   useEffect(() => {
@@ -82,28 +93,38 @@ const ConfigureSandboxForm = ({
     setAutoDeleteIntervalInMinutes(String(config.autoDeleteIntervalInMinutes));
     setApiKey('');
     setAdvancedOpen(false);
-  }, [open, initialConfig]);
+    resetTouched();
+  }, [open, initialConfig, resetTouched]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) resetForm();
     onOpenChange(nextOpen);
   };
 
-  const execTimeout = parseNonNegInt(execTimeoutMs);
-  const autoStop = parseNonNegInt(autoStopIntervalInMinutes);
-  const autoArchive = parseNonNegInt(autoArchiveIntervalInMinutes);
-  const autoDelete = parseNonNegInt(autoDeleteIntervalInMinutes);
+  const execTimeout = parseInteger(execTimeoutMs);
+  const autoStop = parseInteger(autoStopIntervalInMinutes);
+  const autoArchive = parseInteger(autoArchiveIntervalInMinutes);
+  const autoDelete = parseInteger(autoDeleteIntervalInMinutes);
   const trimmedKey = apiKey.trim();
-
-  const isValid =
-    (!requireApiKey || !!trimmedKey) &&
-    execTimeout != null &&
-    autoStop != null &&
-    autoArchive != null &&
-    autoDelete != null;
+  const apiKeyError = requireApiKey ? validateRequired({ value: apiKey, label: 'API key' }) : null;
+  const execTimeoutError = validatePositiveInteger({ value: execTimeoutMs, label: 'Exec timeout' });
+  const autoStopError = validateNonNegativeInteger({
+    value: autoStopIntervalInMinutes,
+    label: 'Auto-stop interval',
+  });
+  const autoArchiveError = validateNonNegativeInteger({
+    value: autoArchiveIntervalInMinutes,
+    label: 'Auto-archive interval',
+  });
+  const autoDeleteError = validateNonNegativeInteger({
+    value: autoDeleteIntervalInMinutes,
+    label: 'Auto-delete interval',
+  });
+  const isValid = !apiKeyError && !execTimeoutError && !autoStopError && !autoArchiveError && !autoDeleteError;
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    touchAll(SANDBOX_FIELDS);
     if (!isValid || busy || execTimeout == null || autoStop == null || autoArchive == null || autoDelete == null) {
       return;
     }
@@ -140,11 +161,12 @@ const ConfigureSandboxForm = ({
         </span>
       }
     >
-      <form className="flex flex-col overflow-y-auto p-5 md:p-6" onSubmit={handleSubmit}>
+      <form className="flex flex-col overflow-y-auto p-5 md:p-6" noValidate onSubmit={handleSubmit}>
         <div className="space-y-4">
           <div>
             <label htmlFor="sandbox-api-key" className="mb-1.5 block text-sm font-medium text-text-primary">
               API key
+              {requireApiKey ? <RequiredMark /> : null}
               {!requireApiKey ? <span className="font-normal text-text-secondary"> (optional)</span> : null}
             </label>
             <input
@@ -155,10 +177,16 @@ const ConfigureSandboxForm = ({
               onChange={event => {
                 setApiKey(event.target.value);
               }}
+              onBlur={() => touch('apiKey')}
               placeholder={requireApiKey ? 'dtn_...' : 'Leave blank to keep existing'}
               autoFocus
-              className={inputClassName}
+              aria-invalid={isTouched('apiKey') && apiKeyError ? true : undefined}
+              aria-describedby={isTouched('apiKey') && apiKeyError ? 'sandbox-api-key-error' : undefined}
+              className={cn(inputClassName, isTouched('apiKey') && apiKeyError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
             />
+            {isTouched('apiKey') && apiKeyError ? (
+              <SettingsFieldError id="sandbox-api-key-error">{apiKeyError}</SettingsFieldError>
+            ) : null}
           </div>
 
           <Accordion
@@ -186,15 +214,27 @@ const ConfigureSandboxForm = ({
                 <input
                   id="sandbox-exec-timeout"
                   type="number"
-                  min={0}
+                  min={1}
+                  step={1}
                   required
                   value={execTimeoutMs}
                   onChange={event => {
                     setExecTimeoutMs(event.target.value);
                   }}
+                  onBlur={() => touch('execTimeout')}
                   placeholder="300000"
-                  className={inputClassName}
+                  aria-invalid={isTouched('execTimeout') && execTimeoutError ? true : undefined}
+                  aria-describedby={
+                    isTouched('execTimeout') && execTimeoutError ? 'sandbox-exec-timeout-error' : undefined
+                  }
+                  className={cn(
+                    inputClassName,
+                    isTouched('execTimeout') && execTimeoutError && SETTINGS_INPUT_ERROR_CLASS_NAME,
+                  )}
                 />
+                {isTouched('execTimeout') && execTimeoutError ? (
+                  <SettingsFieldError id="sandbox-exec-timeout-error">{execTimeoutError}</SettingsFieldError>
+                ) : null}
               </div>
 
               <div>
@@ -205,14 +245,24 @@ const ConfigureSandboxForm = ({
                   id="sandbox-auto-stop"
                   type="number"
                   min={0}
+                  step={1}
                   required
                   value={autoStopIntervalInMinutes}
                   onChange={event => {
                     setAutoStopIntervalInMinutes(event.target.value);
                   }}
+                  onBlur={() => touch('autoStop')}
                   placeholder="15"
-                  className={inputClassName}
+                  aria-invalid={isTouched('autoStop') && autoStopError ? true : undefined}
+                  aria-describedby={isTouched('autoStop') && autoStopError ? 'sandbox-auto-stop-error' : undefined}
+                  className={cn(
+                    inputClassName,
+                    isTouched('autoStop') && autoStopError && SETTINGS_INPUT_ERROR_CLASS_NAME,
+                  )}
                 />
+                {isTouched('autoStop') && autoStopError ? (
+                  <SettingsFieldError id="sandbox-auto-stop-error">{autoStopError}</SettingsFieldError>
+                ) : null}
               </div>
 
               <div>
@@ -223,14 +273,26 @@ const ConfigureSandboxForm = ({
                   id="sandbox-auto-archive"
                   type="number"
                   min={0}
+                  step={1}
                   required
                   value={autoArchiveIntervalInMinutes}
                   onChange={event => {
                     setAutoArchiveIntervalInMinutes(event.target.value);
                   }}
+                  onBlur={() => touch('autoArchive')}
                   placeholder="10080"
-                  className={inputClassName}
+                  aria-invalid={isTouched('autoArchive') && autoArchiveError ? true : undefined}
+                  aria-describedby={
+                    isTouched('autoArchive') && autoArchiveError ? 'sandbox-auto-archive-error' : undefined
+                  }
+                  className={cn(
+                    inputClassName,
+                    isTouched('autoArchive') && autoArchiveError && SETTINGS_INPUT_ERROR_CLASS_NAME,
+                  )}
                 />
+                {isTouched('autoArchive') && autoArchiveError ? (
+                  <SettingsFieldError id="sandbox-auto-archive-error">{autoArchiveError}</SettingsFieldError>
+                ) : null}
               </div>
 
               <div>
@@ -241,14 +303,26 @@ const ConfigureSandboxForm = ({
                   id="sandbox-auto-delete"
                   type="number"
                   min={0}
+                  step={1}
                   required
                   value={autoDeleteIntervalInMinutes}
                   onChange={event => {
                     setAutoDeleteIntervalInMinutes(event.target.value);
                   }}
+                  onBlur={() => touch('autoDelete')}
                   placeholder="43200"
-                  className={inputClassName}
+                  aria-invalid={isTouched('autoDelete') && autoDeleteError ? true : undefined}
+                  aria-describedby={
+                    isTouched('autoDelete') && autoDeleteError ? 'sandbox-auto-delete-error' : undefined
+                  }
+                  className={cn(
+                    inputClassName,
+                    isTouched('autoDelete') && autoDeleteError && SETTINGS_INPUT_ERROR_CLASS_NAME,
+                  )}
                 />
+                {isTouched('autoDelete') && autoDeleteError ? (
+                  <SettingsFieldError id="sandbox-auto-delete-error">{autoDeleteError}</SettingsFieldError>
+                ) : null}
               </div>
             </AccordionDetails>
           </Accordion>

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/ConnectorSettings.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/ConnectorSettings.tsx
@@ -16,6 +16,8 @@ import { useToasterOptional } from '../ToasterContainer.js';
 import AddMcpServerForm, { type AddMcpServerDraft } from './AddMcpServerForm.js';
 import { AUTH_TYPE_LABELS } from './authTypeLabels.js';
 import ConnectorDetails from './ConnectorDetails.js';
+import { RequiredMark, SETTINGS_INPUT_ERROR_CLASS_NAME, SettingsFieldError } from './SettingsFormField.js';
+import { validateRequired } from './settingsFormValidation.js';
 
 type ConnectorListItem =
   { connector: ConnectorBase; isConfigured: true } | { connector: ConnectorCatalogEntry; isConfigured: false };
@@ -44,15 +46,13 @@ const ConnectorSettings = () => {
   const [connectorAwaitingKey, setConnectorAwaitingKey] = useState<ConnectorCatalogEntry | null>(null);
   const [selectedConnector, setSelectedConnector] = useState<ConnectorBase | null>(null);
   const [apiKey, setApiKey] = useState('');
+  const [apiKeyTouched, setApiKeyTouched] = useState(false);
+  const apiKeyError = validateRequired({ value: apiKey, label: 'API key or token' });
 
   const connectorIconMap = useMemo(() => {
-    return (catalog ?? []).reduce(
-      (acc, entry) => {
-        acc[entry.name] = entry.logo ?? '';
-        return acc;
-      },
-      {} as Record<string, string>,
-    );
+    const icons: Record<string, string> = {};
+    for (const entry of catalog) icons[entry.name] = entry.logo ?? '';
+    return icons;
   }, [catalog]);
 
   const refresh = useCallback(async () => {
@@ -124,6 +124,11 @@ const ConnectorSettings = () => {
     return result;
   }, [matchingConnectors]);
 
+  const configuredConnectorNames = useMemo(
+    () => connectors.ordered.filter(item => item.isConfigured).map(item => item.connector.name),
+    [connectors.ordered],
+  );
+
   const runMutation = async (fn: () => Promise<void>, setMutationError = setError) => {
     setBusy(true);
     setError(null);
@@ -141,6 +146,7 @@ const ConnectorSettings = () => {
   const closeApiKeyModal = () => {
     setConnectorAwaitingKey(null);
     setApiKey('');
+    setApiKeyTouched(false);
     setFormError(null);
   };
 
@@ -166,6 +172,7 @@ const ConnectorSettings = () => {
   const handleConnect = (entry: ConnectorCatalogEntry) => {
     if (entry.auth.type === 'header') {
       setApiKey('');
+      setApiKeyTouched(false);
       setFormError(null);
       setConnectorAwaitingKey(entry);
       return;
@@ -178,7 +185,8 @@ const ConnectorSettings = () => {
 
   const handleApiKeySubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!connectorAwaitingKey || !apiKey.trim()) return;
+    setApiKeyTouched(true);
+    if (!connectorAwaitingKey || apiKeyError) return;
 
     const entry = connectorAwaitingKey;
     setFormError(null);
@@ -475,7 +483,7 @@ const ConnectorSettings = () => {
             contentSized
             className="md:max-w-xl"
           >
-            <form onSubmit={handleApiKeySubmit}>
+            <form noValidate onSubmit={handleApiKeySubmit}>
               <div className="space-y-5 px-5 py-5">
                 <div className="flex items-center gap-3">
                   <span
@@ -496,6 +504,7 @@ const ConnectorSettings = () => {
                     className="mb-2 block text-xs font-semibold uppercase tracking-wide text-text-secondary"
                   >
                     API key / token
+                    <RequiredMark />
                   </label>
                   <input
                     id="connector-api-key"
@@ -504,11 +513,20 @@ const ConnectorSettings = () => {
                     onChange={event => {
                       setApiKey(event.target.value);
                     }}
+                    onBlur={() => setApiKeyTouched(true)}
                     placeholder={`Paste the token from ${connectorAwaitingKey?.name ?? 'the provider'}`}
                     autoFocus
                     required
-                    className={auiInputClass('h-11')}
+                    aria-invalid={apiKeyTouched && apiKeyError ? true : undefined}
+                    aria-describedby={apiKeyTouched && apiKeyError ? 'connector-api-key-error' : undefined}
+                    className={cn(
+                      auiInputClass('h-11'),
+                      apiKeyTouched && apiKeyError && SETTINGS_INPUT_ERROR_CLASS_NAME,
+                    )}
                   />
+                  {apiKeyTouched && apiKeyError ? (
+                    <SettingsFieldError id="connector-api-key-error">{apiKeyError}</SettingsFieldError>
+                  ) : null}
                 </div>
                 {formError ? <p className="text-failure-bg text-sm">{formError}</p> : null}
               </div>
@@ -531,6 +549,7 @@ const ConnectorSettings = () => {
               if (!open) setFormError(null);
             }}
             onAdd={handleAddMcpServer}
+            existingNames={configuredConnectorNames}
             busy={busy}
             error={formError}
           />

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/CustomModelProviderForm.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/CustomModelProviderForm.tsx
@@ -6,6 +6,14 @@ import { cn } from '../../atoms/lib/cn.js';
 import { Button } from '../../atoms/primitives/Button.js';
 import { CenteredModal } from '../../atoms/primitives/CenteredModal.js';
 import { Icon } from '../../icons/Icon.js';
+import { RequiredMark, SETTINGS_INPUT_ERROR_CLASS_NAME, SettingsFieldError } from './SettingsFormField.js';
+import {
+  validateHttpUrl,
+  validatePositiveInteger,
+  validateRequired,
+  validateResourceName,
+  validateUniqueValue,
+} from './settingsFormValidation.js';
 
 export type CustomProviderDraft = {
   name: string;
@@ -33,6 +41,7 @@ type CustomModelProviderFormProps = {
   reasoningEffortOptions?: readonly string[];
   busy?: boolean;
   error?: string | null;
+  existingNames?: readonly string[];
 };
 
 type ModelRow = {
@@ -44,6 +53,7 @@ type ModelRow = {
   idTouched?: boolean;
   contextTouched?: boolean;
   maxTouched?: boolean;
+  nameTouched?: boolean;
   // Set once the user edits the model name by hand, so auto-derive from the id stops.
   nameDirty?: boolean;
   // `id` is the upstream model_id; kept last so object-shorthand stays readable.
@@ -80,7 +90,6 @@ const createModelRows = (initialValues?: CustomProviderInitialValues): ModelRow[
 // deeper fill, a subtle hairline, and a clear focus ring.
 const inputClassName =
   'h-11 w-full rounded-md border border-border/70 bg-secondary-bg px-3 text-sm text-text-primary outline-none transition-colors placeholder:text-text-secondary/70 focus-visible:border-focus-ring focus-visible:ring-2 focus-visible:ring-focus-ring/50';
-const inputErrorClassName = 'border-failure-bg focus-visible:border-failure-bg focus-visible:ring-failure-bg';
 
 /** Parse an optional positive integer; returns null when empty or invalid (so it's simply omitted). */
 function parsePositiveInt(raw: string): number | null {
@@ -101,16 +110,6 @@ function slugifyModelId(raw: string): string {
     .replace(/-+$/g, ''); // …then trim any separator truncation left at the end
 }
 
-const RequiredMark = () => (
-  <span className="ml-0.5 text-failure-bg" aria-hidden>
-    *
-  </span>
-);
-
-const FieldError = ({ children }: { children: ReactNode }) => (
-  <p className="mt-1 text-xs text-failure-bg">{children}</p>
-);
-
 const FieldHelp = ({ children }: { children: ReactNode }) => (
   <p className="mt-1 text-xs text-text-secondary">{children}</p>
 );
@@ -124,6 +123,7 @@ const CustomModelProviderForm = ({
   error,
   isEditMode = false,
   initialValues,
+  existingNames = [],
 }: CustomModelProviderFormProps) => {
   const [name, setName] = useState(initialValues?.name ?? '');
   const [baseUrl, setBaseUrl] = useState(initialValues?.baseUrl ?? '');
@@ -161,38 +161,37 @@ const CustomModelProviderForm = ({
       current.map(model => ({
         ...model,
         idTouched: true,
+        nameTouched: true,
         contextTouched: true,
         maxTouched: true,
       })),
     );
   };
 
-  // ── Validation ── Client checks stay backend-agnostic: presence only. Name *format*
-  // rules (slug pattern, length) belong to the server, which may differ per deployment;
-  // violations surface via the `error` prop on submit rather than being second-guessed here.
   const trimmedName = name.trim();
-  const nameError = trimmedName ? null : 'Name is required.';
+  const nameError = validateResourceName({
+    value: name,
+    label: 'Provider name',
+    existingNames,
+    ...(isEditMode && initialValues ? { originalName: initialValues.name } : {}),
+  });
 
   const trimmedBaseUrl = baseUrl.trim();
-  let baseUrlError: string | null = null;
-  if (!trimmedBaseUrl) {
-    baseUrlError = 'Base URL is required.';
-  } else {
-    try {
-      new URL(trimmedBaseUrl);
-    } catch {
-      baseUrlError = 'Enter a valid URL.';
-    }
-  }
-
-  const modelIdError = (model: ModelRow): string | null => (model.id.trim() ? null : 'Model ID is required.');
-  const modelNameError = (model: ModelRow): string | null => (model.name.trim() ? null : 'Model name is required.');
+  const baseUrlError = validateHttpUrl({ value: baseUrl, label: 'Base URL' });
+  const modelIds = models.map(model => model.id.trim());
+  const modelNames = models.map(model => model.name.trim());
+  const modelIdError = (model: ModelRow): string | null =>
+    validateRequired({ value: model.id, label: 'Model ID' }) ??
+    validateUniqueValue({ value: model.id, values: modelIds, label: 'Model ID' });
+  const modelNameError = (model: ModelRow): string | null =>
+    validateResourceName({ value: model.name, label: 'Model name' }) ??
+    validateUniqueValue({ value: model.name, values: modelNames, label: 'Model name' });
 
   // Both limits are required: the harness budgets a run as input + reserved output ≤ context window.
   const modelContextError = (model: ModelRow): string | null =>
-    parsePositiveInt(model.contextLength) == null ? "Set the model's context window." : null;
+    validatePositiveInteger({ value: model.contextLength, label: 'Context length' });
   const modelMaxOutputError = (model: ModelRow): string | null =>
-    parsePositiveInt(model.maxOutputTokens) == null ? 'Set the max output tokens.' : null;
+    validatePositiveInteger({ value: model.maxOutputTokens, label: 'Max output tokens' });
 
   // The Add-provider button gates on the always-visible fields. The collapsed per-model
   // limits are enforced on submit — auto-expanding and focusing the first offender.
@@ -217,7 +216,7 @@ const CustomModelProviderForm = ({
         const el = document.getElementById(`custom-provider-model-${incompleteIndex}-${field}`);
         // scrollIntoView is unimplemented in jsdom; guard the method so tests don't throw.
         el?.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
-        (el as HTMLInputElement | null)?.focus();
+        el?.focus();
       }, 0);
       return;
     }
@@ -261,6 +260,7 @@ const CustomModelProviderForm = ({
     >
       <form
         className="flex min-h-0 flex-1 flex-col"
+        noValidate
         onSubmit={event => {
           event.preventDefault();
           void handleSubmit();
@@ -284,14 +284,17 @@ const CustomModelProviderForm = ({
               readOnly={isEditMode}
               aria-readonly={isEditMode}
               aria-invalid={showNameError ? true : undefined}
+              aria-describedby={showNameError ? 'custom-provider-name-error' : undefined}
               className={cn(
                 inputClassName,
                 isEditMode && 'cursor-not-allowed bg-secondary-bg/60 text-text-secondary',
-                showNameError && inputErrorClassName,
+                showNameError && SETTINGS_INPUT_ERROR_CLASS_NAME,
               )}
             />
             {isEditMode ? <FieldHelp>Provider names cannot be changed after creation.</FieldHelp> : null}
-            {showNameError ? <FieldError>{nameError}</FieldError> : null}
+            {showNameError ? (
+              <SettingsFieldError id="custom-provider-name-error">{nameError}</SettingsFieldError>
+            ) : null}
           </div>
 
           <div>
@@ -308,10 +311,11 @@ const CustomModelProviderForm = ({
               placeholder="http://localhost:11434/v1"
               autoFocus={isEditMode}
               aria-invalid={showBaseUrlError ? true : undefined}
-              className={cn(inputClassName, showBaseUrlError && inputErrorClassName)}
+              aria-describedby={showBaseUrlError ? 'custom-provider-base-url-error' : undefined}
+              className={cn(inputClassName, showBaseUrlError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
             />
             {showBaseUrlError ? (
-              <FieldError>{baseUrlError}</FieldError>
+              <SettingsFieldError id="custom-provider-base-url-error">{baseUrlError}</SettingsFieldError>
             ) : !trimmedBaseUrl ? (
               <FieldHelp>OpenAI-compatible endpoint, usually ending in /v1.</FieldHelp>
             ) : null}
@@ -348,10 +352,8 @@ const CustomModelProviderForm = ({
                 const idError = modelIdError(model);
                 const showIdError = model.idTouched && idError;
                 const nameFieldError = modelNameError(model);
-                // The Model name is auto-derived from the Model ID and is editable. Never flag an
-                // auto-derived value: if the id yields no usable name, stay silent and let the user
-                // type one. Only surface an error once they have hand-edited the name themselves.
-                const showNameFieldError = !!nameFieldError && model.nameDirty;
+                // Auto-derived names stay quiet while typing; submit still reveals an invalid or duplicate value.
+                const showNameFieldError = model.nameTouched && nameFieldError;
                 const contextError = modelContextError(model);
                 const maxError = modelMaxOutputError(model);
                 const showContextError = model.contextTouched && contextError;
@@ -385,7 +387,8 @@ const CustomModelProviderForm = ({
                           onBlur={() => updateModel(index, { idTouched: true })}
                           placeholder="llama3.1:70b"
                           aria-invalid={showIdError ? true : undefined}
-                          className={cn(inputClassName, 'font-mono', showIdError && inputErrorClassName)}
+                          aria-describedby={showIdError ? `custom-provider-model-${index}-id-error` : undefined}
+                          className={cn(inputClassName, 'font-mono', showIdError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
                         />
                       </div>
                       <div className="min-w-0">
@@ -400,9 +403,13 @@ const CustomModelProviderForm = ({
                           type="text"
                           value={model.name}
                           onChange={event => updateModel(index, { name: event.target.value, nameDirty: true })}
+                          onBlur={() => updateModel(index, { nameTouched: true })}
                           placeholder="llama-3-1-70b"
                           aria-invalid={showNameFieldError ? true : undefined}
-                          className={cn(inputClassName, showNameFieldError && inputErrorClassName)}
+                          aria-describedby={
+                            showNameFieldError ? `custom-provider-model-${index}-name-error` : undefined
+                          }
+                          className={cn(inputClassName, showNameFieldError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
                         />
                       </div>
                       <button
@@ -415,8 +422,14 @@ const CustomModelProviderForm = ({
                         <Icon name="trash" className="size-4" />
                       </button>
                     </div>
-                    {showIdError ? <FieldError>{idError}</FieldError> : null}
-                    {showNameFieldError ? <FieldError>{nameFieldError}</FieldError> : null}
+                    {showIdError ? (
+                      <SettingsFieldError id={`custom-provider-model-${index}-id-error`}>{idError}</SettingsFieldError>
+                    ) : null}
+                    {showNameFieldError ? (
+                      <SettingsFieldError id={`custom-provider-model-${index}-name-error`}>
+                        {nameFieldError}
+                      </SettingsFieldError>
+                    ) : null}
 
                     {/* Advanced (plain text toggle, no surrounding box) */}
                     <div className="mt-2">
@@ -451,16 +464,22 @@ const CustomModelProviderForm = ({
                               id={`custom-provider-model-${index}-context-length`}
                               type="number"
                               min={1}
+                              step={1}
                               inputMode="numeric"
                               value={model.contextLength}
                               onChange={event => updateModel(index, { contextLength: event.target.value })}
                               onBlur={() => updateModel(index, { contextTouched: true })}
                               placeholder={PLACEHOLDER_CONTEXT_LENGTH}
                               aria-invalid={showContextError ? true : undefined}
-                              className={cn(inputClassName, showContextError && inputErrorClassName)}
+                              aria-describedby={
+                                showContextError ? `custom-provider-model-${index}-context-error` : undefined
+                              }
+                              className={cn(inputClassName, showContextError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
                             />
                             {showContextError ? (
-                              <FieldError>{contextError}</FieldError>
+                              <SettingsFieldError id={`custom-provider-model-${index}-context-error`}>
+                                {contextError}
+                              </SettingsFieldError>
                             ) : model.contextLength.trim() === '' ? (
                               <FieldHelp>Model&apos;s total token window.</FieldHelp>
                             ) : null}
@@ -478,16 +497,22 @@ const CustomModelProviderForm = ({
                               id={`custom-provider-model-${index}-max-output-tokens`}
                               type="number"
                               min={1}
+                              step={1}
                               inputMode="numeric"
                               value={model.maxOutputTokens}
                               onChange={event => updateModel(index, { maxOutputTokens: event.target.value })}
                               onBlur={() => updateModel(index, { maxTouched: true })}
                               placeholder={PLACEHOLDER_MAX_OUTPUT_TOKENS}
                               aria-invalid={showMaxError ? true : undefined}
-                              className={cn(inputClassName, showMaxError && inputErrorClassName)}
+                              aria-describedby={
+                                showMaxError ? `custom-provider-model-${index}-max-output-error` : undefined
+                              }
+                              className={cn(inputClassName, showMaxError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
                             />
                             {showMaxError ? (
-                              <FieldError>{maxError}</FieldError>
+                              <SettingsFieldError id={`custom-provider-model-${index}-max-output-error`}>
+                                {maxError}
+                              </SettingsFieldError>
                             ) : model.maxOutputTokens.trim() === '' ? (
                               <FieldHelp>Longest reply the model allows — use its real limit.</FieldHelp>
                             ) : null}

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/ImportGithubSkillForm.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/ImportGithubSkillForm.tsx
@@ -2,11 +2,25 @@
 
 import { useState, type SyntheticEvent } from 'react';
 
+import { cn } from '@/atoms/lib/cn.js';
 import { auiInputClass } from '@/atoms/lib/inputClasses.js';
 import { Button } from '@/atoms/primitives/Button.js';
 import { CenteredModal } from '@/atoms/primitives/CenteredModal.js';
 import { Icon } from '@/icons/Icon.js';
 import type { SkillConfigBase } from '../../server/types.js';
+import {
+  RequiredMark,
+  SETTINGS_INPUT_ERROR_CLASS_NAME,
+  SettingsFieldError,
+  useTouchedFields,
+} from './SettingsFormField.js';
+import {
+  validateGitPath,
+  validateGitRef,
+  validateGitRepositoryUrl,
+  validateRequired,
+  validateResourceName,
+} from './settingsFormValidation.js';
 
 type ImportGithubSkillFormProps = {
   open: boolean;
@@ -14,14 +28,26 @@ type ImportGithubSkillFormProps = {
   onImport: (draft: SkillConfigBase) => void | Promise<void>;
   busy?: boolean;
   error?: string | null;
+  existingNames?: readonly string[];
 };
 
-const ImportGithubSkillForm = ({ open, onOpenChange, onImport, busy = false, error }: ImportGithubSkillFormProps) => {
+type SkillField = 'name' | 'description' | 'repoUrl' | 'path' | 'ref';
+const SKILL_FIELDS: readonly SkillField[] = ['name', 'description', 'repoUrl', 'path', 'ref'];
+
+const ImportGithubSkillForm = ({
+  open,
+  onOpenChange,
+  onImport,
+  busy = false,
+  error,
+  existingNames = [],
+}: ImportGithubSkillFormProps) => {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [repoURL, setRepoURL] = useState('');
   const [path, setPath] = useState('');
   const [ref, setRef] = useState('');
+  const { isTouched, resetTouched, touch, touchAll } = useTouchedFields<SkillField>();
 
   const reset = () => {
     setName('');
@@ -29,6 +55,7 @@ const ImportGithubSkillForm = ({ open, onOpenChange, onImport, busy = false, err
     setRepoURL('');
     setPath('');
     setRef('');
+    resetTouched();
   };
 
   const close = () => {
@@ -38,7 +65,8 @@ const ImportGithubSkillForm = ({ open, onOpenChange, onImport, busy = false, err
 
   const handleSubmit = async (event: SyntheticEvent<HTMLFormElement, SubmitEvent>) => {
     event.preventDefault();
-    if (!name.trim() || !description.trim() || !repoURL.trim() || !path.trim() || !ref.trim() || busy) return;
+    touchAll(SKILL_FIELDS);
+    if (!isValid || busy) return;
 
     try {
       await onImport({
@@ -54,7 +82,13 @@ const ImportGithubSkillForm = ({ open, onOpenChange, onImport, busy = false, err
     }
   };
 
-  const canImport = Boolean(name.trim() && description.trim() && repoURL.trim() && path.trim() && ref.trim()) && !busy;
+  const nameError = validateResourceName({ value: name, label: 'Skill name', existingNames });
+  const descriptionError = validateRequired({ value: description, label: 'Description' });
+  const repoUrlError = validateGitRepositoryUrl(repoURL);
+  const pathError = validateGitPath(path);
+  const refError = validateGitRef(ref);
+  const isValid = !nameError && !descriptionError && !repoUrlError && !pathError && !refError;
+  const canImport = isValid && !busy;
 
   return (
     <CenteredModal
@@ -72,11 +106,12 @@ const ImportGithubSkillForm = ({ open, onOpenChange, onImport, busy = false, err
       contentSized
       className="md:max-w-2xl"
     >
-      <form onSubmit={e => void handleSubmit(e)}>
+      <form noValidate onSubmit={e => void handleSubmit(e)}>
         <div className="space-y-5 px-5 py-5 md:px-6">
           <div>
             <label htmlFor="skill-name" className="mb-2 block text-sm font-semibold text-text-primary">
               Name
+              <RequiredMark />
             </label>
             <input
               id="skill-name"
@@ -84,16 +119,23 @@ const ImportGithubSkillForm = ({ open, onOpenChange, onImport, busy = false, err
               onChange={event => {
                 setName(event.target.value);
               }}
+              onBlur={() => touch('name')}
               placeholder="release-notes"
               autoFocus
               required
-              className={auiInputClass('h-11')}
+              aria-invalid={isTouched('name') && nameError ? true : undefined}
+              aria-describedby={isTouched('name') && nameError ? 'skill-name-error' : undefined}
+              className={cn(auiInputClass('h-11'), isTouched('name') && nameError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
             />
+            {isTouched('name') && nameError ? (
+              <SettingsFieldError id="skill-name-error">{nameError}</SettingsFieldError>
+            ) : null}
           </div>
 
           <div>
             <label htmlFor="skill-description" className="mb-2 block text-sm font-semibold text-text-primary">
               Description
+              <RequiredMark />
             </label>
             <textarea
               id="skill-description"
@@ -101,16 +143,26 @@ const ImportGithubSkillForm = ({ open, onOpenChange, onImport, busy = false, err
               onChange={event => {
                 setDescription(event.target.value);
               }}
+              onBlur={() => touch('description')}
               placeholder="Generate release notes from merged pull requests"
               required
               rows={3}
-              className={auiInputClass('resize-y py-2.5')}
+              aria-invalid={isTouched('description') && descriptionError ? true : undefined}
+              aria-describedby={isTouched('description') && descriptionError ? 'skill-description-error' : undefined}
+              className={cn(
+                auiInputClass('resize-y py-2.5'),
+                isTouched('description') && descriptionError && SETTINGS_INPUT_ERROR_CLASS_NAME,
+              )}
             />
+            {isTouched('description') && descriptionError ? (
+              <SettingsFieldError id="skill-description-error">{descriptionError}</SettingsFieldError>
+            ) : null}
           </div>
 
           <div>
             <label htmlFor="skill-repo-url" className="mb-2 block text-sm font-semibold text-text-primary">
               Repository URL
+              <RequiredMark />
             </label>
             <input
               id="skill-repo-url"
@@ -119,15 +171,25 @@ const ImportGithubSkillForm = ({ open, onOpenChange, onImport, busy = false, err
               onChange={event => {
                 setRepoURL(event.target.value);
               }}
+              onBlur={() => touch('repoUrl')}
               placeholder="https://github.com/org/repo"
               required
-              className={auiInputClass('h-11')}
+              aria-invalid={isTouched('repoUrl') && repoUrlError ? true : undefined}
+              aria-describedby={isTouched('repoUrl') && repoUrlError ? 'skill-repo-url-error' : undefined}
+              className={cn(
+                auiInputClass('h-11'),
+                isTouched('repoUrl') && repoUrlError && SETTINGS_INPUT_ERROR_CLASS_NAME,
+              )}
             />
+            {isTouched('repoUrl') && repoUrlError ? (
+              <SettingsFieldError id="skill-repo-url-error">{repoUrlError}</SettingsFieldError>
+            ) : null}
           </div>
 
           <div>
             <label htmlFor="skill-path" className="mb-2 block text-sm font-semibold text-text-primary">
               Folder containing the SKILL.md
+              <RequiredMark />
             </label>
             <input
               id="skill-path"
@@ -135,15 +197,22 @@ const ImportGithubSkillForm = ({ open, onOpenChange, onImport, busy = false, err
               onChange={event => {
                 setPath(event.target.value);
               }}
+              onBlur={() => touch('path')}
               placeholder="skills/release-notes"
               required
-              className={auiInputClass('h-11')}
+              aria-invalid={isTouched('path') && pathError ? true : undefined}
+              aria-describedby={isTouched('path') && pathError ? 'skill-path-error' : undefined}
+              className={cn(auiInputClass('h-11'), isTouched('path') && pathError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
             />
+            {isTouched('path') && pathError ? (
+              <SettingsFieldError id="skill-path-error">{pathError}</SettingsFieldError>
+            ) : null}
           </div>
 
           <div>
             <label htmlFor="skill-ref" className="mb-2 block text-sm font-semibold text-text-primary">
               Branch
+              <RequiredMark />
             </label>
             <input
               id="skill-ref"
@@ -151,10 +220,16 @@ const ImportGithubSkillForm = ({ open, onOpenChange, onImport, busy = false, err
               onChange={event => {
                 setRef(event.target.value);
               }}
+              onBlur={() => touch('ref')}
               placeholder="main"
               required
-              className={auiInputClass('h-11')}
+              aria-invalid={isTouched('ref') && refError ? true : undefined}
+              aria-describedby={isTouched('ref') && refError ? 'skill-ref-error' : undefined}
+              className={cn(auiInputClass('h-11'), isTouched('ref') && refError && SETTINGS_INPUT_ERROR_CLASS_NAME)}
             />
+            {isTouched('ref') && refError ? (
+              <SettingsFieldError id="skill-ref-error">{refError}</SettingsFieldError>
+            ) : null}
           </div>
 
           <div className="space-y-3">

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/ModelSettings.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/ModelSettings.tsx
@@ -43,13 +43,9 @@ const ModelSettings = () => {
   const [customProviderToEdit, setCustomProviderToEdit] = useState<ModelProviderBase | null>(null);
 
   const modelProviderIconMap = useMemo(() => {
-    return (catalog ?? []).reduce(
-      (acc, entry) => {
-        acc[entry.name] = entry.logo ?? '';
-        return acc;
-      },
-      {} as Record<string, string>,
-    );
+    const icons: Record<string, string> = {};
+    for (const entry of catalog) icons[entry.name] = entry.logo ?? '';
+    return icons;
   }, [catalog]);
 
   const normalizedQuery = query.trim().toLowerCase();
@@ -531,6 +527,7 @@ const ModelSettings = () => {
             isEditMode={customProviderToEdit !== null}
             initialValues={customProviderInitialValues}
             onSubmit={customProviderToEdit ? handleUpdateCustomProvider : handleAddCustomProvider}
+            existingNames={configured.map(provider => provider.name)}
             reasoningEffortOptions={supportedReasoningEfforts}
             busy={busy}
             error={formError}

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/SettingsFormField.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/SettingsFormField.tsx
@@ -1,0 +1,36 @@
+import { useCallback, useState, type ReactNode } from 'react';
+
+export const SETTINGS_INPUT_ERROR_CLASS_NAME =
+  'border-failure-bg focus-visible:border-failure-bg focus-visible:ring-failure-bg';
+
+export function RequiredMark() {
+  return <span className="ml-0.5 text-failure-bg after:content-['*']" aria-hidden />;
+}
+
+export function SettingsFieldError({ id, children }: { id: string; children: ReactNode }) {
+  return (
+    <p id={id} className="mt-1 text-xs text-failure-bg">
+      {children}
+    </p>
+  );
+}
+
+export function useTouchedFields<Field extends string>() {
+  const [touched, setTouched] = useState<ReadonlySet<Field>>(() => new Set());
+
+  const touch = useCallback((field: Field) => {
+    setTouched(current => new Set(current).add(field));
+  }, []);
+
+  const touchAll = useCallback((fields: readonly Field[]) => {
+    setTouched(new Set(fields));
+  }, []);
+
+  const resetTouched = useCallback(() => {
+    setTouched(new Set());
+  }, []);
+
+  const isTouched = useCallback((field: Field) => touched.has(field), [touched]);
+
+  return { isTouched, resetTouched, touch, touchAll };
+}

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/SkillSettings.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/SkillSettings.tsx
@@ -258,6 +258,7 @@ const SkillSettings = () => {
           if (!open) setFormError(null);
         }}
         onImport={handleImport}
+        existingNames={skills.map(skill => skill.name)}
         busy={busy}
         error={formError}
       />

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/settingsFormValidation.ts
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/settingsFormValidation.ts
@@ -1,0 +1,158 @@
+// These checks provide immediate form feedback; server schemas remain authoritative for every request.
+const RESOURCE_NAME_PATTERN = /^[a-z](?:[a-z0-9._-]{0,62}[a-z0-9])$/;
+const HTTP_HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+const GIT_REPOSITORY_URL_PATTERN =
+  /^https:\/\/(github\.com\/[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+|gitlab\.com\/[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+)(\/|\.git)?$/;
+const GIT_REF_PATTERN = /^[A-Za-z0-9._\-/]+$/;
+const GIT_PATH_PATTERN = /^[A-Za-z0-9._\-/]+$/;
+
+function containsParentTraversal(value: string): boolean {
+  return value.split('/').includes('..');
+}
+
+function isDuplicate({
+  value,
+  existingValues,
+  originalValue,
+  caseSensitive = true,
+}: {
+  value: string;
+  existingValues: readonly string[];
+  originalValue?: string;
+  caseSensitive?: boolean;
+}): boolean {
+  const normalize = (candidate: string) => (caseSensitive ? candidate.trim() : candidate.trim().toLowerCase());
+  const normalizedValue = normalize(value);
+  if (originalValue !== undefined && normalizedValue === normalize(originalValue)) return false;
+  return existingValues.some(candidate => normalize(candidate) === normalizedValue);
+}
+
+export function validateRequired({ value, label }: { value: string; label: string }): string | null {
+  return value.trim() ? null : `${label} is required.`;
+}
+
+export function validateResourceName({
+  value,
+  label,
+  existingNames = [],
+  originalName,
+}: {
+  value: string;
+  label: string;
+  existingNames?: readonly string[];
+  originalName?: string;
+}): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return `${label} is required.`;
+  if (!RESOURCE_NAME_PATTERN.test(trimmed)) {
+    return `${label} must be 2–64 lowercase characters, start with a letter, and end with a letter or number.`;
+  }
+  if (isDuplicate({ value: trimmed, existingValues: existingNames, originalValue: originalName })) {
+    return `${label} “${trimmed}” already exists.`;
+  }
+  return null;
+}
+
+export function validateHttpUrl({
+  value,
+  label,
+  required = true,
+}: {
+  value: string;
+  label: string;
+  required?: boolean;
+}): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return required ? `${label} is required.` : null;
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? null
+      : `${label} must use http:// or https://.`;
+  } catch {
+    return `Enter a valid ${label.toLowerCase()}.`;
+  }
+}
+
+export function validateHttpHeaderName(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return HTTP_HEADER_NAME_PATTERN.test(trimmed)
+    ? null
+    : 'Header name may contain letters, numbers, hyphens, and standard HTTP header symbols only.';
+}
+
+export function validateGitRepositoryUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return 'Repository URL is required.';
+  if (!GIT_REPOSITORY_URL_PATTERN.test(trimmed) || containsParentTraversal(trimmed)) {
+    return 'Enter an HTTPS GitHub or GitLab repository URL.';
+  }
+  return null;
+}
+
+export function validateGitPath(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return 'Skill folder is required.';
+  if (!GIT_PATH_PATTERN.test(trimmed)) {
+    return 'Skill folder may contain letters, numbers, “.”, “_”, “-”, and “/” only.';
+  }
+  if (containsParentTraversal(trimmed) || trimmed.split('/').includes('.')) {
+    return 'Skill folder must not contain “.” or “..” path segments.';
+  }
+  if (!trimmed.replace(/^\/+|\/+$/g, '')) return 'Skill folder must identify a directory.';
+  return null;
+}
+
+export function validateGitRef(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return 'Branch, tag, or commit is required.';
+  if (!GIT_REF_PATTERN.test(trimmed)) {
+    return 'Branch, tag, or commit may contain letters, numbers, “.”, “_”, “-”, and “/” only.';
+  }
+  if (containsParentTraversal(trimmed) || !trimmed.replace(/^\/+|\/+$/g, '')) {
+    return 'Branch, tag, or commit must not contain “..” segments or only slashes.';
+  }
+  return null;
+}
+
+function validateInteger({ value, label, minimum }: { value: string; label: string; minimum: number }): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return `${label} is required.`;
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed < minimum) {
+    return minimum === 0
+      ? `${label} must be a whole number of 0 or more.`
+      : `${label} must be a whole number greater than 0.`;
+  }
+  return null;
+}
+
+export function validatePositiveInteger({ value, label }: { value: string; label: string }): string | null {
+  return validateInteger({ value, label, minimum: 1 });
+}
+
+export function validateNonNegativeInteger({ value, label }: { value: string; label: string }): string | null {
+  return validateInteger({ value, label, minimum: 0 });
+}
+
+export function validateUniqueValue({
+  value,
+  values,
+  label,
+  caseSensitive = true,
+}: {
+  value: string;
+  values: readonly string[];
+  label: string;
+  caseSensitive?: boolean;
+}): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return `${label} is required.`;
+  const normalizedValue = caseSensitive ? trimmed : trimmed.toLowerCase();
+  const occurrences = values.filter(candidate => {
+    const normalizedCandidate = caseSensitive ? candidate.trim() : candidate.trim().toLowerCase();
+    return normalizedCandidate === normalizedValue;
+  }).length;
+  return occurrences > 1 ? `${label} “${trimmed}” must be unique.` : null;
+}

--- a/packages/trueforge-ui/test/containers/SettingsBuilder/AddMcpServerForm.test.tsx
+++ b/packages/trueforge-ui/test/containers/SettingsBuilder/AddMcpServerForm.test.tsx
@@ -62,4 +62,37 @@ describe('AddMcpServerForm', () => {
 
     expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
   });
+
+  it('shows field-level format and duplicate errors before submitting', () => {
+    const onAdd = vi.fn(async () => undefined);
+
+    render(<AddMcpServerForm open onOpenChange={() => undefined} onAdd={onAdd} existingNames={['existing-mcp']} />);
+
+    const name = screen.getByLabelText('Name');
+    fireEvent.change(name, { target: { value: 'existing-mcp' } });
+    fireEvent.blur(name);
+    expect(screen.getByText('Connector name “existing-mcp” already exists.')).toBeInTheDocument();
+    expect(name).toHaveAttribute('aria-invalid', 'true');
+
+    const url = screen.getByLabelText('URL');
+    fireEvent.change(url, { target: { value: 'ftp://example.com/mcp' } });
+    fireEvent.blur(url);
+    expect(screen.getByText('URL must use http:// or https://.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it('validates API-key auth fields', () => {
+    render(<AddMcpServerForm open onOpenChange={() => undefined} onAdd={vi.fn(async () => undefined)} />);
+
+    fireEvent.click(screen.getByLabelText('API Key'));
+    const apiKey = screen.getByLabelText('API key');
+    fireEvent.blur(apiKey);
+    expect(screen.getByText('API key is required.')).toBeInTheDocument();
+
+    const headerName = screen.getByLabelText(/Header name/);
+    fireEvent.change(headerName, { target: { value: 'Bad Header' } });
+    fireEvent.blur(headerName);
+    expect(screen.getByText(/standard HTTP header symbols/)).toBeInTheDocument();
+  });
 });

--- a/packages/trueforge-ui/test/containers/SettingsBuilder/ConfigureModelProviderForm.test.tsx
+++ b/packages/trueforge-ui/test/containers/SettingsBuilder/ConfigureModelProviderForm.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import ConfigureModelProviderForm from '@/containers/SettingsBuilder/ConfigureModelProviderForm.js';
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.setAttribute('open', '');
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.removeAttribute('open');
+    this.dispatchEvent(new Event('close'));
+  };
+});
+
+describe('ConfigureModelProviderForm', () => {
+  it('shows required-key and optional endpoint errors beside their fields', () => {
+    render(
+      <ConfigureModelProviderForm
+        open
+        onOpenChange={() => undefined}
+        onSave={vi.fn(async () => undefined)}
+        title="Configure provider"
+      />,
+    );
+
+    const apiKey = screen.getByLabelText('API key');
+    fireEvent.blur(apiKey);
+    expect(screen.getByText('API key is required.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Advanced · custom endpoint'));
+    const baseUrl = screen.getByLabelText('Base URL');
+    fireEvent.change(baseUrl, { target: { value: 'ftp://example.com' } });
+    fireEvent.blur(baseUrl);
+    expect(screen.getByText('Base URL must use http:// or https://.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('submits trimmed valid credentials and endpoint', async () => {
+    const onSave = vi.fn(async () => undefined);
+    render(
+      <ConfigureModelProviderForm open onOpenChange={() => undefined} onSave={onSave} title="Configure provider" />,
+    );
+
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: ' secret ' } });
+    fireEvent.click(screen.getByText('Advanced · custom endpoint'));
+    fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: ' https://api.example.com/v1 ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({ apiKey: 'secret', baseUrl: 'https://api.example.com/v1' });
+    });
+  });
+});

--- a/packages/trueforge-ui/test/containers/SettingsBuilder/ConfigureSandboxForm.test.tsx
+++ b/packages/trueforge-ui/test/containers/SettingsBuilder/ConfigureSandboxForm.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import ConfigureSandboxForm from '@/containers/SettingsBuilder/ConfigureSandboxForm.js';
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.setAttribute('open', '');
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.removeAttribute('open');
+    this.dispatchEvent(new Event('close'));
+  };
+});
+
+describe('ConfigureSandboxForm', () => {
+  it('shows API-key and integer-range errors beside their fields', () => {
+    render(
+      <ConfigureSandboxForm
+        open
+        onOpenChange={() => undefined}
+        onSave={vi.fn(async () => undefined)}
+        title="Configure sandbox"
+      />,
+    );
+
+    const apiKey = screen.getByLabelText('API key');
+    fireEvent.blur(apiKey);
+    expect(screen.getByText('API key is required.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Advanced settings'));
+    const execTimeout = screen.getByLabelText('Exec timeout (ms)');
+    fireEvent.change(execTimeout, { target: { value: '0' } });
+    fireEvent.blur(execTimeout);
+    expect(screen.getByText('Exec timeout must be a whole number greater than 0.')).toBeInTheDocument();
+
+    const autoStop = screen.getByLabelText('Auto-stop interval (minutes)');
+    fireEvent.change(autoStop, { target: { value: '1.5' } });
+    fireEvent.blur(autoStop);
+    expect(screen.getByText('Auto-stop interval must be a whole number of 0 or more.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('submits valid integer settings', async () => {
+    const onSave = vi.fn(async () => undefined);
+    render(<ConfigureSandboxForm open onOpenChange={() => undefined} onSave={onSave} title="Configure sandbox" />);
+
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: ' dtn_secret ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        apiKey: 'dtn_secret',
+        execTimeoutMs: 300000,
+        autoStopIntervalInMinutes: 15,
+        autoArchiveIntervalInMinutes: 10080,
+        autoDeleteIntervalInMinutes: 43200,
+      });
+    });
+  });
+});

--- a/packages/trueforge-ui/test/containers/SettingsBuilder/CustomModelProviderForm.test.tsx
+++ b/packages/trueforge-ui/test/containers/SettingsBuilder/CustomModelProviderForm.test.tsx
@@ -16,16 +16,18 @@ beforeAll(() => {
   };
 });
 
-function renderForm(onAdd: (draft: CustomProviderDraft) => void | Promise<void> = vi.fn(async () => undefined)) {
+function renderForm({ existingNames = [] }: { existingNames?: readonly string[] } = {}) {
+  const onAdd = vi.fn(async (_draft: CustomProviderDraft) => undefined);
   render(
     <CustomModelProviderForm
       open
       onOpenChange={() => undefined}
       onSubmit={onAdd}
+      existingNames={existingNames}
       reasoningEffortOptions={['low', 'high']}
     />,
   );
-  return onAdd as ReturnType<typeof vi.fn>;
+  return onAdd;
 }
 
 /** The always-visible required fields (typing the Model ID auto-derives the Model name). */
@@ -74,17 +76,14 @@ describe('CustomModelProviderForm', () => {
     expect(submit).toBeEnabled();
   });
 
-  it('requires the provider name but defers format validation to the server', () => {
-    renderForm();
+  it('validates the provider name format and existing names', () => {
+    renderForm({ existingNames: ['existing-provider'] });
     const name = screen.getByPlaceholderText('local-llama');
-    // A non-empty name with backend-specific format issues is not rejected client-side —
-    // the server validates format and surfaces it on submit.
-    fireEvent.change(name, { target: { value: 'Local Llama' } }); // spaces + capitals
+    fireEvent.change(name, { target: { value: 'Local Llama' } });
     fireEvent.blur(name);
-    expect(screen.queryByText(/lowercase characters/)).not.toBeInTheDocument();
-    // Emptiness is the only client-side check.
-    fireEvent.change(name, { target: { value: '' } });
-    expect(screen.getByText('Name is required.')).toBeInTheDocument();
+    expect(screen.getByText(/Provider name must be 2–64 lowercase/)).toBeInTheDocument();
+    fireEvent.change(name, { target: { value: 'existing-provider' } });
+    expect(screen.getByText('Provider name “existing-provider” already exists.')).toBeInTheDocument();
   });
 
   it('flags an invalid base URL', () => {
@@ -92,21 +91,21 @@ describe('CustomModelProviderForm', () => {
     const url = screen.getByPlaceholderText('http://localhost:11434/v1');
     fireEvent.change(url, { target: { value: 'not a url' } });
     fireEvent.blur(url);
-    expect(screen.getByText('Enter a valid URL.')).toBeInTheDocument();
+    expect(screen.getByText('Enter a valid base url.')).toBeInTheDocument();
   });
 
   it('does not prefill Context length or Max output tokens', () => {
     renderForm();
     // Advanced is expanded by default, so the limits are visible immediately.
-    expect((screen.getByPlaceholderText('128000') as HTMLInputElement).value).toBe('');
-    expect((screen.getByPlaceholderText('4096') as HTMLInputElement).value).toBe('');
+    expect(screen.getByPlaceholderText('128000')).toHaveValue(null);
+    expect(screen.getByPlaceholderText('4096')).toHaveValue(null);
   });
 
   it('requires both limits: submitting with them empty shows the error and does not submit', () => {
     const onAdd = renderForm();
     fillVisible(); // Advanced is expanded by default; the limits are visible but empty.
     fireEvent.click(screen.getByRole('button', { name: 'Add provider' }));
-    expect(screen.getByText(/Set the model.s context window/)).toBeInTheDocument();
+    expect(screen.getByText('Context length is required.')).toBeInTheDocument();
     expect(onAdd).not.toHaveBeenCalled();
   });
 
@@ -114,7 +113,7 @@ describe('CustomModelProviderForm', () => {
     renderForm();
     fillVisible(); // model 1 visible-valid, limits still empty
     fireEvent.click(screen.getByRole('button', { name: 'Add provider' })); // reveals model 1's limit errors
-    expect(screen.getByText(/Set the model.s context window/)).toBeInTheDocument();
+    expect(screen.getByText('Context length is required.')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Add model' }));
     // The freshly added (untouched) model must not inherit "required" errors from the submit attempt.
@@ -169,19 +168,17 @@ describe('CustomModelProviderForm', () => {
   it('auto-derives the Model name as a slug from the Model ID', () => {
     renderForm();
     fireEvent.change(screen.getByPlaceholderText('llama3.1:70b'), { target: { value: 'llama3.1:70b' } });
-    expect((screen.getByPlaceholderText('llama-3-1-70b') as HTMLInputElement).value).toBe('llama-3-1-70b');
+    expect(screen.getByPlaceholderText('llama-3-1-70b')).toHaveValue('llama-3-1-70b');
   });
 
-  it('defers Model name format validation to the server', () => {
+  it('validates the Model name format before submission', () => {
     renderForm();
     fillVisible();
     const modelName = screen.getByPlaceholderText('llama-3-1-70b');
-    fireEvent.change(modelName, { target: { value: 'Bad Name' } }); // spaces + capitals
+    fireEvent.change(modelName, { target: { value: 'Bad Name' } });
     fireEvent.blur(modelName);
-    // No client-side format error; the server validates the slug on submit.
-    expect(screen.queryByText(/lowercase characters/)).not.toBeInTheDocument();
-    // A non-empty (if malformed) model name does not block submit client-side.
-    expect(screen.getByRole('button', { name: 'Add provider' })).toBeEnabled();
+    expect(screen.getByText(/Model name must be 2–64 lowercase/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add provider' })).toBeDisabled();
   });
 
   it('never errors the auto-derived Model name; the user just enters one', () => {
@@ -205,6 +202,21 @@ describe('CustomModelProviderForm', () => {
     expect(screen.queryByText('Model name is required.')).not.toBeInTheDocument();
   });
 
+  it('rejects duplicate model IDs within a provider', () => {
+    renderForm();
+    fillVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Add model' }));
+    const modelIds = screen.getAllByPlaceholderText('llama3.1:70b');
+    const secondModelId = modelIds[1];
+    if (!secondModelId) throw new Error('Expected a second model ID field');
+
+    fireEvent.change(secondModelId, { target: { value: 'llama3.1:70b' } });
+    fireEvent.blur(secondModelId);
+
+    expect(screen.getByText('Model ID “llama3.1:70b” must be unique.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add provider' })).toBeDisabled();
+  });
+
   it('submits the derived slug as the model name', async () => {
     const onAdd = renderForm();
     fillValid();
@@ -226,6 +238,7 @@ describe('CustomModelProviderForm', () => {
         open
         onOpenChange={() => undefined}
         onSubmit={onSubmit}
+        existingNames={['local-llama']}
         reasoningEffortOptions={['low', 'high']}
         initialValues={{
           name: 'local-llama',

--- a/packages/trueforge-ui/test/containers/SettingsBuilder/ImportGithubSkillForm.test.tsx
+++ b/packages/trueforge-ui/test/containers/SettingsBuilder/ImportGithubSkillForm.test.tsx
@@ -17,7 +17,7 @@ describe('ImportGithubSkillForm', () => {
     render(<ImportGithubSkillForm open onOpenChange={() => undefined} onImport={onImport} />);
 
     fireEvent.change(screen.getByLabelText('Name'), {
-      target: { value: ' Release notes ' },
+      target: { value: ' release-notes ' },
     });
     fireEvent.change(screen.getByLabelText('Description'), {
       target: { value: ' Generate release notes ' },
@@ -35,12 +35,49 @@ describe('ImportGithubSkillForm', () => {
 
     await waitFor(() => {
       expect(onImport).toHaveBeenCalledWith({
-        name: 'Release notes',
+        name: 'release-notes',
         description: 'Generate release notes',
         repoURL: 'https://github.com/org/repo',
         path: 'skills/release-notes',
         ref: 'main',
       });
     });
+  });
+
+  it('places resource, repository, path, and ref errors next to their fields', () => {
+    const onImport = vi.fn(async () => undefined);
+
+    render(
+      <ImportGithubSkillForm
+        open
+        onOpenChange={() => undefined}
+        onImport={onImport}
+        existingNames={['release-notes']}
+      />,
+    );
+
+    const name = screen.getByLabelText('Name');
+    fireEvent.change(name, { target: { value: 'release-notes' } });
+    fireEvent.blur(name);
+    expect(screen.getByText('Skill name “release-notes” already exists.')).toBeInTheDocument();
+
+    const repository = screen.getByLabelText('Repository URL');
+    fireEvent.change(repository, { target: { value: 'https://example.com/org/repo' } });
+    fireEvent.blur(repository);
+    expect(screen.getByText('Enter an HTTPS GitHub or GitLab repository URL.')).toBeInTheDocument();
+
+    const path = screen.getByLabelText('Folder containing the SKILL.md');
+    fireEvent.change(path, { target: { value: '../private' } });
+    fireEvent.blur(path);
+    expect(screen.getByText('Skill folder must not contain “.” or “..” path segments.')).toBeInTheDocument();
+
+    const branch = screen.getByLabelText('Branch');
+    fireEvent.change(branch, { target: { value: '../main' } });
+    fireEvent.blur(branch);
+    expect(
+      screen.getByText('Branch, tag, or commit must not contain “..” segments or only slashes.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Import' })).toBeDisabled();
+    expect(onImport).not.toHaveBeenCalled();
   });
 });

--- a/packages/trueforge-ui/test/containers/SettingsBuilder/SkillSettings.test.tsx
+++ b/packages/trueforge-ui/test/containers/SettingsBuilder/SkillSettings.test.tsx
@@ -157,7 +157,7 @@ describe('SkillSettings', () => {
     fireEvent.click(await screen.findByRole('button', { name: /Import from GitHub/ }));
 
     fireEvent.change(screen.getByLabelText('Name'), {
-      target: { value: 'House Style' },
+      target: { value: 'house-style' },
     });
     fireEvent.change(screen.getByLabelText('Description'), {
       target: { value: 'Writing rules' },
@@ -174,7 +174,7 @@ describe('SkillSettings', () => {
     await waitFor(() => {
       expect(host.created).toEqual([
         {
-          name: 'House Style',
+          name: 'house-style',
           description: 'Writing rules',
           repoURL: 'https://github.com/org/repo',
           path: 'skills/house-style',

--- a/packages/trueforge-ui/test/containers/SettingsBuilder/settingsFormValidation.test.ts
+++ b/packages/trueforge-ui/test/containers/SettingsBuilder/settingsFormValidation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  validateGitPath,
+  validateGitRef,
+  validateGitRepositoryUrl,
+  validateHttpHeaderName,
+  validateHttpUrl,
+  validateNonNegativeInteger,
+  validatePositiveInteger,
+  validateResourceName,
+  validateUniqueValue,
+} from '@/containers/SettingsBuilder/settingsFormValidation.js';
+
+describe('settings form validation', () => {
+  it('validates resource-name format and existing names', () => {
+    expect(validateResourceName({ value: 'custom-mcp', label: 'Connector name' })).toBeNull();
+    expect(validateResourceName({ value: 'Custom MCP', label: 'Connector name' })).toMatch(/2–64 lowercase/);
+    expect(validateResourceName({ value: 'custom-mcp', label: 'Connector name', existingNames: ['custom-mcp'] })).toBe(
+      'Connector name “custom-mcp” already exists.',
+    );
+    expect(
+      validateResourceName({
+        value: 'custom-mcp',
+        label: 'Connector name',
+        existingNames: ['custom-mcp'],
+        originalName: 'custom-mcp',
+      }),
+    ).toBeNull();
+  });
+
+  it('accepts only HTTP(S) endpoints', () => {
+    expect(validateHttpUrl({ value: 'http://localhost:11434/v1', label: 'Base URL' })).toBeNull();
+    expect(validateHttpUrl({ value: 'ftp://example.com', label: 'Base URL' })).toBe(
+      'Base URL must use http:// or https://.',
+    );
+    expect(validateHttpUrl({ value: '', label: 'Base URL', required: false })).toBeNull();
+  });
+
+  it('validates Git repository, path, and ref formats', () => {
+    expect(validateGitRepositoryUrl('https://github.com/truefoundry/skills')).toBeNull();
+    expect(validateGitRepositoryUrl('https://example.com/truefoundry/skills')).toMatch(/GitHub or GitLab/);
+    expect(validateGitPath('skills/release-notes')).toBeNull();
+    expect(validateGitPath('../secrets')).toMatch(/must not contain/);
+    expect(validateGitRef('feature/validation')).toBeNull();
+    expect(validateGitRef('../main')).toMatch(/must not contain/);
+  });
+
+  it('validates HTTP header names and integer ranges', () => {
+    expect(validateHttpHeaderName('X-Api-Key')).toBeNull();
+    expect(validateHttpHeaderName('Bad Header')).toMatch(/Header name/);
+    expect(validatePositiveInteger({ value: '1', label: 'Timeout' })).toBeNull();
+    expect(validatePositiveInteger({ value: '0', label: 'Timeout' })).toMatch(/greater than 0/);
+    expect(validateNonNegativeInteger({ value: '0', label: 'Interval' })).toBeNull();
+    expect(validateNonNegativeInteger({ value: '1.5', label: 'Interval' })).toMatch(/whole number/);
+  });
+
+  it('detects repeated values within a form', () => {
+    expect(validateUniqueValue({ value: 'model-a', values: ['model-a', 'model-b'], label: 'Model ID' })).toBeNull();
+    expect(validateUniqueValue({ value: 'model-a', values: ['model-a', 'model-a'], label: 'Model ID' })).toBe(
+      'Model ID “model-a” must be unique.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Add consistent client-side validation to settings forms so invalid values are rejected before submission and actionable errors appear beside the affected fields. Server-side schemas remain authoritative and independently enforced.

Closes #359

## Changes

- add shared accessible field-error and touched-state helpers for settings forms
- validate required values, URLs, resource identifiers, git fields, HTTP header names, numeric ranges, and duplicate names or models
- cover MCP servers, connector credentials, model providers, sandbox providers, and GitHub skill imports
- add focused component and validation tests plus a patch changeset for @truefoundry/trueforge-ui

## Screenshot

![Inline validation errors in the Add MCP server form](https://raw.githubusercontent.com/vibhorgupta96/trueforge/7f2175f5d5ffc9daba086573ed69e0a47b3d1367/.github/pr-screenshots/pr-361-form-validation.png)

## How was this tested?

- pnpm build
- pnpm test
- pnpm typecheck
- pnpm format:check
- pnpm --filter @truefoundry/trueforge-ui lint
- git diff --check

pnpm lint:ci still reports eight errors in five untouched backend files: the four catalog implementations under packages/trueforge/src/catalog and packages/trueforge/src/sandbox/local/core/CodeModeUdsTransport.ts. The changed UI source and tests pass the scoped package lint command.

## Checklist

- [ ] pnpm build, pnpm test, pnpm typecheck, pnpm lint:ci, and pnpm format:check pass locally (all pass except the unrelated root lint errors noted above)
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (packages/trueforge-sdk, .github/fern/openapi/openapi.json, docs/openapi.json) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / .env.example updated if configuration or behavior changed (not applicable; no configuration interface changed)
