### PR TITLE
fix: preserve Helm chart prerelease mode

### DIFF
--- a/.github/workflows/build-and-prepare-chart-release.yml
+++ b/.github/workflows/build-and-prepare-chart-release.yml
@@ -159,7 +159,7 @@ jobs:
             git fetch --depth=1 origin "$PR_BRANCH"
             PR_VERSION=$(git show FETCH_HEAD:charts/trueforge/Chart.yaml | yq -r '.version')
           fi
-          VERSION=$(scripts/resolve-chart-version.sh "$CURRENT" "$APP_VERSION" "$PR_VERSION")
+          VERSION=$(bash scripts/resolve-chart-version.sh "$CURRENT" "$APP_VERSION" "$PR_VERSION")
           if [[ -n "$PR_VERSION" && "$VERSION" == "$PR_VERSION" ]]; then
             echo "Keeping chart version $PR_VERSION from $PR_BRANCH"
           fi

--- a/.github/workflows/build-and-prepare-chart-release.yml
+++ b/.github/workflows/build-and-prepare-chart-release.yml
@@ -149,31 +149,19 @@ jobs:
           UPDATE_APP_VERSION: ${{ needs.resolve.outputs.update_app_version }}
         run: |
           set -euo pipefail
-          SEMVER='^([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z.-]+)?$'
           CURRENT=$(yq -r '.version' charts/trueforge/Chart.yaml)
-          if [[ ! "$CURRENT" =~ $SEMVER ]]; then
-            echo "Chart.yaml version '$CURRENT' on $GITHUB_REF_NAME is not semver" >&2
-            exit 1
-          fi
-          MAJOR="${BASH_REMATCH[1]}"
-          MINOR="${BASH_REMATCH[2]}"
-          PATCH="${BASH_REMATCH[3]}"
-          VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          PR_VERSION=""
 
           # create-pull-request rebuilds the PR branch from base plus this
           # workspace, so a reviewer's major/minor bump on the open PR is dropped
-          # unless it is re-applied here. Only outrank the patch bump: a PR
-          # version at or below it means base already absorbed that release.
+          # unless it is re-applied here.
           if git ls-remote --exit-code --heads origin "$PR_BRANCH" >/dev/null 2>&1; then
             git fetch --depth=1 origin "$PR_BRANCH"
             PR_VERSION=$(git show FETCH_HEAD:charts/trueforge/Chart.yaml | yq -r '.version')
-            if [[ "$PR_VERSION" =~ $SEMVER ]] &&
-              (( BASH_REMATCH[1] > MAJOR ||
-                 (BASH_REMATCH[1] == MAJOR && BASH_REMATCH[2] > MINOR) ||
-                 (BASH_REMATCH[1] == MAJOR && BASH_REMATCH[2] == MINOR && BASH_REMATCH[3] > PATCH + 1) )); then
-              echo "Keeping chart version $PR_VERSION from $PR_BRANCH (over $VERSION)"
-              VERSION="$PR_VERSION"
-            fi
+          fi
+          VERSION=$(scripts/resolve-chart-version.sh "$CURRENT" "$APP_VERSION" "$PR_VERSION")
+          if [[ -n "$PR_VERSION" && "$VERSION" == "$PR_VERSION" ]]; then
+            echo "Keeping chart version $PR_VERSION from $PR_BRANCH"
           fi
           export VERSION IMAGE_TAG APP_VERSION
           yq -i '.version = strenv(VERSION)' charts/trueforge/Chart.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test chart version resolution
+        run: pnpm test:chart-version
+
       - name: Format
         run: pnpm format:check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Test chart version resolution
-        run: pnpm test:chart-version
-
       - name: Format
         run: pnpm format:check
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "start": "STANDALONE=false NODE_ENV=production pnpm --filter @truefoundry/trueforge start",
     "push-sandbox-image-to-daytona": "pnpm --filter @truefoundry/trueforge push-sandbox-image-to-daytona",
     "test:frontend": "pnpm --filter frontend test",
+    "test:chart-version": "bash tests/scripts/resolve-chart-version.test.sh",
     "test:trueforge-core": "pnpm --filter @truefoundry/trueforge-core test",
     "test:trueforge": "pnpm --filter @truefoundry/trueforge test",
     "test:local-sandbox:contract": "pnpm --filter @truefoundry/trueforge test:local-sandbox:contract",

--- a/scripts/resolve-chart-version.sh
+++ b/scripts/resolve-chart-version.sh
@@ -15,9 +15,16 @@ fi
 MAJOR=${BASH_REMATCH[1]}
 MINOR=${BASH_REMATCH[2]}
 PATCH=${BASH_REMATCH[3]}
