### PR TITLE
[trueforge-ui] show mcp server tool name on tool approval

### DIFF
--- a/.changeset/plenty-books-itch.md
+++ b/.changeset/plenty-books-itch.md
@@ -1,0 +1,6 @@
+---
+"@truefoundry/trueforge-ui": minor
+---
+
+show mcp server tool name on tool approval
+  

--- a/.changeset/plenty-books-itch.md
+++ b/.changeset/plenty-books-itch.md
@@ -1,5 +1,5 @@
 ---
-"@truefoundry/trueforge-ui": minor
+"@truefoundry/trueforge-ui": patch
 ---
 
 show mcp server tool name on tool approval

--- a/packages/trueforge-ui/src/containers/ToolApprovalContainer.tsx
+++ b/packages/trueforge-ui/src/containers/ToolApprovalContainer.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from 'react';
 
 import type { ApprovalOption } from '../atoms/ToolApprovalBar.js';
 
+import { parseMcpToolArgs } from '@/utils/toolCallParsing.js';
 import { useSlot } from '../theme/SlotsProvider.js';
 
 export type ToolApprovalOption = {
@@ -18,13 +19,14 @@ export type ToolApprovalOption = {
 };
 
 type ToolApprovalContainerProps = {
-  toolName?: string;
+  argsText?: string;
   options: ToolApprovalOption[];
   onSelectOption: (optionId: string, reason?: string) => void;
 };
 
-export function ToolApprovalContainer({ toolName = '', options, onSelectOption }: ToolApprovalContainerProps) {
+export function ToolApprovalContainer({ argsText, options, onSelectOption }: ToolApprovalContainerProps) {
   const ToolApprovalBar = useSlot('ToolApprovalBar');
+  const { mcpServer, innerToolName } = parseMcpToolArgs(argsText);
   const [selectedDenyOptionId, setSelectedDenyOptionId] = useState<string | null>(null);
   const [denialReason, setDenialReason] = useState('');
   const [showReasonError, setShowReasonError] = useState(false);
@@ -75,7 +77,7 @@ export function ToolApprovalContainer({ toolName = '', options, onSelectOption }
 
   return (
     <ToolApprovalBar
-      toolName={toolName}
+      toolName={`${innerToolName} (${mcpServer})`}
       approveOptions={approveOptions.length > 0 ? approveOptions : undefined}
       denyOptions={denyOptions.length > 0 ? denyOptions : undefined}
       selectedDenyOption={selectedDenyOption}

--- a/packages/trueforge-ui/src/containers/ToolApprovalContainer.tsx
+++ b/packages/trueforge-ui/src/containers/ToolApprovalContainer.tsx
@@ -19,14 +19,21 @@ export type ToolApprovalOption = {
 };
 
 type ToolApprovalContainerProps = {
+  toolName?: string;
   argsText?: string;
   options: ToolApprovalOption[];
   onSelectOption: (optionId: string, reason?: string) => void;
 };
 
-export function ToolApprovalContainer({ argsText, options, onSelectOption }: ToolApprovalContainerProps) {
+export function ToolApprovalContainer({
+  toolName = '',
+  argsText,
+  options,
+  onSelectOption,
+}: ToolApprovalContainerProps) {
   const ToolApprovalBar = useSlot('ToolApprovalBar');
   const { mcpServer, innerToolName } = parseMcpToolArgs(argsText);
+  const displayToolName = innerToolName && mcpServer ? `${innerToolName} (${mcpServer})` : toolName;
   const [selectedDenyOptionId, setSelectedDenyOptionId] = useState<string | null>(null);
   const [denialReason, setDenialReason] = useState('');
   const [showReasonError, setShowReasonError] = useState(false);
@@ -77,7 +84,7 @@ export function ToolApprovalContainer({ argsText, options, onSelectOption }: Too
 
   return (
     <ToolApprovalBar
-      toolName={`${innerToolName} (${mcpServer})`}
+      toolName={displayToolName}
       approveOptions={approveOptions.length > 0 ? approveOptions : undefined}
       denyOptions={denyOptions.length > 0 ? denyOptions : undefined}
       selectedDenyOption={selectedDenyOption}

--- a/packages/trueforge-ui/src/containers/ToolCallContainer.tsx
+++ b/packages/trueforge-ui/src/containers/ToolCallContainer.tsx
@@ -99,6 +99,7 @@ function ToolApprovalSlot({ part }: { part: ToolCallMessagePartProps }) {
 
   return (
     <ToolApprovalContainer
+      toolName={part.toolName}
       argsText={part.argsText}
       options={
         buildApprovalOptions(part.approval?.options) as import('./ToolApprovalContainer.js').ToolApprovalOption[]

--- a/packages/trueforge-ui/src/containers/ToolCallContainer.tsx
+++ b/packages/trueforge-ui/src/containers/ToolCallContainer.tsx
@@ -99,7 +99,7 @@ function ToolApprovalSlot({ part }: { part: ToolCallMessagePartProps }) {
 
   return (
     <ToolApprovalContainer
-      toolName={part.toolName}
+      argsText={part.argsText}
       options={
         buildApprovalOptions(part.approval?.options) as import('./ToolApprovalContainer.js').ToolApprovalOption[]
       }
@@ -291,7 +291,7 @@ export const ToolCallContainer: ToolCallMessagePartComponent = part => {
 
   return (
     <ToolCallCard
-      toolName={part.toolName}
+      toolName={part.toolName + 'test'}
       expanded={expanded}
       onToggle={onToggle}
       awaiting={status === 'running'}

--- a/packages/trueforge-ui/src/containers/ToolCallContainer.tsx
+++ b/packages/trueforge-ui/src/containers/ToolCallContainer.tsx
@@ -291,7 +291,7 @@ export const ToolCallContainer: ToolCallMessagePartComponent = part => {
 
   return (
     <ToolCallCard
-      toolName={part.toolName + 'test'}
+      toolName={part.toolName}
       expanded={expanded}
       onToggle={onToggle}
       awaiting={status === 'running'}

--- a/packages/trueforge-ui/test/containers/ToolApprovalContainer.test.tsx
+++ b/packages/trueforge-ui/test/containers/ToolApprovalContainer.test.tsx
@@ -82,10 +82,18 @@ const options: ToolApprovalOption[] = [
   },
 ];
 
-function renderSubject(onSelectOption: (optionId: string, reason?: string) => void) {
+function renderSubject(
+  onSelectOption: (optionId: string, reason?: string) => void,
+  props: { toolName?: string; argsText?: string } = { toolName: 'shell' },
+) {
   return render(
     <SlotsProvider overrides={{ ToolApprovalBar: ToolApprovalBarProbe }}>
-      <ToolApprovalContainer toolName="shell" options={options} onSelectOption={onSelectOption} />
+      <ToolApprovalContainer
+        toolName={props.toolName}
+        argsText={props.argsText}
+        options={options}
+        onSelectOption={onSelectOption}
+      />
     </SlotsProvider>,
   );
 }
@@ -104,6 +112,26 @@ describe('ToolApprovalContainer', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Reject now' }));
     expect(onSelectOption).toHaveBeenNthCalledWith(1, 'allow-once');
     expect(onSelectOption).toHaveBeenNthCalledWith(2, 'reject-now');
+  });
+
+  it('shows MCP inner tool name with server when args include both fields', () => {
+    const onSelectOption = vi.fn();
+    renderSubject(onSelectOption, {
+      toolName: 'call_tool',
+      argsText: JSON.stringify({ mcp_server: 'github', tool_name: 'search' }),
+    });
+
+    expect(screen.getByTestId('approval-probe')).toHaveAttribute('data-tool-name', 'search (github)');
+  });
+
+  it('falls back to toolName when MCP fields are missing', () => {
+    const onSelectOption = vi.fn();
+    renderSubject(onSelectOption, {
+      toolName: 'shell',
+      argsText: JSON.stringify({ command: 'ls' }),
+    });
+
+    expect(screen.getByTestId('approval-probe')).toHaveAttribute('data-tool-name', 'shell');
   });
 
   it('requires, trims, and submits a denial reason with confirmation metadata', () => {


### PR DESCRIPTION
## Summary

<img width="741" height="464" alt="image" src="https://github.com/user-attachments/assets/5ef880e1-5b28-445b-99c3-c4c548ac86a0" />

Closes #

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only UI change with existing parser reuse and unit tests; no auth, data, or approval-decision logic changes.
> 
> **Overview**
> Tool approval now shows the inner MCP tool and server (e.g. `search (github)`) instead of the generic wrapper name like `call_tool`.
> 
> `ToolApprovalContainer` parses `argsText` via `parseMcpToolArgs` and falls back to the original `toolName` when MCP fields are missing. Tests cover both cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c54c8dbd68f5f0ccf9adb3a5db9544ac7682f731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->