### PR TITLE
feat(ui): add agent deletion controls

### DIFF
--- a/.changeset/fresh-agents-delete.md
+++ b/.changeset/fresh-agents-delete.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': minor
+---
+
+Add deletion controls to the Agents Library and wire the bundled TrueForge adapter to the existing agent delete API.

--- a/docs/ui-sdk/reference/server.mdx
+++ b/docs/ui-sdk/reference/server.mdx
@@ -11,8 +11,8 @@ createTrueFoundryServer(options: CreateTrueFoundryServerOptions): TrueFoundrySer
 
 Options: `{ chatServer, getCapabilities, getModels, getSkills, getMcp, searchAgents, saveAgent, deleteAgent?, catalog? }`.
 Combines a chat server with your agent-management callbacks into a complete `AgentUIServer`.
-`deleteAgent` and `catalog` are the only optional entries; if you omit `deleteAgent`, calling it
-throws.
+`deleteAgent` and `catalog` are the only optional entries; if you omit `deleteAgent`, the Agents
+Library hides its delete controls.
 
 ## Context
 

--- a/docs/ui-sdk/setup-custom-servers/custom-server.mdx
+++ b/docs/ui-sdk/setup-custom-servers/custom-server.mdx
@@ -167,7 +167,7 @@ Spreading `nextPageToken` in only when present keeps the result valid under `exa
 
 <AccordionGroup>
   <Accordion title="deleteSession / deleteAgent">
-    In a hand-written `AgentUIServer` like the one above, omitting these leaves the corresponding affordances unavailable rather than broken. (This differs from the [`createTrueFoundryServer` composition helper](/ui-sdk/setup-custom-servers/connect-with-truefoundry#truefoundry-chat-your-own-builder), where an omitted `deleteAgent` throws when called.)
+    Omitting these leaves the corresponding affordances unavailable rather than broken, including when using the [`createTrueFoundryServer` composition helper](/ui-sdk/setup-custom-servers/connect-with-truefoundry#truefoundry-chat-your-own-builder).
   </Accordion>
 
   <Accordion title="downloadSandboxFile">

--- a/packages/trueforge-ui/docs/createTrueFoundryServer.temp.ts
+++ b/packages/trueforge-ui/docs/createTrueFoundryServer.temp.ts
@@ -279,12 +279,7 @@ export function createTrueFoundryServer<
     getMcp: opts.getMcp,
     searchAgents: opts.searchAgents,
     saveAgent: opts.saveAgent,
-    async deleteAgent(req: { agentName: string }) {
-      if (!opts.deleteAgent) {
-        throw new Error('deleteAgent is host-owned. Pass deleteAgent to createTrueFoundryServer.');
-      }
-      await opts.deleteAgent(req);
-    },
+    ...(opts.deleteAgent !== undefined ? { deleteAgent: opts.deleteAgent } : {}),
 
     getGatewayClients: () => ({ client, privateClient }),
   };

--- a/packages/trueforge-ui/docs/server.md
+++ b/packages/trueforge-ui/docs/server.md
@@ -567,13 +567,14 @@ const server = createTrueFoundryServer({
 
 ### Catalog — complete for this UI
 
-| UI call                     | Required response fields                                   |
-| --------------------------- | ---------------------------------------------------------- |
-| `getModels()`               | `name`, `provider`, `apiModel`, `modelId`                  |
-| `getSkills()`               | `id`, `name`; `fqn?`, `description?`                       |
-| `getMcp()`                  | `id`, `name`; `description?`                               |
-| `searchAgents(req?)`        | `name`; optional display fields on `AgentLibraryEntry`     |
-| `saveAgent` / `deleteAgent` | On port; **not called by UI yet** (optional until Save UI) |
+| UI call              | Required response fields                                  |
+| -------------------- | --------------------------------------------------------- |
+| `getModels()`        | `name`, `provider`, `apiModel`, `modelId`                 |
+| `getSkills()`        | `id`, `name`; `fqn?`, `description?`                      |
+| `getMcp()`           | `id`, `name`; `description?`                              |
+| `searchAgents(req?)` | `name`; optional display fields on `AgentLibraryEntry`    |
+| `saveAgent`          | Called by the Save Agent flow                             |
+| `deleteAgent`        | Called from the Agents Library when the method is present |
 
 ### Chat — method list complete; standalone BYO is not
 
@@ -593,8 +594,7 @@ const server = createTrueFoundryServer({
 enabled.
 
 **On the port but unused by this UI today:**
-`listOwnedSessions`, non-stream `createTurn`, `deleteSession`,
-`saveAgent`, `deleteAgent`.
+`listOwnedSessions`, non-stream `createTurn`.
 
 ### v1 BYO guidance
 

--- a/packages/trueforge-ui/src/atoms/AgentsLibrary.tsx
+++ b/packages/trueforge-ui/src/atoms/AgentsLibrary.tsx
@@ -2,15 +2,19 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
+import { useToasterOptional } from '../containers/ToasterContainer.js';
 import { useSessionShareSearch } from '../hooks/useSessionShareSearch.js';
 import { Icon } from '../icons/Icon.js';
-import { useOptionalAgentSessionsServer } from '../server/ServerContext.js';
+import { useOptionalAgentSessionsServer, useOptionalServer } from '../server/ServerContext.js';
 import { libraryAgentId, useShellMode } from '../server/ShellModeContext.js';
 import type { AgentLibraryEntry, AgentSpec } from '../server/types.js';
 import { useSlot } from '../theme/SlotsProvider.js';
+import { getErrorMessage } from '../utils/getErrorMessage.js';
 import { auiButtonClass } from './lib/buttonClasses.js';
 import { cn } from './lib/cn.js';
 import { useSearchAgentsList } from './lib/useSearchAgentsList.js';
+import { CenteredModal } from './primitives/CenteredModal.js';
+import { DropdownMenu, DropdownMenuItem } from './primitives/DropdownMenu.js';
 import SearchInput from './primitives/SearchInput.js';
 import { Skeleton } from './primitives/Skeleton.js';
 import { Tooltip } from './primitives/Tooltip.js';
@@ -22,9 +26,11 @@ export type AgentsLibraryProps = {
 export type AgentLibraryRowProps = {
   agent: AgentLibraryEntry;
   showEdit: boolean;
+  showDelete: boolean;
   onOpen?: () => void;
   onTry: () => void;
   onEdit: () => void;
+  onDelete: () => void;
 };
 
 /** Short label for model fqns like `provider/gpt-4.1` → `gpt-4.1`. */
@@ -33,7 +39,15 @@ function displayModelLabel(modelName: string): string {
   return slash >= 0 ? modelName.slice(slash + 1) : modelName;
 }
 
-export function AgentLibraryRow({ agent, showEdit, onOpen, onTry, onEdit }: AgentLibraryRowProps) {
+export function AgentLibraryRow({
+  agent,
+  showEdit,
+  showDelete,
+  onOpen,
+  onTry,
+  onEdit,
+  onDelete,
+}: AgentLibraryRowProps) {
   const spec = agent.agentSpec;
   const modelName = spec?.model.name;
   const skillsCount = spec?.skills?.length ?? 0;
@@ -42,6 +56,7 @@ export function AgentLibraryRow({ agent, showEdit, onOpen, onTry, onEdit }: Agen
   const mcpNames = (spec?.mcpServers ?? []).map(m => (m as { name?: string }).name).filter(Boolean);
   const connectorsTitle = mcpNames.length ? `Connectors: ${mcpNames.join(', ')}` : `${mcpCount} connectors`;
   const skillsTitle = skillNames.length ? `Skills: ${skillNames.join(', ')}` : `${skillsCount} skills`;
+  const showActions = showEdit || showDelete;
 
   return (
     <div
@@ -55,7 +70,10 @@ export function AgentLibraryRow({ agent, showEdit, onOpen, onTry, onEdit }: Agen
         onOpen != null &&
           'cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus-ring',
       )}
-      onClick={onOpen}
+      onClick={event => {
+        if (onOpen == null || (event.target instanceof Element && event.target.closest('button') != null)) return;
+        onOpen();
+      }}
       onKeyDown={event => {
         if (onOpen == null || event.target !== event.currentTarget || (event.key !== 'Enter' && event.key !== ' ')) {
           return;
@@ -93,22 +111,39 @@ export function AgentLibraryRow({ agent, showEdit, onOpen, onTry, onEdit }: Agen
         </span>
       ) : null}
       <span className="flex shrink-0 items-center gap-1.5">
-        {showEdit ? (
-          <button
-            type="button"
-            aria-label={`Edit agent ${agent.name}`}
-            className={auiButtonClass({
-              variant: 'ghost',
-              size: 'sm',
-            })}
-            onClick={event => {
-              event.stopPropagation();
-              onEdit();
-            }}
+        {showActions ? (
+          <DropdownMenu
+            trigger={
+              <button
+                type="button"
+                aria-label={`Agent actions for ${agent.name}`}
+                title={`Agent actions for ${agent.name}`}
+                className={auiButtonClass({
+                  variant: 'ghost',
+                  size: 'icon',
+                  className: 'size-8 text-text-secondary hover:text-text-primary',
+                })}
+              >
+                <Icon name="ellipsis" className="size-3.5 rotate-90" />
+              </button>
+            }
           >
-            <Icon name="pencil" className="size-3.5" />
-            Edit
-          </button>
+            {showEdit ? (
+              <DropdownMenuItem onClick={onEdit}>
+                <Icon name="pencil" className="size-3.5" />
+                Edit
+              </DropdownMenuItem>
+            ) : null}
+            {showDelete ? (
+              <DropdownMenuItem
+                className="text-failure-bg hover:bg-failure-bg/12 hover:text-failure-bg focus:bg-failure-bg/12 focus:text-failure-bg"
+                onClick={onDelete}
+              >
+                <Icon name="trash" className="size-3.5" />
+                Delete
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenu>
         ) : null}
         <button
           type="button"
@@ -132,13 +167,19 @@ export function AgentLibraryRow({ agent, showEdit, onOpen, onTry, onEdit }: Agen
 
 export function AgentsLibrary({ onSelectAgent }: AgentsLibraryProps) {
   const shell = useShellMode();
+  const server = useOptionalServer();
+  const toaster = useToasterOptional();
   const { updateShareSearch } = useSessionShareSearch();
   const sessionsServer = useOptionalAgentSessionsServer();
   const SlottedAgentLibraryRow = useSlot('AgentLibraryRow');
   const [query, setQuery] = useState('');
+  const [agentPendingDelete, setAgentPendingDelete] = useState<AgentLibraryEntry | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const open = shell.libraryOpen;
 
   const canEdit = shell.isComposerEnabled === true;
+  const canDelete = typeof server?.deleteAgent === 'function';
   const agentsListEpoch = shell.agentsListEpoch;
 
   useEffect(() => {
@@ -148,10 +189,12 @@ export function AgentsLibrary({ onSelectAgent }: AgentsLibraryProps) {
   const closeLibrary = useCallback(() => {
     shell.setLibraryOpen(false);
     setQuery('');
+    setAgentPendingDelete(null);
+    setDeleteError(null);
   }, [shell]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || agentPendingDelete != null) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
       event.stopImmediatePropagation();
@@ -159,7 +202,7 @@ export function AgentsLibrary({ onSelectAgent }: AgentsLibraryProps) {
     };
     window.addEventListener('keydown', onKeyDown, true);
     return () => window.removeEventListener('keydown', onKeyDown, true);
-  }, [closeLibrary, open]);
+  }, [agentPendingDelete, closeLibrary, open]);
 
   const { agents, isInitialLoading, isSearching, loadingMore, error, hasMore, listRef, sentinelRef } =
     useSearchAgentsList({
@@ -189,98 +232,191 @@ export function AgentsLibrary({ onSelectAgent }: AgentsLibraryProps) {
     });
   };
 
+  const requestDelete = (agent: AgentLibraryEntry) => {
+    setDeleteError(null);
+    setAgentPendingDelete(agent);
+  };
+
+  const closeDeleteConfirmation = () => {
+    if (deleting) return;
+    setAgentPendingDelete(null);
+    setDeleteError(null);
+  };
+
+  const confirmDelete = async () => {
+    const agent = agentPendingDelete;
+    const deleteAgent = server?.deleteAgent;
+    if (agent == null || deleteAgent === undefined || deleting) return;
+
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await deleteAgent({ agentName: agent.name });
+
+      const deletedAgentId = libraryAgentId(agent);
+      if (shell.historyAgentFilter === deletedAgentId) {
+        shell.setHistoryAgentFilter(null);
+      }
+      if (
+        shell.mode.status === 'active' &&
+        (shell.mode.agentId === deletedAgentId || shell.mode.agentName === agent.name)
+      ) {
+        if (shell.isComposerEnabled) {
+          shell.openDraft();
+        } else {
+          shell.openLibraryHome();
+        }
+      }
+
+      shell.invalidateAgentsList();
+      setAgentPendingDelete(null);
+      toaster?.showSuccess({ title: `${agent.name} deleted` });
+    } catch (caught) {
+      if (toaster == null) {
+        setDeleteError(getErrorMessage(caught, 'Could not delete agent.'));
+      } else {
+        toaster.showError(caught);
+      }
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   if (!open) return null;
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col bg-primary-bg">
-      <header className="flex shrink-0 items-center gap-2 border-b border-border px-2 py-1.5">
-        <button
-          type="button"
-          aria-label="Back"
-          title="Back"
-          className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
-          onClick={closeLibrary}
-        >
-          <Icon name="arrow-left" />
-        </button>
-        <h1 className="text-lg font-semibold tracking-tight text-text-primary">Agents Library</h1>
-      </header>
+    <>
+      <div className="flex h-full min-h-0 w-full flex-col bg-primary-bg">
+        <header className="flex shrink-0 items-center gap-2 border-b border-border px-2 py-1.5">
+          <button
+            type="button"
+            aria-label="Back"
+            title="Back"
+            className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
+            onClick={closeLibrary}
+          >
+            <Icon name="arrow-left" />
+          </button>
+          <h1 className="text-lg font-semibold tracking-tight text-text-primary">Agents Library</h1>
+        </header>
 
-      <div className="bg-secondary-bg/40 flex min-h-0 flex-1 flex-col">
-        <div className="shrink-0 border-b border-border px-4 py-3">
-          <SearchInput query={query} setQuery={setQuery} placeholder="Search agents" />
-          {isSearching ? (
-            <p className="text-text-secondary mt-1.5 text-xs" role="status">
-              Searching…
-            </p>
-          ) : null}
-        </div>
-        <div
-          ref={listRef}
-          className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-2"
-          role="menu"
-          aria-label="Agents"
-        >
-          {isInitialLoading ? (
-            <div className="flex flex-col gap-2 p-1" role="status" aria-label="Loading agents">
-              {Array.from({ length: 6 }, (_, i) => (
-                <Skeleton key={i} className="h-11 w-full rounded-md" />
-              ))}
-            </div>
-          ) : error ? (
-            <p className="text-failure-bg px-3 py-8 text-center text-sm">{error}</p>
-          ) : agents.length === 0 ? (
-            <p className="text-text-secondary px-3 py-8 text-center text-sm">
-              {query.trim()
-                ? `No agents match "${query.trim()}".`
-                : 'No agents yet. Build one in a chat, then save it as an agent.'}
-            </p>
-          ) : (
-            <>
-              {agents.map(agent => {
-                const agentSpec = agent.agentSpec;
-                const agentId = agent.agentId;
-                const showEdit = canEdit && agentSpec != null;
-                return (
-                  <SlottedAgentLibraryRow
-                    key={libraryAgentId(agent)}
-                    agent={agent}
-                    showEdit={showEdit}
-                    {...(sessionsServer != null && agentId != null
-                      ? {
-                          onOpen: () => {
-                            updateShareSearch({
-                              agentId,
-                              tab: 'overview',
-                              sessionId: null,
-                              view: null,
-                              timeRange: null,
-                            });
-                            shell.openLibraryAgent(agentId);
-                          },
-                        }
-                      : {})}
-                    onTry={() => handleTry(agent)}
-                    onEdit={() => {
-                      if (agentSpec != null) handleEdit(agent, agentSpec);
-                    }}
-                  />
-                );
-              })}
-              {hasMore ? (
-                <div ref={sentinelRef} className="flex h-8 shrink-0 items-center justify-center" aria-hidden>
-                  {loadingMore ? (
-                    <span className="text-text-secondary text-xs" role="status">
-                      Loading more…
-                    </span>
-                  ) : null}
-                </div>
-              ) : null}
-            </>
-          )}
+        <div className="bg-secondary-bg/40 flex min-h-0 flex-1 flex-col">
+          <div className="shrink-0 border-b border-border px-4 py-3">
+            <SearchInput query={query} setQuery={setQuery} placeholder="Search agents" />
+            {isSearching ? (
+              <p className="text-text-secondary mt-1.5 text-xs" role="status">
+                Searching…
+              </p>
+            ) : null}
+          </div>
+          <div
+            ref={listRef}
+            className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-2"
+            role="menu"
+            aria-label="Agents"
+          >
+            {isInitialLoading ? (
+              <div className="flex flex-col gap-2 p-1" role="status" aria-label="Loading agents">
+                {Array.from({ length: 6 }, (_, i) => (
+                  <Skeleton key={i} className="h-11 w-full rounded-md" />
+                ))}
+              </div>
+            ) : error ? (
+              <p className="text-failure-bg px-3 py-8 text-center text-sm">{error}</p>
+            ) : agents.length === 0 ? (
+              <p className="text-text-secondary px-3 py-8 text-center text-sm">
+                {query.trim()
+                  ? `No agents match "${query.trim()}".`
+                  : 'No agents yet. Build one in a chat, then save it as an agent.'}
+              </p>
+            ) : (
+              <>
+                {agents.map(agent => {
+                  const agentSpec = agent.agentSpec;
+                  const agentId = agent.agentId;
+                  const showEdit = canEdit && agentSpec != null;
+                  return (
+                    <SlottedAgentLibraryRow
+                      key={libraryAgentId(agent)}
+                      agent={agent}
+                      showEdit={showEdit}
+                      showDelete={canDelete}
+                      {...(sessionsServer != null && agentId != null
+                        ? {
+                            onOpen: () => {
+                              updateShareSearch({
+                                agentId,
+                                tab: 'overview',
+                                sessionId: null,
+                                view: null,
+                                timeRange: null,
+                              });
+                              shell.openLibraryAgent(agentId);
+                            },
+                          }
+                        : {})}
+                      onTry={() => handleTry(agent)}
+                      onEdit={() => {
+                        if (agentSpec != null) handleEdit(agent, agentSpec);
+                      }}
+                      onDelete={() => requestDelete(agent)}
+                    />
+                  );
+                })}
+                {hasMore ? (
+                  <div ref={sentinelRef} className="flex h-8 shrink-0 items-center justify-center" aria-hidden>
+                    {loadingMore ? (
+                      <span className="text-text-secondary text-xs" role="status">
+                        Loading more…
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
+              </>
+            )}
+          </div>
         </div>
       </div>
-    </div>
+
+      <CenteredModal
+        open={agentPendingDelete != null}
+        onOpenChange={nextOpen => {
+          if (!nextOpen) closeDeleteConfirmation();
+        }}
+        title={agentPendingDelete == null ? 'Delete agent' : `Delete ${agentPendingDelete.name}?`}
+        description="This removes the agent from the library. Existing chats will stay in your history."
+        contentSized
+      >
+        <div className="flex flex-col gap-4 p-5">
+          {deleteError != null ? (
+            <p
+              className="rounded-md border border-failure-bg/30 bg-failure-bg/10 px-3 py-2 text-sm text-failure-bg"
+              role="alert"
+            >
+              {deleteError}
+            </p>
+          ) : null}
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              className={auiButtonClass({ variant: 'outline' })}
+              disabled={deleting}
+              onClick={closeDeleteConfirmation}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className={auiButtonClass({ variant: 'destructive' })}
+              disabled={deleting}
+              onClick={() => void confirmDelete()}
+            >
+              {deleting ? 'Deleting…' : 'Delete agent'}
+            </button>
+          </div>
+        </div>
+      </CenteredModal>
+    </>
   );
 }
 

--- a/packages/trueforge-ui/src/atoms/AgentsLibrary.tsx
+++ b/packages/trueforge-ui/src/atoms/AgentsLibrary.tsx
@@ -270,7 +270,8 @@ export function AgentsLibrary({ onSelectAgent }: AgentsLibraryProps) {
 
       shell.invalidateAgentsList();
       setAgentPendingDelete(null);
-      toaster?.showSuccess({ title: `${agent.name} deleted` });
+      // Let the native dialog close before ToastStack chooses its portal target.
+      window.setTimeout(() => toaster?.showSuccess({ title: `${agent.name} deleted` }), 0);
     } catch (caught) {
       if (toaster == null) {
         setDeleteError(getErrorMessage(caught, 'Could not delete agent.'));

--- a/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/builderServer.ts
+++ b/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/builderServer.ts
@@ -111,5 +111,14 @@ export function createHarnessBuilderServer(
       const created = await client.agents.create({ name: agentName, manifest });
       return { agentId: created.data.id };
     },
+
+    async deleteAgent({ agentName }) {
+      const { data } = await client.agents.list();
+      const existing = data.find(agent => agent.name === agentName);
+      if (existing === undefined) {
+        return;
+      }
+      await client.agents.delete(existing.id);
+    },
   };
 }

--- a/packages/trueforge-ui/src/server/createTrueFoundryServer.ts
+++ b/packages/trueforge-ui/src/server/createTrueFoundryServer.ts
@@ -81,13 +81,7 @@ export function createTrueFoundryServer<
     getMcp: opts.getMcp,
     searchAgents: opts.searchAgents,
     saveAgent: opts.saveAgent,
-    deleteAgent: async req => {
-      if (opts.deleteAgent) {
-        await opts.deleteAgent(req);
-        return;
-      }
-      throw new Error('deleteAgent is host-owned. Pass deleteAgent to createTrueFoundryServer.');
-    },
+    ...(opts.deleteAgent !== undefined ? { deleteAgent: opts.deleteAgent } : {}),
   };
 
   const server: TrueFoundryServer<TSpec, TModel, TSkill, TMcp, TAgent, TSave, TCatalog, TCapabilities, TSessions> = {

--- a/packages/trueforge-ui/test/atoms/AgentsLibrary.test.tsx
+++ b/packages/trueforge-ui/test/atoms/AgentsLibrary.test.tsx
@@ -232,6 +232,95 @@ describe('AgentsLibrary', () => {
     expect(screen.queryByRole('button', { name: 'Edit agent writer' })).not.toBeInTheDocument();
   });
 
+  it('hides Delete when the server does not support deleting agents', async () => {
+    const server = mockServer([{ name: 'writer', agentId: 'writer-id' }]);
+
+    render(
+      <SlotsProvider>
+        <ServerProvider server={server}>
+          <ShellModeProvider>
+            <AgentsLibrary open onOpenChange={() => undefined} />
+          </ShellModeProvider>
+        </ServerProvider>
+      </SlotsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Try agent writer' })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: 'Delete agent writer' })).not.toBeInTheDocument();
+  });
+
+  it('confirms deletion, calls the server port, and refreshes the library', async () => {
+    const searchAgents = vi
+      .fn()
+      .mockResolvedValueOnce([{ name: 'writer', agentId: 'writer-id' }])
+      .mockResolvedValueOnce([]);
+    const deleteAgent = vi.fn(async () => {});
+    const server = createMockAgentUIServer({ searchAgents, deleteAgent });
+
+    render(
+      <SlotsProvider>
+        <ServerProvider server={server}>
+          <ShellModeProvider>
+            <AgentsLibrary open onOpenChange={() => undefined} />
+          </ShellModeProvider>
+        </ServerProvider>
+      </SlotsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Delete agent writer' })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Delete agent writer' }));
+
+    expect(screen.getByRole('dialog', { name: 'Delete writer?' })).toBeInTheDocument();
+    expect(screen.getByText('Existing chats will stay in your history.', { exact: false })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete agent' }));
+
+    await waitFor(() => {
+      expect(deleteAgent).toHaveBeenCalledWith({ agentName: 'writer' });
+      expect(searchAgents).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.queryByRole('button', { name: 'Delete agent writer' })).not.toBeInTheDocument();
+  });
+
+  it('allows cancellation and keeps a failed deletion available for retry', async () => {
+    const deleteAgent = vi.fn(async () => {
+      throw new Error('Delete request failed');
+    });
+    const server = createMockAgentUIServer({
+      searchAgents: vi.fn(async () => [{ name: 'writer', agentId: 'writer-id' }]),
+      deleteAgent,
+    });
+
+    render(
+      <SlotsProvider>
+        <ServerProvider server={server}>
+          <ShellModeProvider>
+            <AgentsLibrary open onOpenChange={() => undefined} />
+          </ShellModeProvider>
+        </ServerProvider>
+      </SlotsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Delete agent writer' })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Delete agent writer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(deleteAgent).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete agent writer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete agent' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Delete request failed');
+    });
+    expect(screen.getByRole('dialog', { name: 'Delete writer?' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete agent writer' })).toBeInTheDocument();
+  });
+
   it('shows create-one guidance when there are no agents yet', async () => {
     const server = mockServer([]);
 

--- a/packages/trueforge-ui/test/atoms/AgentsLibrary.test.tsx
+++ b/packages/trueforge-ui/test/atoms/AgentsLibrary.test.tsx
@@ -63,15 +63,24 @@ function renderLibrary(
   );
 }
 
-function LibraryHarness({ children, onSelectAgent }: { children?: ReactNode; onSelectAgent?: (name: string) => void }) {
+function LibraryHarness({
+  children,
+  onSelectAgent,
+  withToaster = false,
+}: {
+  children?: ReactNode;
+  onSelectAgent?: (name: string) => void;
+  withToaster?: boolean;
+}) {
   const shell = useShellMode();
+  const library = <AgentsLibrary onSelectAgent={onSelectAgent} />;
   return (
     <>
       <button type="button" onClick={() => shell.setLibraryOpen(true)}>
         Open library
       </button>
       <output data-testid="library-agent-id">{shell.libraryAgentId ?? ''}</output>
-      <AgentsLibrary onSelectAgent={onSelectAgent} />
+      {withToaster ? <ToasterProvider>{library}</ToasterProvider> : library}
       {children}
     </>
   );
@@ -158,14 +167,17 @@ describe('AgentsLibrary', () => {
   });
 
   it('shows Edit when composer is enabled and agentSpec is present', async () => {
-    const server = mockServer([
-      {
-        name: 'writer',
-        agentId: 'writer-id',
-        agentSpec: { model: { name: 'openai-main/gpt-4.1' }, skills: [{ id: 's1', name: 'Skill' }] },
-      },
-      { name: 'try-only', agentId: 'try-only' },
-    ]);
+    const server = createMockAgentUIServer({
+      searchAgents: vi.fn(async () => [
+        {
+          name: 'writer',
+          agentId: 'writer-id',
+          agentSpec: { model: { name: 'openai-main/gpt-4.1' }, skills: [{ id: 's1', name: 'Skill' }] },
+        },
+        { name: 'try-only', agentId: 'try-only' },
+      ]),
+      deleteAgent: vi.fn(async () => {}),
+    });
 
     renderLibrary(<LibraryHarness />, {
       server,
@@ -174,10 +186,12 @@ describe('AgentsLibrary', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Open library' }));
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit agent writer' })).toBeInTheDocument();
-    });
-    expect(screen.queryByRole('button', { name: 'Edit agent try-only' })).not.toBeInTheDocument();
+    const writerActions = await screen.findByRole('button', { name: 'Agent actions for writer' });
+    fireEvent.click(writerActions);
+    expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /Manage Schedules/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /Clone/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Try agent try-only' })).toBeInTheDocument();
   });
 
@@ -230,26 +244,19 @@ describe('AgentsLibrary', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Try agent writer' })).toBeInTheDocument();
     });
-    expect(screen.queryByRole('button', { name: 'Edit agent writer' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Agent actions for writer' })).not.toBeInTheDocument();
   });
 
   it('hides Delete when the server does not support deleting agents', async () => {
     const server = mockServer([{ name: 'writer', agentId: 'writer-id' }]);
 
-    render(
-      <SlotsProvider>
-        <ServerProvider server={server}>
-          <ShellModeProvider>
-            <AgentsLibrary open onOpenChange={() => undefined} />
-          </ShellModeProvider>
-        </ServerProvider>
-      </SlotsProvider>,
-    );
+    renderLibrary(<LibraryHarness />, { server });
+    fireEvent.click(screen.getByRole('button', { name: 'Open library' }));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Try agent writer' })).toBeInTheDocument();
     });
-    expect(screen.queryByRole('button', { name: 'Delete agent writer' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Agent actions for writer' })).not.toBeInTheDocument();
   });
 
   it('confirms deletion, calls the server port, and refreshes the library', async () => {
@@ -260,22 +267,11 @@ describe('AgentsLibrary', () => {
     const deleteAgent = vi.fn(async () => {});
     const server = createMockAgentUIServer({ searchAgents, deleteAgent });
 
-    render(
-      <SlotsProvider>
-        <ServerProvider server={server}>
-          <ToasterProvider>
-            <ShellModeProvider>
-              <AgentsLibrary open onOpenChange={() => undefined} />
-            </ShellModeProvider>
-          </ToasterProvider>
-        </ServerProvider>
-      </SlotsProvider>,
-    );
+    renderLibrary(<LibraryHarness withToaster />, { server });
+    fireEvent.click(screen.getByRole('button', { name: 'Open library' }));
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Delete agent writer' })).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Delete agent writer' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Agent actions for writer' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
 
     expect(screen.getByRole('dialog', { name: 'Delete writer?' })).toBeInTheDocument();
     expect(screen.getByText('Existing chats will stay in your history.', { exact: false })).toBeInTheDocument();
@@ -285,10 +281,11 @@ describe('AgentsLibrary', () => {
       expect(deleteAgent).toHaveBeenCalledWith({ agentName: 'writer' });
       expect(searchAgents).toHaveBeenCalledTimes(2);
     });
-    expect(screen.queryByRole('button', { name: 'Delete agent writer' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Agent actions for writer' })).not.toBeInTheDocument();
     const successToast = await screen.findByRole('alert');
     expect(successToast).toHaveTextContent('writer deleted');
-    expect(successToast.closest('dialog')).toHaveAttribute('aria-label', 'Agents Library');
+    expect(successToast).toBeVisible();
+    expect(successToast.closest('dialog')).toBeNull();
   });
 
   it('allows cancellation and keeps a failed deletion available for retry', async () => {
@@ -300,31 +297,24 @@ describe('AgentsLibrary', () => {
       deleteAgent,
     });
 
-    render(
-      <SlotsProvider>
-        <ServerProvider server={server}>
-          <ShellModeProvider>
-            <AgentsLibrary open onOpenChange={() => undefined} />
-          </ShellModeProvider>
-        </ServerProvider>
-      </SlotsProvider>,
-    );
+    renderLibrary(<LibraryHarness />, { server });
+    fireEvent.click(screen.getByRole('button', { name: 'Open library' }));
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Delete agent writer' })).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Delete agent writer' }));
+    const actions = await screen.findByRole('button', { name: 'Agent actions for writer' });
+    fireEvent.click(actions);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(deleteAgent).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Delete agent writer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Agent actions for writer' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
     fireEvent.click(screen.getByRole('button', { name: 'Delete agent' }));
 
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent('Delete request failed');
     });
     expect(screen.getByRole('dialog', { name: 'Delete writer?' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Delete agent writer' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Agent actions for writer' })).toBeInTheDocument();
   });
 
   it('shows create-one guidance when there are no agents yet', async () => {

--- a/packages/trueforge-ui/test/atoms/AgentsLibrary.test.tsx
+++ b/packages/trueforge-ui/test/atoms/AgentsLibrary.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { AgentsLibrary } from '@/atoms/AgentsLibrary.js';
 import { AgentsLibraryButton } from '@/atoms/AgentsLibraryButton.js';
 import { CenteredModal } from '@/atoms/primitives/CenteredModal.js';
+import { ToasterProvider } from '@/containers/ToasterContainer.js';
 import { ServerProvider } from '@/server/ServerContext.js';
 import { ShellModeProvider, useShellMode } from '@/server/ShellModeContext.js';
 import type { AgentUIServer } from '@/server/types.js';
@@ -262,9 +263,11 @@ describe('AgentsLibrary', () => {
     render(
       <SlotsProvider>
         <ServerProvider server={server}>
-          <ShellModeProvider>
-            <AgentsLibrary open onOpenChange={() => undefined} />
-          </ShellModeProvider>
+          <ToasterProvider>
+            <ShellModeProvider>
+              <AgentsLibrary open onOpenChange={() => undefined} />
+            </ShellModeProvider>
+          </ToasterProvider>
         </ServerProvider>
       </SlotsProvider>,
     );
@@ -283,6 +286,9 @@ describe('AgentsLibrary', () => {
       expect(searchAgents).toHaveBeenCalledTimes(2);
     });
     expect(screen.queryByRole('button', { name: 'Delete agent writer' })).not.toBeInTheDocument();
+    const successToast = await screen.findByRole('alert');
+    expect(successToast).toHaveTextContent('writer deleted');
+    expect(successToast.closest('dialog')).toHaveAttribute('aria-label', 'Agents Library');
   });
 
   it('allows cancellation and keeps a failed deletion available for retry', async () => {

--- a/packages/trueforge-ui/test/plugins/trueforge-agent-server-adapter/harnessBuilderServer.test.ts
+++ b/packages/trueforge-ui/test/plugins/trueforge-agent-server-adapter/harnessBuilderServer.test.ts
@@ -300,4 +300,48 @@ describe('harnessBuilderServer', () => {
       },
     });
   });
+
+  it('deleteAgent resolves the immutable id and uses the agents delete route', async () => {
+    const requests: { method: string; url: string }[] = [];
+    const fetchMock: typeof fetch = async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/api/v1/agents') && method === 'GET') {
+        return Response.json({
+          data: [{ id: 'agt_1', name: 'writer', manifest: { model: { name: 'test/model' } } }],
+        });
+      }
+      if (url.endsWith('/api/v1/agents/agt_1') && method === 'DELETE') {
+        requests.push({ method, url });
+        return Response.json({});
+      }
+      return new Response(`Unexpected request: ${method} ${url}`, { status: 500 });
+    };
+
+    const builder = createHarnessBuilderServer({ fetch: fetchMock });
+    if (builder.deleteAgent === undefined) {
+      throw new Error('Expected deleteAgent to be implemented');
+    }
+    await builder.deleteAgent({ agentName: 'writer' });
+
+    assert.equal(requests.length, 1);
+    assert.match(requests[0]?.url ?? '', /\/api\/v1\/agents\/agt_1$/);
+  });
+
+  it('deleteAgent is idempotent when the agent name is already absent', async () => {
+    const fetchMock: typeof fetch = async input => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.endsWith('/api/v1/agents')) {
+        return Response.json({ data: [] });
+      }
+      return new Response(`Unexpected request: ${url}`, { status: 500 });
+    };
+
+    const builder = createHarnessBuilderServer({ fetch: fetchMock });
+    if (builder.deleteAgent === undefined) {
+      throw new Error('Expected deleteAgent to be implemented');
+    }
+
+    await assert.doesNotReject(builder.deleteAgent({ agentName: 'already-gone' }));
+  });
 });

--- a/packages/trueforge-ui/test/server/createTrueFoundryServer.test.ts
+++ b/packages/trueforge-ui/test/server/createTrueFoundryServer.test.ts
@@ -57,6 +57,7 @@ describe('createTrueFoundryServer', () => {
     expect(server.listSessions).toBe(chatServer.listSessions);
     expect(server.catalog).toBeUndefined();
     expect(server.sessions).toBe(sessions);
+    expect(server.deleteAgent).toBeUndefined();
 
     await expect(server.getCapabilities()).resolves.toEqual(capabilities);
     await expect(server.getModels()).resolves.toHaveLength(1);
@@ -71,6 +72,30 @@ describe('createTrueFoundryServer', () => {
       intent: 'create',
     });
     expect(saveAgent).toHaveBeenCalled();
+  });
+
+  it('attaches and delegates the optional deleteAgent callback', async () => {
+    const chatServer = createMockAgentUIServer();
+    const deleteAgent = vi.fn(async () => {});
+    const server = createTrueFoundryServer({
+      chatServer,
+      getCapabilities: async () => ({
+        data: { sandbox: { enabled: false }, skill: { enabled: false } },
+      }),
+      getModels: async () => [],
+      getSkills: async () => [],
+      getMcp: async () => [],
+      searchAgents: async () => [],
+      saveAgent: async () => ({}),
+      deleteAgent,
+    });
+
+    if (server.deleteAgent === undefined) {
+      throw new Error('Expected deleteAgent to be attached');
+    }
+    await server.deleteAgent({ agentName: 'writer' });
+
+    expect(deleteAgent).toHaveBeenCalledWith({ agentName: 'writer' });
   });
 
   it('attaches optional catalog when provided', async () => {


### PR DESCRIPTION
## Summary

Closes #429

## Changes

- Add a delete action and confirmation dialog to each Agents Library row when the server exposes `deleteAgent`.
- Preserve existing chats while clearing stale active-agent and history-filter state after deletion.
- Wire the bundled TrueForge adapter to the existing agents list and `DELETE /api/v1/agents/{agent_id}` SDK routes.
- Keep custom servers capability-safe by omitting `deleteAgent` when no callback is provided.
- Add the required UI package changeset and update the server-contract documentation.

## How was this tested?

- `pnpm test:trueforge-ui` — 130 test files / 847 tests passed, including package build and export smoke tests.
- `pnpm --filter @truefoundry/trueforge-ui typecheck`
- `pnpm --filter @truefoundry/trueforge-ui lint`
- `pnpm format:check`

## Checklist

- [x] Tests added for success, cancellation, failure, unsupported hosts, adapter routing, and idempotency.
- [x] No hand-edits to generated OpenAPI or SDK code.
- [x] Documentation and changeset updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes are destructive and touch shell navigation state; risk is mitigated by confirmation, capability gating, and adapter idempotency, but hosts must implement `deleteAgent` correctly.
> 
> **Overview**
> Adds **agent deletion** to the Agents Library when the host server exposes `deleteAgent`, shipped as a **minor** `@truefoundry/trueforge-ui` release.
> 
> Library rows now use an **actions menu** (Edit when composer + spec allow, Delete when `typeof server.deleteAgent === 'function'`) with a **confirmation modal**, toasts or inline errors, list refresh via `invalidateAgentsList`, and shell cleanup (history filter, active agent → draft or library home). Row open/click behavior ignores action buttons.
> 
> **Server wiring:** `createTrueFoundryServer` only attaches `deleteAgent` when a callback is passed (no runtime throw). The bundled harness builder adapter implements delete by resolving the agent id from the list and calling `DELETE /api/v1/agents/{id}` (idempotent if missing). Docs now state that omitting `deleteAgent` **hides** delete UI instead of failing at call time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de00e93fb0d7024983cbbab9db2145bb5719e66d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->