### PR TITLE
Fixes #446: Clarify contribution approval labels in the docs 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,10 @@ Community expertise is most valuable when shared through detailed bug reports, r
 
 For these reasons, we focus community contributions on issue reports, analysis, and feedback, over larger code changes.
 
-> [!Note]
-> If you would still like to contribute code, we keep a dedicated set of issues marked as [help-wanted](https://github.com/truefoundry/trueforge/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) that are well scoped.
+| Label                                                                                                                      | Meaning                                                                                         |
+| -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [`help-wanted`](https://github.com/truefoundry/trueforge/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) | Well-scoped issue where community contributions are welcome.                                    |
+| `needs-maintainer-approval`                                                                                                | Proposal is still awaiting maintainer review; contributors should not start implementation yet. |
 
 ### Reporting bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ By participating you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md). 
 ## Ways to contribute
 
 > [!Important]
-> Please only submit pull requests if you have received approval from a maintainer.
+> Please only submit pull requests for an issue when you have received approval from a maintainer.
 > While we value good intentions, we require approvals for community code contributions to ensure we use everyone's time effectively.
 
 - **Report bugs** — open an issue with steps to reproduce, expected vs actual behavior, and your environment.
@@ -18,16 +18,24 @@ For security vulnerabilities, do **not** open a public issue — see [SECURITY.m
 
 ### Why we require approvals for community code contributions
 
+> [!Tip]
+> Every new issue by default is labelled with [needs-maintainer-attention](https://github.com/truefoundry/trueforge/issues?q=is%3Aissue%20state%3Aopen%20label%3Aneeds-maintainer-attention). A maintainer will review the issue and discuss the next steps. Please don't remove this label while creating the issue.
+
 Effective changes to TrueForge require architectural context, an understanding of system-level constraints, and visibility into the project's roadmap. Community pull requests often focus on issues that are lower priority, affect a small number of users, or need substantial changes to fit the broader system. Reviewing and iterating on those changes can take more time than implementing a fix directly, diverting attention from higher-priority work.
 
 Community expertise is most valuable when shared through detailed bug reports, reproduction steps, logs, root-cause analysis, and design discussions in issues. Understanding the problem, identifying the right solution, and prioritizing the work are typically the hard parts; implementation is comparatively straightforward with coding assistants.
 
 For these reasons, we focus community contributions on issue reports, analysis, and feedback, over larger code changes.
 
-| Label                                                                                                                      | Meaning                                                                                         |
-| -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`help-wanted`](https://github.com/truefoundry/trueforge/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) | Well-scoped issue where community contributions are welcome.                                    |
-| `needs-maintainer-approval`                                                                                                | Proposal is still awaiting maintainer review; contributors should not start implementation yet. |
+> [!Note]
+> If you would still like to contribute code, we keep a dedicated set of issues marked as [help-wanted](https://github.com/truefoundry/trueforge/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) that are well scoped.
+
+### Issue labels
+
+| Label                                                                                                                                          | Meaning                                                                  |
+| ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [help-wanted](https://github.com/truefoundry/trueforge/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)                       | Well-scoped issue where community contributions are welcome.             |
+| [needs-maintainer-attention](https://github.com/truefoundry/trueforge/issues?q=is%3Aissue%20state%3Aopen%20label%3Aneeds-maintainer-attention) | Issue needs discussion with maintainers before implementation can start. |
 
 ### Reporting bugs
 


### PR DESCRIPTION
## Summary

Clarifies how repository labels relate to the maintainer approval process for community code contributions.

Closes #446

## Changes

- Clarified that `help-wanted` issues are open to community contributions.
- Clarified that `needs-maintainer-approval` issues should not be implemented until reviewed.

## How was this tested?

- Ran `pnpm prettier --check CONTRIBUTING.md`.
- Ran `git diff --check`.
- Pre-commit formatting checks passed.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense (not applicable for this documentation-only change)
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contribution guidelines; no runtime or security impact.
> 
> **Overview**
> Updates **CONTRIBUTING.md** so contributors understand when maintainer approval is required and how GitHub issue labels map to that process.
> 
> The important callout now says to open PRs **for an issue** only after a maintainer has approved work, not just “don’t submit PRs without approval” in the abstract. A new tip explains that new issues are labeled **`needs-maintainer-attention`** by default (matching the issue templates), that maintainers will triage them, and that contributors should not remove that label.
> 
> A new **Issue labels** table documents **`help-wanted`** (community code welcome) versus **`needs-maintainer-attention`** (discuss with maintainers before implementing). Closes #446.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23092be415ebb4e7cb030dca957577fdf5bb888c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->