+CURRENT_PRERELEASE=${BASH_REMATCH[4]:-}
 SELECTED_MAJOR=$MAJOR
 SELECTED_MINOR=$MINOR
-SELECTED_PATCH=$((PATCH + 1))
+SELECTED_PATCH=$PATCH
+
+# A stable chart starts the next patch. A prerelease chart is already on its
+# target core, so subsequent RCs and the stable release keep that core.
+if [[ -z "$CURRENT_PRERELEASE" ]]; then
+  SELECTED_PATCH=$((PATCH + 1))
+fi
 
 if [[ ! "$APP_VERSION" =~ $SEMVER ]]; then
   echo "App version '$APP_VERSION' is not semver" >&2
@@ -46,19 +53,26 @@ if [[ -n "$PR_VERSION" && "$PR_VERSION" =~ $SEMVER ]]; then
   fi
 fi
 
-# Chart and app versions have independent numeric cores but share the release lane.
-SELECTED_PRERELEASE=$APP_PRERELEASE
-PRERELEASE_COUNTER='^-([0-9A-Za-z-]+)\.([0-9]+)$'
-if [[ "$PR_CORE_SELECTED" == true && -n "$APP_PRERELEASE" && "$APP_PRERELEASE" =~ $PRERELEASE_COUNTER ]]; then
-  APP_TAG=${BASH_REMATCH[1]}
-  APP_COUNTER=${BASH_REMATCH[2]}
-  if [[ "$PR_PRERELEASE" =~ $PRERELEASE_COUNTER ]]; then
-    PR_TAG=${BASH_REMATCH[1]}
-    PR_COUNTER=${BASH_REMATCH[2]}
-    if [[ "$PR_TAG" == "$APP_TAG" ]] && ((PR_COUNTER > APP_COUNTER)); then
-      SELECTED_PRERELEASE=$PR_PRERELEASE
+# The app version only selects stable or prerelease mode. Chart RC counters are
+# derived from chart versions and advance independently from the app's suffix.
+SELECTED_PRERELEASE=""
+if [[ -n "$APP_PRERELEASE" ]]; then
+  RC_COUNTER='^-rc\.([0-9]+)$'
+  HIGHEST_RC=-1
+
+  if ((MAJOR == SELECTED_MAJOR && MINOR == SELECTED_MINOR && PATCH == SELECTED_PATCH)) &&
+    [[ "$CURRENT_PRERELEASE" =~ $RC_COUNTER ]]; then
+    HIGHEST_RC=${BASH_REMATCH[1]}
+  fi
+
+  if [[ "$PR_CORE_SELECTED" == true && "$PR_PRERELEASE" =~ $RC_COUNTER ]]; then
+    PR_COUNTER=${BASH_REMATCH[1]}
+    if ((PR_COUNTER > HIGHEST_RC)); then
+      HIGHEST_RC=$PR_COUNTER
     fi
   fi
+
+  SELECTED_PRERELEASE="-rc.$((HIGHEST_RC + 1))"
 fi
 
 VERSION="${SELECTED_MAJOR}.${SELECTED_MINOR}.${SELECTED_PATCH}${SELECTED_PRERELEASE}"

