### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ To work on TrueForge from this repository, see [CONTRIBUTING.md](CONTRIBUTING.md
 
 We compare TrueForge against Claude Managed Agents and deepagents on the same tasks, tools, and model - same accuracy, lower cost. Reproduce it from [`benchmark/`](benchmark/). Write-up: [Benchmarking](https://trueforge.dev/benchmarking).
 
+## ☁️ One-Click Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/TrueForge/)
+
 ## Contributing
 
 We love contributions - bug reports, features, and docs fixes. See [CONTRIBUTING.md](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md). Fork PRs should change source only; maintainers regenerate the SDK after merge.


### PR DESCRIPTION
## Summary

Adds a RepoCloud one-click deploy button to the README, placed in a new "☁️ One-Click Deploy" section between Benchmarks and Contributing.

 - New `## ☁️ One-Click Deploy` section with deploy button
 - Button links to https://repocloud.io/details/TrueForge/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no code, config, or deployment logic affected.
> 
> **Overview**
> Adds a **☁️ One-Click Deploy** section to the README between **Benchmarks** and **Contributing**, with a RepoCloud deploy badge that links to `https://repocloud.io/details/TrueForge/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80e47fa399e579e9d2e85ada4fc12ccb65d81eba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->