### PR TITLE
[trueforge-ui] markdown link should open in new tab

### DIFF
--- a/.changeset/markdown-links-new-tab.md
+++ b/.changeset/markdown-links-new-tab.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge-ui": patch
+---
+
+Open markdown links in assistant messages in a new tab

--- a/packages/trueforge-ui/src/atoms/Markdown.tsx
+++ b/packages/trueforge-ui/src/atoms/Markdown.tsx
@@ -81,7 +81,7 @@ function makeComponents(opts: {
 
   return {
     // Chat markdown links should open in a new tab.
-    a({ href, children, ...props }) {
+    a({ href, children, node: _node, ...props }) {
       return (
         <a {...props} href={href} target="_blank" rel="noopener noreferrer">
           {children}

--- a/packages/trueforge-ui/src/atoms/Markdown.tsx
+++ b/packages/trueforge-ui/src/atoms/Markdown.tsx
@@ -80,6 +80,14 @@ function makeComponents(opts: {
   } = opts;
 
   return {
+    // Chat markdown links should open in a new tab.
+    a({ href, children, ...props }) {
+      return (
+        <a {...props} href={href} target="_blank" rel="noopener noreferrer">
+          {children}
+        </a>
+      );
+    },
     // Strip default <pre> wrapper — each block renderer provides its own container.
     pre({ children }: { children?: ReactNode }) {
       return <>{children}</>;

--- a/packages/trueforge-ui/test/atoms/Markdown.test.tsx
+++ b/packages/trueforge-ui/test/atoms/Markdown.test.tsx
@@ -29,6 +29,14 @@ describe('Markdown', () => {
     expect(strong.closest('.markdown-body')).toBeTruthy();
   });
 
+  it('opens links in a new tab', () => {
+    render(<Markdown content="See [docs](https://example.com/docs) for details." />);
+    const link = screen.getByRole('link', { name: 'docs' });
+    expect(link).toHaveAttribute('href', 'https://example.com/docs');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
   it('renders openui fenced blocks via OpenUiFenceBlock', async () => {
     render(<Markdown content={'```openui\nCard() { title: "Sales" }\n```'} />);
     await waitFor(() => {

--- a/packages/trueforge-ui/test/atoms/Markdown.test.tsx
+++ b/packages/trueforge-ui/test/atoms/Markdown.test.tsx
@@ -35,6 +35,7 @@ describe('Markdown', () => {
     expect(link).toHaveAttribute('href', 'https://example.com/docs');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).not.toHaveAttribute('node');
   });
 
   it('renders openui fenced blocks via OpenUiFenceBlock', async () => {


### PR DESCRIPTION
## Summary

Markdown links should open in new tab

Closes #

## Changes

https://github.com/user-attachments/assets/bcd8c27f-7c3c-43de-ba8d-60da4104baa5


## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to link target behavior with a unit test; no auth, data, or security-logic changes. `noopener noreferrer` is included.
> 
> **Overview**
> Markdown links in chat (and other `Markdown` usages) now open in a new tab instead of navigating the current page.
> 
> A custom `a` renderer on `Markdown` sets `target="_blank"` and `rel="noopener noreferrer"`, and a unit test covers href, target, and rel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dbe7ac2a18f21bb38a8797ef76101cb0d0892ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->