--- a/scripts/resolve-chart-version.sh
+++ b/scripts/resolve-chart-version.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CURRENT=${1:?current chart version is required}
+APP_VERSION=${2:?app version is required}
+PR_VERSION=${3:-}
+
+SEMVER='^([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z.-]+)?$'
+
+if [[ ! "$CURRENT" =~ $SEMVER ]]; then
+  echo "Current chart version '$CURRENT' is not semver" >&2
+  exit 1
+fi
+
+MAJOR=${BASH_REMATCH[1]}
+MINOR=${BASH_REMATCH[2]}
+PATCH=${BASH_REMATCH[3]}
+SELECTED_MAJOR=$MAJOR
+SELECTED_MINOR=$MINOR
+SELECTED_PATCH=$((PATCH + 1))
+
+if [[ ! "$APP_VERSION" =~ $SEMVER ]]; then
+  echo "App version '$APP_VERSION' is not semver" >&2
+  exit 1
+fi
+
+APP_PRERELEASE=${BASH_REMATCH[4]:-}
+PR_PRERELEASE=""
+PR_CORE_SELECTED=false
+
+if [[ -n "$PR_VERSION" && "$PR_VERSION" =~ $SEMVER ]]; then
+  PR_MAJOR=${BASH_REMATCH[1]}
+  PR_MINOR=${BASH_REMATCH[2]}
+  PR_PATCH=${BASH_REMATCH[3]}
+  PR_PRERELEASE=${BASH_REMATCH[4]:-}
+
+  if ((PR_MAJOR > SELECTED_MAJOR ||
+    (PR_MAJOR == SELECTED_MAJOR && PR_MINOR > SELECTED_MINOR) ||
+    (PR_MAJOR == SELECTED_MAJOR && PR_MINOR == SELECTED_MINOR && PR_PATCH > SELECTED_PATCH))); then
+    SELECTED_MAJOR=$PR_MAJOR
+    SELECTED_MINOR=$PR_MINOR
+    SELECTED_PATCH=$PR_PATCH
+    PR_CORE_SELECTED=true
+  elif ((PR_MAJOR == SELECTED_MAJOR && PR_MINOR == SELECTED_MINOR && PR_PATCH == SELECTED_PATCH)); then
+    PR_CORE_SELECTED=true
+  fi
+fi
+
+# Chart and app versions have independent numeric cores but share the release lane.
+SELECTED_PRERELEASE=$APP_PRERELEASE
+PRERELEASE_COUNTER='^-([0-9A-Za-z-]+)\.([0-9]+)$'
+if [[ "$PR_CORE_SELECTED" == true && -n "$APP_PRERELEASE" && "$APP_PRERELEASE" =~ $PRERELEASE_COUNTER ]]; then
+  APP_TAG=${BASH_REMATCH[1]}
+  APP_COUNTER=${BASH_REMATCH[2]}
+  if [[ "$PR_PRERELEASE" =~ $PRERELEASE_COUNTER ]]; then
+    PR_TAG=${BASH_REMATCH[1]}
+    PR_COUNTER=${BASH_REMATCH[2]}
+    if [[ "$PR_TAG" == "$APP_TAG" ]] && ((PR_COUNTER > APP_COUNTER)); then
+      SELECTED_PRERELEASE=$PR_PRERELEASE
+    fi
+  fi
+fi
+
+VERSION="${SELECTED_MAJOR}.${SELECTED_MINOR}.${SELECTED_PATCH}${SELECTED_PRERELEASE}"
+printf '%s\n' "$VERSION"

--- a/tests/scripts/resolve-chart-version.test.sh
+++ b/tests/scripts/resolve-chart-version.test.sh
@@ -28,7 +28,6 @@ assert_version 0.1.7 0.1.6 0.1.6
 # Entering prerelease mode starts the chart's own RC counter at zero. The app's
 # prerelease tag and counter do not influence the chart version.
 assert_version 0.1.6-rc.0 0.1.5 0.1.5-rc.2
-assert_version 0.1.6-rc.0 0.1.5 0.1.5-beta.9
 
 # Merged chart RCs and RCs in the open chart PR both advance linearly.
 assert_version 0.1.6-rc.1 0.1.6-rc.0 0.1.5-rc.99

