### PR TITLE
docs: improve Helm install guidance

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -52,6 +52,39 @@ TrueForge runs in [two modes](/introduction#two-ways-to-run-it): **local mode** 
       --version <x.y.z>
     ```
 
+    Find the version you want to install in the [published Helm charts](https://tfy.jfrog.io/ui/packages/oci:%2F%2Ftrueforge).
+
+    To expose TrueForge through an Istio gateway, save this `VirtualService` in
+    `values.yaml` under `extraObjects`. Replace the host and gateway with your
+    own values:
+
+    ```yaml
+    extraObjects:
+      - apiVersion: networking.istio.io/v1
+        kind: VirtualService
+        metadata:
+          name: '{{ include "trueforge.fullname" . }}'
+        spec:
+          hosts:
+            - trueforge.example.com
+          gateways:
+            - istio-system/public-gateway
+          http:
+            - route:
+                - destination:
+                    host: '{{ include "trueforge.fullname" . }}'
+                    port:
+                      name: http
+    ```
+
+    Then install the chart with the values file:
+
+    ```bash
+    helm install trueforge oci://tfy.jfrog.io/tfy-helm/trueforge \
+      --version <x.y.z> \
+      --values values.yaml
+    ```
+
     | Value                  | Default | Description                                                             |
     | ---------------------- | ------- | ------------------------------------------------------------------------ |
     | `replicaCount`         | `1`     | Number of server replicas (peered over Redis).                           |


### PR DESCRIPTION
## What this solves

Closes #385.

The Quickstart Helm instructions did not tell users where to find published chart versions, and they did not include a minimal ingress configuration.

This PR:
- links to the JFrog page containing published TrueForge Helm chart versions;
- adds a ready-to-adapt Istio VirtualService example using the chart extraObjects value;
- keeps ingress guidance deliberately scoped to the common Istio approach, rather than documenting every possible ingress controller or gateway.

## Validation

- git diff --check passed.
- pnpm lint:ci is currently blocked by 31 pre-existing, unrelated TypeScript lint errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Quickstart Helm tab; no application or chart behavior is modified.
> 
> **Overview**
> Adds missing Kubernetes Helm install details to the Quickstart: a link to published chart versions on JFrog, and a copy-paste Istio `VirtualService` under `extraObjects` plus a `--values` install command.
> 
> Ingress coverage stays Istio-only; no chart or runtime code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e19307fb2dedc7d8874ff381c377134199b608a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->