### PR TITLE
Show chat title in conversation header

### DIFF
--- a/.changeset/calm-chats-title.md
+++ b/.changeset/calm-chats-title.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Show the current chat title in every conversation header.

--- a/packages/trueforge-ui/src/atoms/ChatTitleHeaderLabel.tsx
+++ b/packages/trueforge-ui/src/atoms/ChatTitleHeaderLabel.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useAuiState } from '../assistant-ui.js';
+import { displayChatTitle } from '../utils/chatTitle.js';
+import { cn } from './lib/cn.js';
+
+/** Current conversation title shown in layout headers. */
+export function ChatTitleHeaderLabel({ className }: { className?: string }) {
+  const title = useAuiState(s => s.threadListItem.title);
+  const displayTitle = displayChatTitle(title);
+
+  return (
+    <div className={cn('min-w-0 flex-1 px-1', className)}>
+      <span
+        data-slot="aui_chat-title"
+        className="block truncate text-sm font-semibold text-text-primary"
+        title={displayTitle}
+      >
+        {displayTitle}
+      </span>
+    </div>
+  );
+}

--- a/packages/trueforge-ui/src/containers/ThreadListContainer.tsx
+++ b/packages/trueforge-ui/src/containers/ThreadListContainer.tsx
@@ -26,6 +26,7 @@ import { Icon } from '../icons/Icon.js';
 import { useOptionalServer } from '../server/ServerContext.js';
 import { useOptionalShellMode } from '../server/ShellModeContext.js';
 import { useSlot } from '../theme/SlotsProvider.js';
