### PR TITLE
Set node version to minimum 22.14

### DIFF
--- a/.changeset/node-engines-22-14.md
+++ b/.changeset/node-engines-22-14.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge': patch
+---
+
+Require Node.js 22.14+ (`better-sqlite3` v13 is built for Node-API 10 and SIGSEGVs on 22.13 and below).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Open a feature request in the issue tracker, or upvote an existing request that 
 
 ## Prerequisites
 
-- **Node.js 22.13+** (see [`.nvmrc`](.nvmrc); required by pnpm 11.16)
+- **Node.js 22.14+** (see [`.nvmrc`](.nvmrc); pnpm 11.16 needs 22.13+, and `better-sqlite3` v13 needs Node-API 10)
 - **pnpm** (version pinned via `packageManager` in [`package.json`](package.json); `corepack enable` handles it)
 - **Docker** — only needed for Postgres/Redis dev infra, the smoke test, and local SDK generation (maintainers). Fork contributors do not generate the SDK.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/truefoundry/trueforge/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" alt="License: MIT"></a>
-  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/Node.js-%3E%3D22.13-green.svg?style=flat-square" alt="Node.js >= 22.13"></a>
+  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/Node.js-%3E%3D22.14-green.svg?style=flat-square" alt="Node.js >= 22.14"></a>
   <a href="https://trueforge.dev"><img src="https://img.shields.io/badge/Documentation-trueforge.dev-blue.svg?style=flat-square" alt="Documentation"></a>
   <a href="https://trueforge.dev/quickstart"><img src="https://img.shields.io/badge/Quickstart-trueforge.dev/quickstart-blue.svg?style=flat-square" alt="Quickstart"></a>
   <a href="https://trueforge.dev/api/overview"><img src="https://img.shields.io/badge/SDK-trueforge.dev/api/overview-blue.svg?style=flat-square" alt="SDK"></a>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -10,7 +10,7 @@ TrueForge runs in [two modes](/introduction#two-ways-to-run-it): **local mode** 
 
 <Tabs>
   <Tab title="Local mode (npx)">
-    Requires [Node.js](https://nodejs.org) 22 or newer. One command, no other infrastructure — the UI and backend run locally, and data is stored in a local SQLite file:
+    Requires [Node.js](https://nodejs.org) 22.14 or newer. One command, no other infrastructure — the UI and backend run locally, and data is stored in a local SQLite file:
 
     ```bash
     npx @truefoundry/trueforge

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@11.16.0+sha512.b767e9a98fc87aec0f42daefcd0e84941c2cdb45d73c4e1e68860fb2bdfdbe032ab592105479e5e05c237f740c8a5ffdbbb52385797ddc2296745a1bbb883e8d",
   "engines": {
-    "node": ">=22.13.0"
+    "node": ">=22.14.0"
   },
   "scripts": {
     "build": "pnpm --filter @truefoundry/trueforge-core build && pnpm --filter @truefoundry/trueforge-sdk build && pnpm --filter @truefoundry/trueforge-ui build && pnpm --filter frontend build && pnpm --filter @truefoundry/trueforge build",

--- a/packages/trueforge/README.md
+++ b/packages/trueforge/README.md
@@ -8,7 +8,7 @@ TrueForge runs the agent loop (model calls, MCP tools, skills, sandboxing, appro
 
 ## Quick start
 
-Requires [Node.js](https://nodejs.org) 22+.
+Requires [Node.js](https://nodejs.org) 22.14+.
 
 ```bash
 npx @truefoundry/trueforge

--- a/packages/trueforge/package.json
+++ b/packages/trueforge/package.json
@@ -25,7 +25,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=22.14.0"
   },
   "scripts": {
     "build:frontend-assets": "node scripts/copy-frontend.mjs",


### PR DESCRIPTION
## Summary

Set node version to minimum 22.14 because of better sqlite's dependency on NAPI 10

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and engines-field only; no runtime logic changes. Users on Node 22.13 will be blocked by engines, which is the intended crash-avoidance.
> 
> **Overview**
> Raises the minimum Node.js version from 22.13 (workspace) / 22 (published package) to **22.14.0**. `better-sqlite3` v13 is built for Node-API 10 and can SIGSEGV on 22.13 and below.
> 
> `engines.node` is updated in the workspace and `@truefoundry/trueforge` package.json, with matching docs/badges (README, CONTRIBUTING, quickstart) and a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24bae193174cc5e7926e39d8994202646d53ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->