### PR TITLE
fix(trueforge): match the redaction sentinel exactly and publish less of a secret

### DIFF
--- a/.changeset/secret-redaction-exact-mask.md
+++ b/.changeset/secret-redaction-exact-mask.md
@@ -1,0 +1,9 @@
+---
+"@truefoundry/trueforge": patch
+---
+
+Match the secret redaction sentinel exactly, and publish at most the last four characters of a stored secret.
+
+A settings write that carried `***REDACTED***` anywhere inside a real secret was treated as "keep the stored one", so the value the user typed was silently discarded — the old secret stayed, or a create failed with a message about a missing key. Only the mask a `GET` actually returns is treated as a keep now.
+
+Responses previously showed the first three and last three characters of any secret of ten characters or more, which left little of a short key unknown. A secret now masks to its last four characters and only when it is at least twelve long; anything shorter is masked completely.

--- a/packages/trueforge/src/utils/secretRedaction.ts
+++ b/packages/trueforge/src/utils/secretRedaction.ts
@@ -4,21 +4,49 @@
  */
 
 export const SECRET_REDACTION = '***REDACTED***';
-const MIN_LENGTH_FOR_PREFIX_SUFFIX = 10;
+/**
+ * Below this, a suffix would be most of the secret, so nothing is shown at all.
+ * A 10-character key used to be published as its first three and last three characters.
+ */
+const MIN_LENGTH_FOR_SUFFIX = 12;
+/** How much of a long secret a response may show, matching what other providers publish. */
+const SUFFIX_LENGTH = 4;
+const MASK_SEPARATOR = '-';
 
-/** Response mask: prefix/suffix for longer secrets; full mask when too short to hide. */
+/** Response mask: a bounded suffix for longer secrets; full mask when too short to hide. */
 export function toRedactedSecretValue(secret: string): string {
-  if (secret.length < MIN_LENGTH_FOR_PREFIX_SUFFIX) {
+  if (secret.length < MIN_LENGTH_FOR_SUFFIX) {
     return SECRET_REDACTION;
   }
-  return `${secret.slice(0, 3)}-${SECRET_REDACTION}-${secret.slice(-3)}`;
+  return `${SECRET_REDACTION}${MASK_SEPARATOR}${secret.slice(-SUFFIX_LENGTH)}`;
+}
+
+/** The prefix every suffix-bearing mask starts with, which is fixed. */
+const MASK_PREFIX = `${SECRET_REDACTION}${MASK_SEPARATOR}`;
+
+/**
+ * Whole-value test for the suffix-bearing mask.
+ *
+ * Compared by length and prefix rather than by regular expression: the sentinel is full of regex
+ * metacharacters, so a pattern built from it needs escaping to stay correct.
+ */
+function isMaskWithSuffix(value: string): boolean {
+  return value.length === MASK_PREFIX.length + SUFFIX_LENGTH && value.startsWith(MASK_PREFIX);
 }
 
 /**
  * True when the client sent a redacted stand-in from a prior GET.
+ *
+ * Matched against the exact shapes `toRedactedSecretValue` produces rather than by substring. A
+ * substring test classified any real secret that happened to contain the sentinel as "keep the
+ * stored one", so the value the user typed was dropped without an error saying so — persisted as
+ * the old secret, or failing a create with a message about a missing key.
+ *
+ * A secret whose whole value is exactly one of these shapes is still indistinguishable from a mask.
+ * Nothing in-band can separate those two; only a field saying "keep" alongside the value could.
  */
 export function isRedactedSecretValue(value: string): boolean {
-  return value.includes(SECRET_REDACTION);
+  return value === SECRET_REDACTION || isMaskWithSuffix(value);
 }
 
 /**

--- a/packages/trueforge/tests/unit/apis/mcpServers.test.ts
+++ b/packages/trueforge/tests/unit/apis/mcpServers.test.ts
@@ -12,6 +12,7 @@ import { createSqliteDb } from '../../../src/db/sqlite/client';
 import { SqliteMcpServerStore } from '../../../src/db/sqlite/mcp-server-store/SqliteMcpServerStore';
 import { SqliteOAuthTokenStore } from '../../../src/db/sqlite/token-store/SqliteOAuthTokenStore';
 import { mcpOAuthCallbackUrl } from '../../../src/mcp/auth/mcpOAuthHelpers';
+import { toRedactedSecretValue } from '../../../src/utils/secretRedaction';
 
 const putBody = {
   type: 'remote' as const,
@@ -29,8 +30,8 @@ const putBodyWithDcr = {
 };
 
 const HEADER_TOKEN = 'Bearer test-token';
-/** Wire form of HEADER_TOKEN for length ≥ 10: first 3 + SECRET_REDACTION + last 3. */
-const HEADER_TOKEN_REDACTED = 'Bea-***REDACTED***-ken';
+/** Wire form of HEADER_TOKEN. Derived rather than written out, so the mask has one definition. */
+const HEADER_TOKEN_REDACTED = toRedactedSecretValue(HEADER_TOKEN);
 
 const putBodyWithHeaderAuth = {
   type: 'remote' as const,
@@ -484,27 +485,33 @@ describe('mcp-servers routers', () => {
     });
   });
 
