### PR TITLE
feat(catalog): add GLM-5.3 to the z.ai model provider

### DIFF
--- a/packages/trueforge/catalog/model-catalog.yaml
+++ b/packages/trueforge/catalog/model-catalog.yaml
@@ -231,6 +231,15 @@ providers:
             - high
             - xhigh
             - max
+      - model_id: glm-5.3
+        name: glm-5-3
+        properties:
+          context_length: 1000000
+          max_output_tokens: 128000
+          reasoning_efforts:
+            - low
+            - high
+            - max
   - type: moonshot
     logo: https://assets.production.truefoundry.com/moonshot.png
     models:


### PR DESCRIPTION
Adds **GLM-5.3** under the `zai` provider in the shipped model catalog.

| field | value |
| --- | --- |
| model_id | `glm-5.3` |
| name | `glm-5-3` |
| context_length | 1,000,000 |
| max_output_tokens | 128,000 |
| reasoning_efforts | low, high, max |

Values are from the [GLM-5.3 docs](https://docs.z.ai/guides/llm/glm-5.3). Reasoning is always on for this model and cannot be disabled, so `none` and the other levels the 5.2 entry lists are intentionally omitted.

Catalog YAML only; the generated `.gen.ts` is gitignored and rebuilt at build time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Discovery-only catalog YAML; not used at runtime and does not change auth, execution, or data handling.
> 
> **Overview**
> Adds **GLM-5.3** (`glm-5.3` / `glm-5-3`) to the shipped `zai` model catalog so the UI can copy it into provider settings.
> 
> Preset: 1M context, 128k max output, reasoning efforts `low` / `high` / `max` only (reasoning cannot be disabled on this model). Catalog YAML only; generated TS is rebuilt at build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4294ee92b50da764b20c26f0423320e0dbd901b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->