### PR TITLE
Add GET agent code-snippets for TypeScript SDK samples

### DIFF
--- a/.changeset/agent-code-snippets.md
+++ b/.changeset/agent-code-snippets.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": patch
+---
+
+Add GET /api/v1/agents/{agent_id}/code-snippets with TypeScript TrueForge SDK stream and non-stream samples.

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -4426,6 +4426,118 @@
         "x-fern-sdk-method-name": "update"
       }
     },
+    "/api/v1/agents/{agent_id}/code-snippets": {
+      "get": {
+        "description": "TypeScript TrueForge SDK samples (stream and non-stream) for creating a session and turn against this agent.",
+        "parameters": [
+          {
+            "description": "Immutable agent identifier.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "description": "Immutable agent identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "base_url": {
+                          "description": "Origin to pass as the TrueForge SDK `baseUrl`.",
+                          "format": "uri",
+                          "type": "string"
+                        },
+                        "snippets": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "icon": {
+                                "format": "uri",
+                                "type": "string"
+                              },
+                              "label_name": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "language": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "sample_code": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "non_stream": {
+                                    "description": "SDK sample that creates a turn without streaming.",
+                                    "type": "string"
+                                  },
+                                  "stream": {
+                                    "description": "SDK sample that streams turn events.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "stream",
+                                  "non_stream"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "label_name",
+                              "language",
+                              "icon",
+                              "sample_code"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "base_url",
+                        "snippets"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "TypeScript SDK samples and the origin to use as `baseUrl`."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Agent not found."
+          }
+        },
+        "summary": "Get agent SDK code snippets",
+        "tags": [
+          "Agents"
+        ],
+        "x-excluded": true,
+        "x-fern-ignore": true
+      }
+    },
     "/api/v1/auth/callback": {
       "get": {
         "description": "Browser-redirect target hit by the identity provider after login, never called directly by SDK consumers. In local/single-binary mode, redirects straight back into the app.",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4426,6 +4426,118 @@
         "x-fern-sdk-method-name": "update"
       }
     },
+    "/api/v1/agents/{agent_id}/code-snippets": {
+      "get": {
+        "description": "TypeScript TrueForge SDK samples (stream and non-stream) for creating a session and turn against this agent.",
+        "parameters": [
+          {
+            "description": "Immutable agent identifier.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "description": "Immutable agent identifier.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "base_url": {
+                          "description": "Origin to pass as the TrueForge SDK `baseUrl`.",
+                          "format": "uri",
+                          "type": "string"
+                        },
+                        "snippets": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "icon": {
+                                "format": "uri",
+                                "type": "string"
+                              },
+                              "label_name": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "language": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "sample_code": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "non_stream": {
+                                    "description": "SDK sample that creates a turn without streaming.",
+                                    "type": "string"
+                                  },
+                                  "stream": {
+                                    "description": "SDK sample that streams turn events.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "stream",
+                                  "non_stream"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "label_name",
+                              "language",
+                              "icon",
+                              "sample_code"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "base_url",
+                        "snippets"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "TypeScript SDK samples and the origin to use as `baseUrl`."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestErrorResponse"
+                }
+              }
+            },
+            "description": "Agent not found."
+          }
+        },
+        "summary": "Get agent SDK code snippets",
+        "tags": [
+          "Agents"
+        ],
+        "x-excluded": true,
+        "x-fern-ignore": true
+      }
+    },
     "/api/v1/auth/callback": {
       "get": {
         "description": "Browser-redirect target hit by the identity provider after login, never called directly by SDK consumers. In local/single-binary mode, redirects straight back into the app.",

--- a/packages/trueforge/src/apis/agentCodeSnippets.ts
+++ b/packages/trueforge/src/apis/agentCodeSnippets.ts
@@ -1,0 +1,35 @@
+import type { AgentCodeSnippets } from '../schemas/agent';
+import { typescriptNonStreamTemplate, typescriptStreamTemplate } from './codesnippet-templates/typescript';
+
+const TYPESCRIPT_ICON = 'https://assets.production.truefoundry.com/typescript.svg';
+
+function renderSnippetTemplate(template: string, vars: { agentName: string; baseUrl: string }): string {
+  const literals: Record<string, string> = {
+    agentName: JSON.stringify(vars.agentName),
+    baseUrl: JSON.stringify(vars.baseUrl),
+  };
+  return template.replaceAll(/\{\{(\w+)\}\}/g, (match, key: string) => {
+    const value = literals[key];
+    if (value === undefined) {
+      throw new Error(`Unknown snippet template placeholder ${match}`);
+    }
+    return value;
+  });
+}
+
+export function buildAgentCodeSnippets(input: { agentName: string; baseUrl: string }): AgentCodeSnippets {
+  return {
+    base_url: input.baseUrl,
+    snippets: [
+      {
+        label_name: 'TypeScript',
+        language: 'typescript',
+        icon: TYPESCRIPT_ICON,
+        sample_code: {
+          stream: renderSnippetTemplate(typescriptStreamTemplate, input),
+          non_stream: renderSnippetTemplate(typescriptNonStreamTemplate, input),
+        },
+      },
+    ],
+  };
+}

--- a/packages/trueforge/src/apis/agents.ts
+++ b/packages/trueforge/src/apis/agents.ts
@@ -12,12 +12,14 @@ import type { WithTransaction } from '../db/transaction';
 import {
   createAgentRoute,
   deleteAgentRoute,
+  getAgentCodeSnippetsRoute,
   getAgentRoute,
   listAgentsRoute,
   putAgentRoute,
 } from '../routes/agentRoutes';
 import { validateAgentSpec } from '../runtime/sessionResources';
 import { type Agent, type CreateAgentRequest } from '../schemas/agent';
+import { buildAgentCodeSnippets } from './agentCodeSnippets';
 import { TENANT_ID } from './sessions';
 
 export interface AgentsRouterDeps<TTransaction> {
@@ -89,6 +91,23 @@ export function createAgentsRouter<TTransaction>(deps: AgentsRouterDeps<TTransac
     return c.json({ data: toWireAgent(record) }, 200);
   };
 
+  const getCodeSnippetsHandler: RouteHandler<typeof getAgentCodeSnippetsRoute> = async c => {
+    const { agent_id: agentId } = c.req.valid('param');
+    const record = await deps.agentStore.getAgent({ tenant_id: TENANT_ID, id: agentId });
+    if (record === undefined) {
+      return c.json({ error: { message: `Agent not found: ${agentId}` } }, 404);
+    }
+    return c.json(
+      {
+        data: buildAgentCodeSnippets({
+          agentName: record.name,
+          baseUrl: new URL(c.req.url).origin,
+        }),
+      },
+      200,
+    );
+  };
+
   const deleteHandler: RouteHandler<typeof deleteAgentRoute> = async c => {
     const { agent_id: agentId } = c.req.valid('param');
     await deps.agentStore.deleteAgent({ tenant_id: TENANT_ID, id: agentId });
@@ -113,6 +132,7 @@ export function createAgentsRouter<TTransaction>(deps: AgentsRouterDeps<TTransac
   const router = new OpenAPIHono();
   router.openapi(listAgentsRoute, listHandler);
   router.openapi(createAgentRoute, createHandler);
+  router.openapi(getAgentCodeSnippetsRoute, getCodeSnippetsHandler);
   router.openapi(getAgentRoute, getHandler);
   router.openapi(deleteAgentRoute, deleteHandler);
   router.openapi(putAgentRoute, putHandler);

--- a/packages/trueforge/src/apis/codesnippet-templates/typescript.ts
+++ b/packages/trueforge/src/apis/codesnippet-templates/typescript.ts
@@ -1,0 +1,55 @@
+export const typescriptStreamTemplate = `// npm install @truefoundry/trueforge-sdk
+import { TrueForge, TrueForgeApi, isEventDelta, mergeEventDelta } from "@truefoundry/trueforge-sdk";
+
+const client = new TrueForge({
+  baseUrl: {{baseUrl}},
+  timeoutInSeconds: 600,
+});
+
+const { data: session } = await client.sessions.create({
+  agent: { name: {{agentName}} },
+});
+
+const events = new Map<string, TrueForgeApi.TurnStreamingEvent>();
+let turnId: string | undefined;
+let lastSequenceNumber = 0;
+
+const stream = await client.sessions.createTurnStream(session.id, {
+  input: [{ type: "user.message", content: "Hello!" }],
+});
+
+for await (const { data: event, id } of stream.withMetadata()) {
+  if (id != null) lastSequenceNumber = Number(id);
+  if (event.type === "turn.created") turnId = event.turnId;
+  if (isEventDelta(event)) {
+    const base = events.get(event.id);
+    if (base) mergeEventDelta(base, event);
+  } else {
+    events.set(event.id, event);
+  }
+  if (event.type === "turn.done") console.log("status:", event.state.status);
+}
+`;
+
+export const typescriptNonStreamTemplate = `// npm install @truefoundry/trueforge-sdk
+import { TrueForge } from "@truefoundry/trueforge-sdk";
+
+const client = new TrueForge({
+  baseUrl: {{baseUrl}},
+  timeoutInSeconds: 600,
+});
+
+const { data: session } = await client.sessions.create({
+  agent: { name: {{agentName}} },
+});
+
+const { data: turn } = await client.sessions.createTurn(session.id, {
+  input: [{ type: "user.message", content: "Hello!" }],
+});
+
+console.log(turn.id, turn.state);
+
+// Turn may still be running. Call getTurn to read a later state.
+const { data: latest } = await client.sessions.getTurn(session.id, turn.id);
+console.log(latest.state);
+`;

--- a/packages/trueforge/src/routes/agentRoutes.ts
+++ b/packages/trueforge/src/routes/agentRoutes.ts
@@ -81,8 +81,8 @@ export const getAgentCodeSnippetsRoute = createRoute({
   summary: 'Get agent SDK code snippets',
   description:
     'TypeScript TrueForge SDK samples (stream and non-stream) for creating a session and turn against this agent.',
-  'x-fern-sdk-group-name': ['agents'],
-  'x-fern-sdk-method-name': 'get_code_snippets',
+  'x-fern-ignore': true,
+  'x-excluded': true,
   request: {
     params: AgentIdParamsSchema,
   },

--- a/packages/trueforge/src/routes/agentRoutes.ts
+++ b/packages/trueforge/src/routes/agentRoutes.ts
@@ -6,6 +6,7 @@ import { createRoute, z } from '@hono/zod-openapi';
 import {
   CreateAgentRequestSchema,
   DeleteAgentResponseSchema,
+  GetAgentCodeSnippetsResponseSchema,
   GetAgentResponseSchema,
   ListAgentsResponseSchema,
   UpdateAgentRequestSchema,
@@ -69,6 +70,30 @@ export const createAgentRoute = createRoute({
       content: { 'application/json': { schema: RequestErrorResponseSchema } },
       description:
         'The agent spec is valid but requires a capability this server does not provide (e.g. sandbox or skills).',
+    },
+  },
+});
+
+export const getAgentCodeSnippetsRoute = createRoute({
+  method: 'get',
+  path: '/{agent_id}/code-snippets',
+  tags: [OpenApiTag.AGENTS],
+  summary: 'Get agent SDK code snippets',
+  description:
+    'TypeScript TrueForge SDK samples (stream and non-stream) for creating a session and turn against this agent.',
+  'x-fern-sdk-group-name': ['agents'],
+  'x-fern-sdk-method-name': 'get_code_snippets',
+  request: {
+    params: AgentIdParamsSchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: GetAgentCodeSnippetsResponseSchema } },
+      description: 'TypeScript SDK samples and the origin to use as `baseUrl`.',
+    },
+    404: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'Agent not found.',
     },
   },
 });

--- a/packages/trueforge/src/schemas/agent.ts
+++ b/packages/trueforge/src/schemas/agent.ts
@@ -42,8 +42,7 @@ export const AgentCodeSnippetSampleCodeSchema = z
     stream: z.string().describe('SDK sample that streams turn events.'),
     non_stream: z.string().describe('SDK sample that creates a turn without streaming.'),
   })