-  it('PUT with a different redacted header value still keeps the stored secret', async () => {
+  it('PUT with a header value that merely contains the sentinel stores it', async () => {
     await settingsRouter.request('/', putInit(wrapManifest(putBodyWithHeaderAuth)));
 
-    // Any value containing ***REDACTED*** is treated as keep, not only the exact GET mask.
-    const keep = {
+    /*
+     * This used to be asserted the other way round: any value containing ***REDACTED*** anywhere
+     * was treated as "keep the stored one". A real header value
+     * carrying the sentinel was silently dropped and the old token stayed. Only the mask a GET
+     * actually returns means keep, so this value is a rotation like any other.
+     */
+    const typed = `oth-${'***REDACTED***'}-xxx`;
+    const rotated = {
       ...putBodyWithHeaderAuth,
       url: 'https://mcp.example.com/v3/mcp',
       auth: {
         type: 'header' as const,
-        headers: { Authorization: 'oth-***REDACTED***-xxx' },
+        headers: { Authorization: typed },
       },
     };
-    const response = await settingsRouter.request('/', putInit(wrapManifest(keep)));
+    const response = await settingsRouter.request('/', putInit(wrapManifest(rotated)));
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       data: configured(
         {
-          ...keep,
+          ...rotated,
           auth: {
             type: 'header',
-            headers: { Authorization: HEADER_TOKEN_REDACTED },
+            headers: { Authorization: toRedactedSecretValue(typed) },
           },
         },
         'authenticated',
@@ -514,8 +521,8 @@ describe('mcp-servers routers', () => {
     const stored = await mcpServerStore.getServer({ tenant_id: TENANT_ID, name: putBodyWithHeaderAuth.name });
     expect(stored?.manifest).toEqual({
       ...putBodyWithHeaderAuth,
-      url: keep.url,
-      auth: putBodyWithHeaderAuth.auth,
+      url: rotated.url,
+      auth: { type: 'header', headers: { Authorization: typed } },
     });
   });
 
@@ -523,7 +530,7 @@ describe('mcp-servers routers', () => {
     await settingsRouter.request('/', putInit(wrapManifest(putBodyWithHeaderAuth)));
 
     const rotatedToken = 'Bearer rotated-token';
-    const rotatedTokenRedacted = 'Bea-***REDACTED***-ken';
+    const rotatedTokenRedacted = toRedactedSecretValue(rotatedToken);
     const rotated = {
       ...putBodyWithHeaderAuth,
       auth: {

--- a/packages/trueforge/tests/unit/apis/sandboxProviders.test.ts
+++ b/packages/trueforge/tests/unit/apis/sandboxProviders.test.ts
@@ -218,22 +218,29 @@ describe('sandbox-provider secret redaction and strict PUT', () => {
     expect(stored?.manifest).toEqual({ ...putBody, exec_timeout_ms: 120000 });
   });
 
-  it('PUT with a different redacted api_key still keeps the stored secret', async () => {
+  it('PUT with an api_key that merely contains the sentinel stores it', async () => {
     const { settingsRouter, sandboxProviderStore } = await createRouters();
     expect((await settingsRouter.request('/', putInit(putBody))).status).toBe(200);
 
-    const keep = {
+    /*
+     * This used to be asserted the other way round: any value containing ***REDACTED*** anywhere
+     * was treated as "keep the stored one". A real key carrying the
+     * sentinel was silently dropped and the old one stayed. Only the mask a GET actually returns
+     * means keep, so this is a rotation like any other.
+     */
+    const typed = `oth-${'***REDACTED***'}-xxx`;
+    const rotated = {
       ...putBody,
-      auth: { api_key: 'oth-***REDACTED***-xxx' },
+      auth: { api_key: typed },
     };
-    const response = await settingsRouter.request('/', putInit(keep));
+    const response = await settingsRouter.request('/', putInit(rotated));
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
-      data: wireResponse({ ...keep, auth: { api_key: toRedactedSecretValue(putBody.auth.api_key) } }),
+      data: wireResponse({ ...rotated, auth: { api_key: toRedactedSecretValue(typed) } }),
     });
 
     const stored = await sandboxProviderStore.getSandboxProvider(TENANT_ID);
-    expect(stored?.manifest).toEqual(putBody);
+    expect(stored?.manifest).toEqual(rotated);
   });
 
   it('PUT with a real api_key rotates the stored secret', async () => {

--- a/packages/trueforge/tests/unit/utils/secretRedaction.test.ts
+++ b/packages/trueforge/tests/unit/utils/secretRedaction.test.ts
@@ -1,0 +1,90 @@
+import {
+  isRedactedSecretValue,
+  MissingStoredSecretError,
+  resolveStoredSecretValue,
+  SECRET_REDACTION,
+  toRedactedSecretValue,
+} from '../../../src/utils/secretRedaction';
+
+/**
+ * The property these cover: the mask a GET returns is the only thing a later PUT may treat as
+ * "keep what you already have", and that mask publishes as little of the secret as it can.
+ */
+describe('secret redaction masking', () => {
+  it('never reveals more than the last four characters', () => {
+    const masked = toRedactedSecretValue('sk-ant-0123456789abcdef');
+
+    expect(masked).toBe(`${SECRET_REDACTION}-cdef`);
+    // The first three characters used to be published as well, which on a short key left very
+    // little unknown.
+    expect(masked).not.toContain('sk-');
+  });
+
+  it('masks a short secret completely, because a suffix would be most of it', () => {
+    expect(toRedactedSecretValue('short')).toBe(SECRET_REDACTION);
+    expect(toRedactedSecretValue('12345678901')).toBe(SECRET_REDACTION);
+  });
+
+  it('leaks at most four of a secret at the threshold length', () => {
+    const secret = '123456789012';
+    const masked = toRedactedSecretValue(secret);
+
+    const revealed = [...secret].filter(character => masked.includes(character));
+    expect(masked).toBe(`${SECRET_REDACTION}-9012`);
+    // Eight of twelve characters stay unknown. The old mask published six of ten.
+    expect(new Set(revealed).size).toBeLessThanOrEqual(4);
+  });
+});
+
+describe('recognising the mask a client sends back', () => {
+  it('recognises the two shapes a GET can return', () => {
+    expect(isRedactedSecretValue(SECRET_REDACTION)).toBe(true);
+    expect(isRedactedSecretValue(toRedactedSecretValue('sk-0123456789abcdef'))).toBe(true);
+  });
+
+  it('does not treat a real secret containing the sentinel as a mask', () => {
+    /*
+     * A substring test classified any value with the sentinel anywhere in it as "keep the stored
+     * one", so a secret that happened to contain it was silently dropped — persisting the old
+     * value, or failing a create with a message about a missing key and no explanation.
+     */
+    expect(isRedactedSecretValue(`Bearer token=${SECRET_REDACTION}-demo`)).toBe(false);
+    expect(isRedactedSecretValue(`${SECRET_REDACTION}-with-a-longer-tail`)).toBe(false);
+    expect(isRedactedSecretValue(`prefix-${SECRET_REDACTION}`)).toBe(false);
+    expect(isRedactedSecretValue(`sk-${SECRET_REDACTION}-test`)).toBe(false);
+  });
+
+  it('does not treat an ordinary secret as a mask', () => {
+    expect(isRedactedSecretValue('sk-ant-0123456789')).toBe(false);
+    expect(isRedactedSecretValue('')).toBe(false);
+  });
+});
+
+describe('resolving what to store', () => {
+  it('stores a real secret that contains the sentinel instead of dropping it', () => {
+    // The user typed this. Before the fix it vanished and the old key stayed.
+    const typed = `sk-${SECRET_REDACTION}-test`;
+
+    expect(resolveStoredSecretValue({ incoming: typed, existing: 'sk-old-value-here' })).toBe(typed);
+  });
+
+  it('keeps the stored secret when the client sends that secret’s own mask', () => {
+    const stored = 'sk-ant-0123456789abcdef';
+
+    expect(resolveStoredSecretValue({ incoming: toRedactedSecretValue(stored), existing: stored })).toBe(stored);
+  });
+
+  it('keeps the stored secret for the bare sentinel, which a short one masks to', () => {
+    expect(resolveStoredSecretValue({ incoming: SECRET_REDACTION, existing: 'short' })).toBe('short');
+  });
+
+  it('refuses a mask when there is nothing stored to keep', () => {
+    expect(() => resolveStoredSecretValue({ incoming: SECRET_REDACTION, existing: undefined })).toThrow(
+      MissingStoredSecretError,
+    );
+  });
+
+  it('rotates to a new real secret', () => {
+    expect(resolveStoredSecretValue({ incoming: 'sk-new', existing: 'sk-old' })).toBe('sk-new');
+  });
+});


### PR DESCRIPTION
Fixes #423.

## Both defects, and one correction to the proposed fix

**Defect 1 — sentinel matched by substring.** `isRedactedSecretValue` used `.includes()`, so any real secret containing `***REDACTED***` anywhere was read as "keep the stored one". The value the user typed was discarded with nothing saying so: the old secret survived an update, and a create failed with a message about a missing key. It is now a whole-value test.

**One correction.** The issue proposes `value === SECRET_REDACTION`, on the grounds that "the redaction function only ever emits that exact standalone string". It does not — that is only the short-secret branch. A secret at or above the threshold masks to the sentinel *plus* a suffix, and a client round-tripping an unedited form sends that back. Exact-equality-only would classify it as a real value and **store the mask as the secret**, which is a worse bug than the one being fixed. So the test matches the two shapes `toRedactedSecretValue` actually emits, anchored to the whole value, and nothing else.

A secret whose entire content is exactly one of those two shapes remains indistinguishable from a mask. Nothing in-band can separate them — only a separate `keep` field beside the value could, which is an API change rather than a fix. Left alone, and documented in the module so the next reader does not have to rediscover it.

**Defect 2 — prefix/suffix leak.** Any secret of ten characters or more came back as first three + last three, so a ten-character key published six of its ten to every viewer of a settings response, screen share, or captured log. Now: last four only, and only for secrets of at least twelve, so eight characters stay unknown at the threshold. Shorter secrets are masked completely. Suffix-only matches what other providers publish, as the issue suggests.

```
before   toRedactedSecretValue('sk-ant-01234')  ->  sk-***REDACTED***-234
after    toRedactedSecretValue('sk-ant-01234')  ->  ***REDACTED***-1234
```

## Two existing tests asserted the defect

`mcpServers.test.ts` and `sandboxProviders.test.ts` each sent a redacted-*looking* value that was not the stored secret's mask (`oth-***REDACTED***-xxx`) and asserted the stored secret survived, with the comment:

> `// Any value containing ***REDACTED*** is treated as keep, not only the exact GET mask.`

That is defect 1 written down as intended behaviour, so both now assert the opposite: a value that merely contains the sentinel is stored like any other rotation. Flagging it explicitly since inverting an existing assertion deserves a look rather than a skim.

The MCP tests also hardcoded the wire form (`'Bea-***REDACTED***-ken'`). That is now derived from `toRedactedSecretValue`, so the mask has one definition and the tests cannot drift from it again.

## Verified

- `tests/unit/apis/` + `tests/unit/utils/` — **146 passed, 15 suites**, including 11 new cases covering both defects, the round-trip keep, the create-with-mask refusal, and rotation.
- `tsc --noEmit` clean for `src` and for `tests/unit/tsconfig.json`.
- `prettier --check` and `eslint` clean on the files touched.
- Six failures elsewhere in the package (`LocalSandboxProvider`, `Code Mode UDS`) are a Windows host — unix sockets and symlink paths — and **fail identically on a clean checkout with this branch stashed**, so they are not from this change.

## Notes

- `.changeset/secret-redaction-exact-mask.md` added, per the `packages/trueforge` rule in `AGENTS.md`.
- No wire-shape or schema change: the mask is a string field either way, so `packages/trueforge-sdk` and the OpenAPI spec are untouched.
- Defect 2b in the issue — the round-trip relying on the substring check — is closed by the same change, since the emitted mask is now what the keep test recognises.
- Unrelated, in case it is useful: `pnpm --filter @truefoundry/trueforge test` cannot run on a Windows host, because the script uses a `NODE_OPTIONS='…' node …` inline env prefix and cmd.exe has no such syntax. I ran jest directly to get around it. That looks like the same family as #427 and #374, so I have not touched it here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret persistence and response masking for settings APIs (MCP headers, sandbox/model providers); clients may see a different mask string on GET, but round-trip keep still works for the new shapes.
> 
> **Overview**
> Tightens **settings secret redaction** so GET masks leak less and PUT “keep existing secret” only applies to the exact mask shapes the API returns—not any string that happens to contain `***REDACTED***`.
> 
> **Response masking** no longer publishes the first three characters. Long secrets (≥12 chars) now appear as `***REDACTED***-` plus the **last four** characters; shorter secrets are fully redacted.
> 
> **Write-back detection** in `isRedactedSecretValue` switches from a substring check to whole-value matching: bare sentinel or the fixed suffix-mask form from `toRedactedSecretValue`. Real secrets that embed the sentinel are stored as typed instead of silently keeping the old value. MCP header auth and sandbox provider API tests are inverted accordingly; dedicated unit tests cover masking, recognition, and `resolveStoredSecretValue`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe3696c925d44e6b02143b3696b14f45bc5bf1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->