### PR TITLE
docs: fix private vulnerability reporting link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Please do **not** report security vulnerabilities through public GitHub issues, 
 Instead, report them privately through one of these channels:
 
 - Email: **[security@truefoundry.com](mailto:security@truefoundry.com)**
-- GitHub: use [private vulnerability reporting](#) on this repository
+- GitHub: use [private vulnerability reporting](https://github.com/truefoundry/trueforge/security/advisories/new) on this repository
 
 Please include as much of the following as you can:
 


### PR DESCRIPTION
## Summary

The private vulnerability reporting link in `SECURITY.md` currently points to `#`, which only jumps to the top of the same page.

## Changes

- Link directly to this repository's private vulnerability reporting form.

## How was this tested?

- Confirmed through the GitHub API that private vulnerability reporting is enabled for this repository.
- Manually verified that the target is the repository's `/security/advisories/new` form.
- No code or generated files changed.

## Checklist

- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally (not run; documentation-only change)
- [x] Tests added/updated where it makes sense (not applicable to a link-only change)
- [x] No hand-edits to generated code
- [x] Documentation updated