-  .strict()
-  .openapi('AgentCodeSnippetSampleCode');
+  .strict();
 
 export const AgentCodeSnippetSchema = z
   .object({
@@ -52,20 +51,16 @@ export const AgentCodeSnippetSchema = z
     icon: z.url(),
     sample_code: AgentCodeSnippetSampleCodeSchema,
   })
-  .strict()
-  .openapi('AgentCodeSnippet');
+  .strict();
 
 export const AgentCodeSnippetsSchema = z
   .object({
     base_url: z.url().describe('Origin to pass as the TrueForge SDK `baseUrl`.'),
     snippets: z.array(AgentCodeSnippetSchema),
   })
-  .strict()
-  .openapi('AgentCodeSnippets');
+  .strict();
 
-export const GetAgentCodeSnippetsResponseSchema = z
-  .object({ data: AgentCodeSnippetsSchema })
-  .openapi('GetAgentCodeSnippetsResponse');
+export const GetAgentCodeSnippetsResponseSchema = z.object({ data: AgentCodeSnippetsSchema });
 
 export type CreateAgentRequest = z.infer<typeof CreateAgentRequestSchema>;
 export type UpdateAgentRequest = z.infer<typeof UpdateAgentRequestSchema>;

--- a/packages/trueforge/src/schemas/agent.ts
+++ b/packages/trueforge/src/schemas/agent.ts
@@ -37,6 +37,37 @@ export const GetAgentResponseSchema = z.object({ data: AgentSchema }).openapi('G
 export const ListAgentsResponseSchema = z.object({ data: z.array(AgentSchema) }).openapi('ListAgentsResponse');
 export const DeleteAgentResponseSchema = z.object({}).openapi('DeleteAgentResponse');
 
+export const AgentCodeSnippetSampleCodeSchema = z
+  .object({
+    stream: z.string().describe('SDK sample that streams turn events.'),
+    non_stream: z.string().describe('SDK sample that creates a turn without streaming.'),
+  })
+  .strict()
+  .openapi('AgentCodeSnippetSampleCode');
+
+export const AgentCodeSnippetSchema = z
+  .object({
+    label_name: z.string().min(1),
+    language: z.string().min(1),
+    icon: z.url(),
+    sample_code: AgentCodeSnippetSampleCodeSchema,
+  })
+  .strict()
+  .openapi('AgentCodeSnippet');
+
+export const AgentCodeSnippetsSchema = z
+  .object({
+    base_url: z.url().describe('Origin to pass as the TrueForge SDK `baseUrl`.'),
+    snippets: z.array(AgentCodeSnippetSchema),
+  })
+  .strict()
+  .openapi('AgentCodeSnippets');
+
+export const GetAgentCodeSnippetsResponseSchema = z
+  .object({ data: AgentCodeSnippetsSchema })
+  .openapi('GetAgentCodeSnippetsResponse');
+
 export type CreateAgentRequest = z.infer<typeof CreateAgentRequestSchema>;
 export type UpdateAgentRequest = z.infer<typeof UpdateAgentRequestSchema>;
 export type Agent = z.infer<typeof AgentSchema>;
+export type AgentCodeSnippets = z.infer<typeof AgentCodeSnippetsSchema>;

--- a/packages/trueforge/tests/unit/apis/agents.test.ts
+++ b/packages/trueforge/tests/unit/apis/agents.test.ts
@@ -120,6 +120,20 @@ describe('agents router', () => {
 
     const put = await router.request('/missing-agent-id', jsonInit('PUT', updateBody));
     expect(put.status).toBe(404);
+
+    const snippets = await router.request('/missing-agent-id/code-snippets');
+    expect(snippets.status).toBe(404);
+  });
+
+  it('GET code-snippets returns snippets for an existing agent', async () => {
+    const created = await router.request('/', jsonInit('POST', { ...writeBody, name: 'snippet-bot' }));
+    expect(created.status).toBe(201);
+    const createdJson = (await created.json()) as { data: WireAgent };
+
+    const response = await router.request(`/${createdJson.data.id}/code-snippets`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { data: { snippets: unknown[] } };
+    expect(body.data.snippets.length).toBeGreaterThan(0);
   });
 
   it('DELETE removes an agent by id and is idempotent', async () => {


### PR DESCRIPTION
## Summary

Adds a harness “Use in Code” API so the UI can fetch TypeScript SDK samples for a named agent (stream and non-stream).

AGE-1996

## Changes

- `GET /api/v1/agents/{agent_id}/code-snippets`
- `x-fern-ignore` / `x-excluded` — not a public SDK method; UI should `fetch` this JSON (same idea as logout, not a browser redirect)
- Returns `{ data: { base_url, snippets[] } }` with TypeScript `sample_code.stream` / `sample_code.non_stream`
- Samples use `@truefoundry/trueforge-sdk`: `createTurnStream` (events) vs `createTurn` + `getTurn` (no poll loop)
- 404 when the agent id is missing
- Patch changeset for `@truefoundry/trueforge`

## How was this tested?

- Unit: `pnpm --filter @truefoundry/trueforge test -- tests/unit/apis/agents.test.ts` (200 with a non-empty `snippets` array; 404 for unknown id)
- Manual: `GET http://localhost:3000/api/v1/agents/<agent_id>/code-snippets` and ran the stream sample with `npx tsx` (needs `"type": "module"` in the scratch `package.json`)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / `.env.example` updated if configuration or behavior changed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only, UI-oriented endpoint with no changes to auth, sessions, or agent mutation; main risk is stale or misleading sample text if SDK APIs change.
> 
> **Overview**
> Adds **`GET /api/v1/agents/{agent_id}/code-snippets`** so the harness “Use in Code” flow can load ready-to-copy **TypeScript** samples for a registry agent. The route is documented in OpenAPI but marked **`x-fern-ignore` / `x-excluded`** (UI `fetch` only, not a generated SDK method).
> 
> On success it returns `{ data: { base_url, snippets[] } }`, where **`base_url`** is the request origin for SDK `baseUrl` and each snippet includes **`sample_code.stream`** and **`sample_code.non_stream`**. Snippets are built from templates that substitute the agent’s **name** and **`baseUrl`** via JSON-safe placeholder rendering (`buildAgentCodeSnippets`). Samples walk through `@truefoundry/trueforge-sdk`: create session by agent name, then either **`createTurnStream`** (with delta merging) or **`createTurn`** plus **`getTurn`**. Unknown **`agent_id`** returns **404**, matching other agent routes.
> 
> Unit tests cover 404 for missing ids and a non-empty **`snippets`** array for a created agent; a patch **changeset** records the `@truefoundry/trueforge` release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 411a79c2b443ebb8c2341663cc5f4b67daffae81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->