### PR TITLE
ci: open chart-release PRs as trueforge-dev-bot

### DIFF
--- a/.github/workflows/build-and-prepare-chart-release.yml
+++ b/.github/workflows/build-and-prepare-chart-release.yml
@@ -125,8 +125,16 @@ jobs:
     env:
       PR_BRANCH: release-chart/trueforge
     steps:
+      - id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TRUEFORGE_GENERATE_SDK_APP_ID }}
+          private-key: ${{ secrets.TRUEFORGE_GENERATE_SDK_APP_PRIVATE_KEY }}
+
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install yq
         run: |
@@ -180,7 +188,7 @@ jobs:
       - name: Open or update chart-release PR
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: ${{ env.PR_BRANCH }}
           base: main
           commit-message: 'release(chart): ${{ steps.chart.outputs.version }}'


### PR DESCRIPTION
## Summary

Open chart-release PRs as `trueforge-dev-bot` (same App token as the sandbox image pin workflow).

## Changes

- `open-chart-pr` uses `TRUEFORGE_GENERATE_SDK_APP_ID` / `TRUEFORGE_GENERATE_SDK_APP_PRIVATE_KEY` instead of `GITHUB_TOKEN`

## How was this tested?

- Workflow-only; after merge, confirm the chart-release PR is from `trueforge-dev-bot[bot]`

## Checklist

- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally — N/A (CI workflow only)
- [x] Tests added/updated where it makes sense — N/A
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / `.env.example` updated if configuration or behavior changed — N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only credential swap with no application or chart runtime behavior changes; relies on existing App secrets already used in other workflows.
> 
> **Overview**
> Chart-release bot PRs are now opened and updated using the **trueforge-dev-bot** GitHub App instead of the default workflow `GITHUB_TOKEN`.
> 
> The `open-chart-pr` job mints a token via `actions/create-github-app-token@v2` with `TRUEFORGE_GENERATE_SDK_APP_ID` / `TRUEFORGE_GENERATE_SDK_APP_PRIVATE_KEY` (same credentials as the sandbox image pin and SDK generate workflows). That token is passed to **checkout** and **peter-evans/create-pull-request**, so commits and PRs show the App bot as author rather than `github-actions[bot]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb7be92bbd72a702a48691b7e8a56b473be3d758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->