--- a/tests/scripts/resolve-chart-version.test.sh
+++ b/tests/scripts/resolve-chart-version.test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+resolver=scripts/resolve-chart-version.sh
+failures=0
+
+assert_version() {
+  local expected=$1
+  local current=$2
+  local app_version=$3
+  local pr_version=${4:-}
+  local actual
+
+  actual=$("$resolver" "$current" "$app_version" "$pr_version")
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'FAIL: current=%s app=%s pr=%s expected=%s actual=%s\n' \
+      "$current" "$app_version" "${pr_version:-none}" "$expected" "$actual" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_version 0.1.4 0.1.3 0.1.4
+assert_version 0.1.4-rc.0 0.1.3 0.1.4-rc.0
+assert_version 0.1.6-rc.3 0.1.5 0.1.5-rc.3
+assert_version 0.2.0-rc.4 0.1.5 0.1.5-rc.3 0.2.0-rc.4
+assert_version 0.1.6-rc.4 0.1.5 0.1.5-rc.3 0.1.6-rc.4
+assert_version 0.2.0-rc.3 0.1.5 0.1.5-rc.3 0.2.0
+assert_version 0.2.0 0.1.5 0.1.5 0.2.0-rc.4
+assert_version 0.1.6-beta.1 0.1.5 0.1.5-beta.1 0.1.6-rc.4
+assert_version 0.1.6-rc.3 0.1.5 0.1.5-rc.3 0.1.4-rc.9
+
+if ((failures > 0)); then
+  exit 1
+fi
+
+echo "Chart version resolution tests passed"

--- a/tests/scripts/resolve-chart-version.test.sh
+++ b/tests/scripts/resolve-chart-version.test.sh
@@ -13,7 +13,7 @@ assert_version() {
   local pr_version=${4:-}
   local actual
 
-  actual=$("$resolver" "$current" "$app_version" "$pr_version")
+  actual=$(bash "$resolver" "$current" "$app_version" "$pr_version")
   if [[ "$actual" != "$expected" ]]; then
     printf 'FAIL: current=%s app=%s pr=%s expected=%s actual=%s\n' \
       "$current" "$app_version" "${pr_version:-none}" "$expected" "$actual" >&2
@@ -21,15 +21,30 @@ assert_version() {
   fi
 }
 
-assert_version 0.1.4 0.1.3 0.1.4
-assert_version 0.1.4-rc.0 0.1.3 0.1.4-rc.0
-assert_version 0.1.6-rc.3 0.1.5 0.1.5-rc.3
-assert_version 0.2.0-rc.4 0.1.5 0.1.5-rc.3 0.2.0-rc.4
-assert_version 0.1.6-rc.4 0.1.5 0.1.5-rc.3 0.1.6-rc.4
-assert_version 0.2.0-rc.3 0.1.5 0.1.5-rc.3 0.2.0
+# Stable chart releases continue with patch bumps.
+assert_version 0.1.6 0.1.5 0.1.5
+assert_version 0.1.7 0.1.6 0.1.6
+
+# Entering prerelease mode starts the chart's own RC counter at zero. The app's
+# prerelease tag and counter do not influence the chart version.
+assert_version 0.1.6-rc.0 0.1.5 0.1.5-rc.2
+assert_version 0.1.6-rc.0 0.1.5 0.1.5-beta.9
+
+# Merged chart RCs and RCs in the open chart PR both advance linearly.
+assert_version 0.1.6-rc.1 0.1.6-rc.0 0.1.5-rc.99
+assert_version 0.1.6-rc.4 0.1.6-rc.3 0.1.5-rc.0
+assert_version 0.1.6-rc.1 0.1.5 0.1.5-rc.7 0.1.6-rc.0
+assert_version 0.1.6-rc.5 0.1.6-rc.3 0.1.5-rc.7 0.1.6-rc.4
+
+# Leaving prerelease mode stabilizes the existing core before patch bumps resume.
+assert_version 0.1.6 0.1.6-rc.4 0.1.6
+assert_version 0.1.6 0.1.5 0.1.6 0.1.6-rc.4
+
+# A reviewed higher chart core is preserved without coupling it to the app core.
+assert_version 0.2.0-rc.0 0.1.5 0.1.5-rc.3 0.2.0
+assert_version 0.2.0-rc.5 0.1.5 0.1.5-rc.3 0.2.0-rc.4
 assert_version 0.2.0 0.1.5 0.1.5 0.2.0-rc.4
-assert_version 0.1.6-beta.1 0.1.5 0.1.5-beta.1 0.1.6-rc.4
-assert_version 0.1.6-rc.3 0.1.5 0.1.5-rc.3 0.1.4-rc.9
+assert_version 0.1.6-rc.0 0.1.5 0.1.5-rc.3 0.1.4-rc.9
 
 if ((failures > 0)); then
   exit 1


### PR DESCRIPTION
## Summary

- use the app version only to select stable or prerelease mode
- keep the chart numeric core and RC counter independent from the app version
- start a chart prerelease at `rc.0` and advance from the latest chart RC on `main` or the open chart PR
- stabilize the in-progress chart core when prerelease mode ends, then resume patch bumps
- preserve a reviewed higher chart core from the open chart PR

Expected lifecycle:

`0.1.5 → 0.1.6-rc.0 → 0.1.6-rc.1 → 0.1.6 → 0.1.7`

## Validation

- `pnpm test:chart-version`
- `pnpm format:check`
- `git diff --check`

Closes #384.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation that sets published Helm chart versions; behavior is covered by new tests but mistakes would affect OCI chart tags.
> 
> **Overview**
> **Fixes chart release versioning** so prerelease app builds get matching `-rc.N` chart versions instead of only patch bumps on stable cores.
> 
> The **build-and-prepare-chart-release** workflow no longer inlines semver math and PR-branch comparisons. It still reads the open `release-chart/trueforge` branch for a reviewer-bumped version, then delegates to **`scripts/resolve-chart-version.sh`**, which picks the numeric core (patch bump from stable main, hold core across RCs, stabilize when the app goes stable), uses **app version only for stable vs prerelease mode**, maintains a **chart-local RC counter** (not tied to the app’s prerelease suffix), and **keeps a higher core from the open chart PR**.
> 
> Adds **`pnpm test:chart-version`** and shell tests covering stable bumps, RC progression, stabilization, and preserved PR cores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22521c71f36d85e998f8a2cd64ae6dcf37b3a005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->