### PR TITLE
docs: document Daytona key snapshot permission requirement

### DIFF
--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -31,6 +31,15 @@ That means:
 
 Open **Settings → Sandbox providers**, pick the [Daytona](https://www.daytona.io) preset from the catalog, and paste your API key.
 
+<Note>
+  The Daytona API key needs permission to create **snapshots**, not only sandboxes. The first time you configure the
+  provider, TrueForge builds a release snapshot in your Daytona account, and every sandbox it starts afterwards is
+  cloned from that snapshot. Create the key with **Sandboxes** access and **Snapshots** write (create) permission.
+
+  If the key is missing snapshot permission, configuring the provider fails with a generic `Daytona rejected the API key`
+  even though the key is otherwise valid. If you hit that, check the key's permissions before regenerating it.
+</Note>
+
 <div style={{ position: "relative", boxSizing: "content-box", width: "100%", aspectRatio: "1.75", padding: "40px 0" }}>
   <iframe
     src="https://app.supademo.com/embed/cmsk7vatl00pz0n0jme1d96w5?embed_v=2&utm_source=embed"

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -36,7 +36,7 @@ Open **Settings → Sandbox providers**, pick the [Daytona](https://www.daytona.
   provider, TrueForge builds a release snapshot in your Daytona account, and every sandbox it starts afterwards is
   cloned from that snapshot. Create the key with **Sandboxes** access and **Snapshots** write (create) permission.
 
-  If the key is missing snapshot permission, configuring the provider fails with a generic `Daytona rejected the API key`
+  If the key is missing snapshot permission, configuring the provider fails 
   even though the key is otherwise valid. If you hit that, check the key's permissions before regenerating it.
 </Note>
 


### PR DESCRIPTION
The Daytona sandbox-provider setup in `docs/sandbox.mdx` only said "paste your API key." A key with just *Sandboxes* access fails with a misleading `Daytona rejected the API key`, because TrueForge builds a **release snapshot** in the Daytona account and clones every sandbox from it (`turns.ts` / `checkSnapshotStatus`). The key also needs **Snapshots (write)** permission.

Adds a note with the required key scope and the symptom to watch for.

Reported from a real install: https://hiteshpattanayak.com/posts/trueforge-daytona-setup-what-the-docs-miss/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> The **Configuring a provider** section in `docs/sandbox.mdx` now includes a note that a Daytona API key must allow **Snapshots** write (create), not only **Sandboxes** access.
> 
> The note explains that TrueForge creates a release snapshot on first provider setup and clones sandboxes from it, and that missing snapshot permission can make setup fail with a generic invalid-key error even when the key otherwise works—so operators should verify permissions before regenerating the key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab0fff90dd0d5c9268c0b9a36f708525ae4541d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->