### PR TITLE
docs: improve Helm install guidance

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -52,6 +52,31 @@ TrueForge runs in [two modes](/introduction#two-ways-to-run-it): **local mode** 
       --version <x.y.z>
     ```
 
+    Find the version you want to install in the [published Helm charts](https://tfy.jfrog.io/ui/packages/oci:%2F%2Ftrueforge).
+
+    To expose TrueForge through an Istio gateway, add a `VirtualService` with
+    `extraObjects` in your values file. Replace the host and gateway with your
+    own values:
+
+    ```yaml
+    extraObjects:
+      - apiVersion: networking.istio.io/v1
+        kind: VirtualService
+        metadata:
+          name: '{{ include "trueforge.fullname" . }}'
+        spec:
+          hosts:
+            - trueforge.example.com
+          gateways:
+            - istio-system/public-gateway
+          http:
+            - route:
+                - destination:
+                    host: '{{ include "trueforge.fullname" . }}'
+                    port:
+                      number: '{{ .Values.service.port }}'
+    ```
+
     | Value                  | Default | Description                                                             |
     | ---------------------- | ------- | ------------------------------------------------------------------------ |
     | `replicaCount`         | `1`     | Number of server replicas (peered over Redis).                           |


### PR DESCRIPTION
## Summary
- Link Quickstart readers to the published Helm chart versions.
- Document an Istio VirtualService ingress example through extraObjects.

Closes #385

## Validation
- git diff --check passed.
- pnpm lint:ci reports 31 pre-existing, unrelated TypeScript lint errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Helm quickstart; no runtime, security, or chart template behavior is modified.
> 
> **Overview**
> Improves the Kubernetes Helm quickstart so readers can pick a published chart version and expose the service through Istio.
> 
> Adds a link to the JFrog Helm catalog and an `extraObjects` `VirtualService` example (host/gateway placeholders) that matches the chart’s extra-manifests support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3812895811c091ee28515a3f60dce86923a03ebd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->