### PR TITLE
fix(sandbox): scope Daytona snapshots by account

### DIFF
--- a/.changeset/swift-sandboxes-share.md
+++ b/.changeset/swift-sandboxes-share.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-core': patch
+---
+
+Scope derived Daytona snapshot build names to the configured account so different accounts do not collide on the same TrueForge sandbox image.

--- a/packages/trueforge-core/src/core/sandbox/provider/DaytonaProvider.ts
+++ b/packages/trueforge-core/src/core/sandbox/provider/DaytonaProvider.ts
@@ -2,7 +2,7 @@ import type { Sandbox, Snapshot } from '@daytona/sdk';
 import { Daytona, DaytonaError } from '@daytona/sdk';
 import { context } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { randomUUID } from 'node:crypto';
+import { createHmac, randomUUID } from 'node:crypto';
 import { join } from 'node:path/posix';
 import type { Logger } from 'winston';
 import { extractErrorLogFields } from '../../util/errorLogFields';
@@ -49,9 +49,14 @@ function imageDigest(image: string): string {
   return lastSegment.slice(colon + 1);
 }
 
-/** Deterministic build name per image digest so every server replica converges on one build. */
-function deriveImageBuildName(digest: string): string {
-  return `${IMAGE_BUILD_NAME_PREFIX}${digest}`;
+/**
+ * Deterministic build name per Daytona account and image digest. Daytona snapshot names are global,
+ * so an image-only name can resolve to another account's inaccessible snapshot. The API key is
+ * high-entropy secret material and is used only as the HMAC key; it never appears in the name.
+ */
+function deriveImageBuildName({ digest, apiKey }: { digest: string; apiKey: string }): string {
+  const accountImageDigest = createHmac('sha256', apiKey).update(digest).digest('hex').slice(0, 40);
+  return `${IMAGE_BUILD_NAME_PREFIX}${accountImageDigest}`;
 }
 
 /** Terminal-failure build states: a build stuck here never becomes ready on its own. */
@@ -84,9 +89,9 @@ export interface DaytonaSandboxProviderOptions {
   /** Release-owned sandbox image reference; built into a Daytona snapshot and cloned per sandbox. */
   sandboxImage: string;
   /**
-   * Daytona snapshot name to clone sandboxes from. When omitted it is derived from the image
-   * digest. Callers that create sandboxes pass the persisted build_ref so cloning targets the
-   * snapshot that was actually built, not a speculative name derived from the current image.
+   * Daytona snapshot name to clone sandboxes from. When omitted it is derived from the account
+   * credential and image digest. Callers that create sandboxes pass the persisted build_ref so
+   * cloning targets the snapshot that was actually built, not a speculative name.
    */
   buildRef?: string | undefined;
   timeoutMs: number;
@@ -106,7 +111,7 @@ export class DaytonaSandboxProvider implements SandboxProvider {
   private readonly tenantName: string;
   /** Release-owned sandbox image reference; built into a Daytona snapshot and cloned per sandbox. */
   private readonly imageUri: string;
-  /** Daytona snapshot name sandboxes are cloned from; the persisted build_ref, or derived from the image digest. */
+  /** Daytona snapshot name sandboxes are cloned from; the persisted build_ref, or a credential-scoped image name. */
   private readonly buildRef: string;
   private readonly timeoutMs: number;
   private readonly autoStopIntervalInMinutes: number;
@@ -129,7 +134,8 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     this.apiUrl = options.apiUrl ?? DEFAULT_DAYTONA_API_URL;
     this.tenantName = options.tenantName;
     this.imageUri = options.sandboxImage;
-    this.buildRef = options.buildRef ?? deriveImageBuildName(imageDigest(options.sandboxImage));
+    this.buildRef =
+      options.buildRef ?? deriveImageBuildName({ digest: imageDigest(options.sandboxImage), apiKey: options.apiKey });
     this.timeoutMs = options.timeoutMs;
     this.autoStopIntervalInMinutes = options.autoStopIntervalInMinutes;
     this.autoArchiveIntervalInMinutes = options.autoArchiveIntervalInMinutes;

--- a/packages/trueforge-core/tests/core/sandbox/daytonaSnapshotRegistration.test.ts
+++ b/packages/trueforge-core/tests/core/sandbox/daytonaSnapshotRegistration.test.ts
@@ -12,14 +12,14 @@ const API_URL = 'https://daytona.test/api';
  * Builds a provider whose snapshot lookup reports "not built yet" so `buildImage` always reaches
  * the register-only POST.
  */
-function makeProvider(): DaytonaSandboxProvider {
+function makeProvider({ apiKey = 'dtn-test' }: { apiKey?: string } = {}): DaytonaSandboxProvider {
   // useDeprecatedPolling keeps the constructor from opening the event-stream WebSocket.
-  const client = new Daytona({ apiKey: 'dtn-test', useDeprecatedPolling: true });
+  const client = new Daytona({ apiKey, useDeprecatedPolling: true });
   jest.spyOn(client.snapshot, 'get').mockRejectedValue(new DaytonaError('not found', NOT_FOUND_STATUS));
 
   return new DaytonaSandboxProvider({
     client,
-    apiKey: 'dtn-test',
+    apiKey,
     apiUrl: API_URL,
     tenantName: 'test-tenant',
     sandboxImage: 'registry.example.com/sandbox:029ea5ff',
@@ -35,7 +35,9 @@ function makeProvider(): DaytonaSandboxProvider {
 function mockFetch({ status, body }: { status: number; body: unknown }): jest.SpiedFunction<typeof globalThis.fetch> {
   return jest
     .spyOn(globalThis, 'fetch')
-    .mockResolvedValue(new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } }));
+    .mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })),
+    );
 }
 
 afterEach(() => {
@@ -56,10 +58,25 @@ describe('DaytonaSandboxProvider register-only snapshot create', () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe(`${API_URL}/snapshots`);
     const init = fetchMock.mock.calls[0]?.[1];
     expect(init?.method).toBe('POST');
-    expect(JSON.parse(String(init?.body))).toEqual({
-      name: 'trueforge-build-029ea5ff',
-      imageName: 'registry.example.com/sandbox:029ea5ff',
+    const body: unknown = JSON.parse(String(init?.body));
+    expect(body).toMatchObject({ imageName: 'registry.example.com/sandbox:029ea5ff' });
+    expect(body).toHaveProperty('name', expect.stringMatching(/^trueforge-build-[a-f0-9]{40}$/));
+  });
+
+  it('scopes derived build names to the Daytona credential', async () => {
+    const fetchMock = mockFetch({
+      status: 200,
+      body: { id: 'snap-1', state: 'pending', errorReason: null },
     });
+
+    await makeProvider({ apiKey: 'dtn-account-one' }).buildImage();
+    await makeProvider({ apiKey: 'dtn-account-two' }).buildImage();
+
+    const firstBody: unknown = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    const secondBody: unknown = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(firstBody).toMatchObject({ name: expect.stringMatching(/^trueforge-build-[a-f0-9]{40}$/) });
+    expect(secondBody).toMatchObject({ name: expect.stringMatching(/^trueforge-build-[a-f0-9]{40}$/) });
+    expect(firstBody).not.toEqual(secondBody);
   });
 
   it('treats a concurrent-create conflict as pending, not a thrown failure', async () => {


### PR DESCRIPTION
## Summary

Daytona snapshot names are global, while TrueForge previously derived the snapshot build name from only the sandbox image digest. Two Daytona accounts using the same TrueForge image therefore converged on the same name, which could resolve to another account's inaccessible snapshot and return Access denied.

This scopes the derived name to both the Daytona credential and image digest using HMAC-SHA256. The credential is used only as the HMAC key and is never serialized into the snapshot name.

No maintainer approval or tracking issue is linked yet.

## Changes

- Derive deterministic snapshot names from the Daytona credential and image digest.
- Preserve convergence for replicas using the same account and image.
- Add regression coverage proving different credentials produce different build names.
- Add a patch changeset for trueforge-core.

## How was this tested?

- `pnpm --filter @truefoundry/trueforge-core exec jest --config jest.config.cjs packages/trueforge-core/tests/core/sandbox/daytonaSnapshotRegistration.test.ts --runInBand` — 5 tests passed.
- `pnpm --filter @truefoundry/trueforge-core typecheck` — passed.
- Live TrueForge configuration reached Daytona snapshot ready state, and Daytona sandboxes successfully ran CSV, XLSX, and MCP-to-PostgreSQL integration turns.

## Checklist

- [x] I have read the contributing guidelines
- [ ] Full workspace build, test, lint, and format checks pass locally (focused tests and trueforge-core typecheck passed; CI will run the complete matrix)
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code
- [x] Docs / `.env.example` updated if configuration or behavior changed (not applicable: no configuration shape changed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox snapshot registration naming on the Daytona provider path; deployments without a persisted build_ref may register under a new name and need a fresh build, but the fix addresses real cross-account snapshot collisions.
> 
> **Overview**
> Daytona snapshot names are global, so TrueForge previously derived `trueforge-build-*` names from the sandbox image digest alone. **Different Daytona accounts sharing the same TrueForge image could collide on that name** and hit another account’s snapshot (e.g. Access denied).
> 
> This PR **mixes the Daytona API key into derivation** via HMAC-SHA256 over the digest (key material never appears in the name). Replicas with the same credential and image still get one deterministic name; **omitted `buildRef` now resolves to a 40-character hex suffix** instead of the raw digest. Persisted `build_ref` behavior is unchanged.
> 
> Tests assert the new name shape and that **different API keys produce different registration names**; a patch changeset documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4070e936fd0cf1442331123b619426e5e7b845b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->