+import { displayChatTitle } from '../utils/chatTitle.js';
 
 /**
  * Simplified relative to the reference: renders threads in a single flat list
@@ -129,7 +130,7 @@ function ThreadListItemRow({
   return (
     <ThreadListItemPrimitive.Root className="min-w-0">
       <ThreadListRow
-        title={title ?? 'New Chat'}
+        title={displayChatTitle(title)}
         active={id === mainThreadId}
         agentName={agentName}
         lastMessageAt={lastMessageAt}

--- a/packages/trueforge-ui/src/hooks/useChatChromeActionsVisible.ts
+++ b/packages/trueforge-ui/src/hooks/useChatChromeActionsVisible.ts
@@ -37,11 +37,8 @@ export function useChatChromeActionsVisible(): boolean {
   return shell != null && shell.mode.status === 'active' && !shell.mode.isMutable;
 }
 
-// True when the thread header has anything to show (title, Save, and/or Clear).
-// Clear alone matters for orphaned immutable history (deleted agent, no name).
+// Active chats always show a title; untitled drafts use the shared placeholder.
 export function useChatHeaderContentVisible(): boolean {
-  const namedVisible = useNamedAgentHeaderVisible();
-  const saveVisible = useSaveAgentVisible();
-  const clearVisible = useChatChromeActionsVisible();
-  return namedVisible || saveVisible || clearVisible;
+  const shell = useOptionalShellMode();
+  return shell?.mode.status === 'active';
 }

--- a/packages/trueforge-ui/src/layouts/DrawerLayout.tsx
+++ b/packages/trueforge-ui/src/layouts/DrawerLayout.tsx
@@ -3,6 +3,7 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 
 import { useAui } from '../assistant-ui.js';
+import { ChatTitleHeaderLabel } from '../atoms/ChatTitleHeaderLabel.js';
 import { NamedAgentHeaderLabel } from '../atoms/NamedAgentHeaderLabel.js';
 import { ShellActions } from '../atoms/ShellActions.js';
 import { auiButtonClass } from '../atoms/lib/buttonClasses.js';
@@ -70,8 +71,8 @@ export function DrawerLayout({ className }: { className?: string }) {
       <header className="flex shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5">
         {!settingsOpen ? (
           <>
-            <NamedAgentHeaderLabel />
-            <span className="min-w-0 flex-1" />
+            <NamedAgentHeaderLabel className="max-w-[35%] shrink-0" />
+            {isIdle ? <span className="min-w-0 flex-1" /> : <ChatTitleHeaderLabel />}
             <ClearChatButton />
             <SaveAgentButton />
           </>

--- a/packages/trueforge-ui/src/layouts/SidebarLayout.tsx
+++ b/packages/trueforge-ui/src/layouts/SidebarLayout.tsx
@@ -3,6 +3,7 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 
 import { useAui } from '../assistant-ui.js';
+import { ChatTitleHeaderLabel } from '../atoms/ChatTitleHeaderLabel.js';
 import { auiButtonClass } from '../atoms/lib/buttonClasses.js';
 import { cn } from '../atoms/lib/cn.js';
 import { NamedAgentHeaderLabel } from '../atoms/NamedAgentHeaderLabel.js';
@@ -143,8 +144,7 @@ export function SidebarLayout({ className }: { className?: string }) {
         <header
           className={cn(
             'flex shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5',
-            // Desktop: hide when settings/idle or the thread header has nothing to show
-            // (empty untitled draft). Mobile still needs Sessions + ShellActions.
+            // Mobile still needs Sessions + ShellActions while settings or the agent picker is open.
             (settingsOpen || isIdle || !hasChatHeaderContent) && 'md:hidden',
           )}
         >
@@ -160,8 +160,8 @@ export function SidebarLayout({ className }: { className?: string }) {
               >
                 <Icon name="bars" />
               </button>
-              <NamedAgentHeaderLabel />
-              <span className="min-w-0 flex-1" />
+              <NamedAgentHeaderLabel className="max-w-[35%] shrink-0" />
+              {isIdle ? <span className="min-w-0 flex-1" /> : <ChatTitleHeaderLabel />}
               <ClearChatButton />
               <SaveAgentButton />
             </>

--- a/packages/trueforge-ui/src/layouts/StackChatPanel.tsx
+++ b/packages/trueforge-ui/src/layouts/StackChatPanel.tsx
@@ -3,6 +3,7 @@
 import { lazy, Suspense, useEffect, useState, type ReactNode } from 'react';
 
 import { useAui } from '../assistant-ui.js';
+import { ChatTitleHeaderLabel } from '../atoms/ChatTitleHeaderLabel.js';
 import { NamedAgentHeaderLabel } from '../atoms/NamedAgentHeaderLabel.js';
 import { ShellActions } from '../atoms/ShellActions.js';
 import { auiButtonClass } from '../atoms/lib/buttonClasses.js';
@@ -75,8 +76,8 @@ export function StackChatPanel({ className, threadHeaderEnd }: StackChatPanelPro
             >
               <Icon name="clock-rotate-left" />
             </button>
-            <NamedAgentHeaderLabel />
-            <span className="min-w-0 flex-1" />
+            <NamedAgentHeaderLabel className="max-w-[35%] shrink-0" />
+            {isIdle ? <span className="min-w-0 flex-1" /> : <ChatTitleHeaderLabel />}
             <ClearChatButton />
             <SaveAgentButton />
             {threadHeaderEnd}

--- a/packages/trueforge-ui/src/utils/chatTitle.ts
+++ b/packages/trueforge-ui/src/utils/chatTitle.ts
@@ -1,0 +1,6 @@
+export const UNTITLED_CHAT_TITLE = 'New Chat';
+
+export function displayChatTitle(title: string | null | undefined): string {
+  const trimmed = title?.trim();
+  return trimmed ? trimmed : UNTITLED_CHAT_TITLE;
+}

--- a/packages/trueforge-ui/test/atoms/ChatTitleHeaderLabel.test.tsx
+++ b/packages/trueforge-ui/test/atoms/ChatTitleHeaderLabel.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useAuiState = vi.fn();
+
+vi.mock('@/assistant-ui.js', () => ({
+  useAuiState: (selector: (state: unknown) => unknown) => useAuiState(selector),
+}));
+
+import { ChatTitleHeaderLabel } from '@/atoms/ChatTitleHeaderLabel.js';
+
+function setChatTitle(title: string | null | undefined) {
+  useAuiState.mockImplementation((selector: (state: unknown) => unknown) => selector({ threadListItem: { title } }));
+}
+
+describe('ChatTitleHeaderLabel', () => {
+  beforeEach(() => {
+    useAuiState.mockReset();
+  });
+
+  it('shows the full current chat title in a truncating label', () => {
+    const title = 'Investigate an unusually long production deployment failure';
+    setChatTitle(title);
+
+    render(<ChatTitleHeaderLabel />);
+
+    expect(screen.getByText(title)).toHaveClass('truncate');
+    expect(screen.getByText(title)).toHaveAttribute('title', title);
+  });
+
+  it.each([undefined, null, '', '   '])('shows New Chat for an untitled chat (%s)', title => {
+    setChatTitle(title);
+
+    render(<ChatTitleHeaderLabel />);
+
+    expect(screen.getByText('New Chat')).toHaveAttribute('title', 'New Chat');
+  });
+});

--- a/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
+++ b/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
@@ -517,6 +517,22 @@ describe('layout slot overrides', () => {
     ['dock/widget', StackChatPanel],
   ] as const;
 
+  it.each(hosts)('%s shows the untitled chat placeholder in the thread header', (_name, Layout) => {
+    const { container } = render(
+      <SlotsProvider>
+        <ShellModeProvider agentConfig={{ mode: 'SingleAgent', name: 'a' }}>
+          <RuntimeHarness messages={[]}>
+            <div className="h-96">
+              <Layout />
+            </div>
+          </RuntimeHarness>
+        </ShellModeProvider>
+      </SlotsProvider>,
+    );
+
+    expect(container.querySelector('[data-slot="aui_chat-title"]')).toHaveTextContent('New Chat');
+  });
+
   it.each(hosts)('%s honors overrides.ClearChatButton', (_name, Layout) => {
     render(
       <SlotsProvider overrides={{ ClearChatButton: CustomClearChat }}>

--- a/packages/trueforge-ui/test/hooks/useChatChromeActionsVisible.test.tsx
+++ b/packages/trueforge-ui/test/hooks/useChatChromeActionsVisible.test.tsx
@@ -79,5 +79,6 @@ describe('useChatHeaderContentVisible', () => {
 
     expect(result.current.named).toBe(false);
     expect(result.current.clear).toBe(false);
+    expect(result.current.header).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Show the current chat title in the persistent conversation header so the active chat is identifiable without opening the session list. The title stays alongside the existing agent label and actions across every shipped layout.

Closes #352

## Changes

- display the active thread title in sidebar, drawer, dock, and widget conversation headers
- truncate long titles within the available header width while exposing the full value through the native title tooltip
- use a shared New Chat placeholder for blank or whitespace-only titles in both headers and session rows
- keep the title hidden while the agent picker is idle and preserve existing agent labels and header actions
- add focused title and layout integration tests plus a patch changeset for @truefoundry/trueforge-ui

## Screenshot

![Chat title in the persistent conversation header](https://raw.githubusercontent.com/vibhorgupta96/trueforge/7f2175f5d5ffc9daba086573ed69e0a47b3d1367/.github/pr-screenshots/pr-362-chat-title.png)

## How was this tested?

- pnpm build
- pnpm test
- pnpm typecheck
- pnpm format:check
- pnpm --filter @truefoundry/trueforge-ui lint
- pnpm --filter @truefoundry/trueforge-ui test
- git diff --check

pnpm lint:ci still reports eight errors in five untouched backend files: the four catalog implementations under packages/trueforge/src/catalog and packages/trueforge/src/sandbox/local/core/CodeModeUdsTransport.ts. The changed UI source and tests pass the scoped package lint command.

## Checklist

- [ ] pnpm build, pnpm test, pnpm typecheck, pnpm lint:ci, and pnpm format:check pass locally (all pass except the unrelated root lint errors noted above)
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (packages/trueforge-sdk, .github/fern/openapi/openapi.json, docs/openapi.json) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / .env.example updated if configuration or behavior changed (not applicable; no configuration interface changed)
