### PR TITLE
Update session metrics on createTurn and terminal writes

### DIFF
--- a/.changeset/20260827210200-session-metrics.md
+++ b/.changeset/20260827210200-session-metrics.md
@@ -3,4 +3,4 @@
 '@truefoundry/trueforge': patch
 ---
 
-Persist zero-initialized metrics on agent sessions.
+Persist zero-initialized session metrics and fold totals on createTurn and terminal writes.

--- a/.changeset/20260831083812-session-metrics-fold.md
+++ b/.changeset/20260831083812-session-metrics-fold.md
@@ -3,4 +3,4 @@
 '@truefoundry/trueforge': patch
 ---
 
-Persist zero-initialized metrics on agent sessions.
+Fold session metrics totals on createTurn and terminal writes.

--- a/packages/trueforge-core/src/agent-session/store/ISessionStore.ts
+++ b/packages/trueforge-core/src/agent-session/store/ISessionStore.ts
@@ -262,7 +262,8 @@ export interface ISessionStore<
    * row or leave `last_turn_id` pointing at a turn that was never created.
    * The implementation supplies the mechanism (session lock, row lock/tx, …).
    *
-   * Also bumps `session.last_activity_timestamp_ms` in that same atomic unit.
+   * Also bumps `session.last_activity_timestamp_ms` and increments
+   * `session.metrics.total_turns` in that same atomic unit.
    *
    * Fork semantics for `turn.previous_turn_id`:
    * - `null` — new root turn (no parent); always allowed.
@@ -282,9 +283,10 @@ export interface ISessionStore<
 
   /**
    * One tx: (a) conditionally cancel a running turn with `reason`; (b) if it
-   * did cancel, insert the caller-built `turn_done_event` — already-terminal
-   * turns skip the event insert; (c) return the now-immutable turn record.
-   * Missing turn → {@link TurnNotFoundError}.
+   * did cancel, insert the caller-built `turn_done_event` and add cost plus
+   * `completed_at − created_at` into `session.metrics` — already-terminal
+   * turns skip the event insert and the metrics fold; (c) return the now-immutable
+   * turn record. Missing turn → {@link TurnNotFoundError}.
    */
   freezeAndGetTurn(input: FreezeAndGetTurnInput): Promise<TurnRecord<TTurnCustom>>;
 
@@ -297,7 +299,9 @@ export interface ISessionStore<
   ): Promise<{ data: TurnRecordWithoutSnapshot<TTurnCustom>[]; pagination: TokenPagination }>;
 
   /**
-   * Writes the terminal state and `turn_done_event` atomically. Store contract —
+   * Writes the terminal state and `turn_done_event` atomically, and adds
+   * `metrics.total_cost_in_usd` plus `completed_at − created_at` into
+   * `session.metrics` in that same unit. Store contract —
    * **first terminal write wins**:
    * - Allowed: `running` → `done` | `cancelled` | `error`.
    * - Rejected with **409** (or equivalent conflict): any write when status is already

--- a/packages/trueforge-core/src/agent-session/store/ISessionStore.ts
+++ b/packages/trueforge-core/src/agent-session/store/ISessionStore.ts
@@ -282,11 +282,8 @@ export interface ISessionStore<
   createTurn(input: CreateTurnInput<TTurnCustom>): Promise<void>;
 
   /**
-   * One tx: (a) conditionally cancel a running turn with `reason`; (b) if it
-   * did cancel, insert the caller-built `turn_done_event` and add cost plus
-   * `completed_at − created_at` into `session.metrics` — already-terminal
-   * turns skip the event insert and the metrics fold; (c) return the now-immutable
-   * turn record. Missing turn → {@link TurnNotFoundError}.
+   * Cancel if still running (persist `turn_done` and fold cost/duration into
+   * `session.metrics`); already-terminal turns are a read. Missing → {@link TurnNotFoundError}.
    */
   freezeAndGetTurn(input: FreezeAndGetTurnInput): Promise<TurnRecord<TTurnCustom>>;
 
@@ -299,17 +296,9 @@ export interface ISessionStore<
   ): Promise<{ data: TurnRecordWithoutSnapshot<TTurnCustom>[]; pagination: TokenPagination }>;
 
   /**
-   * Writes the terminal state and `turn_done_event` atomically, and adds
-   * `metrics.total_cost_in_usd` plus `completed_at − created_at` into
-   * `session.metrics` in that same unit. Store contract —
-   * **first terminal write wins**:
-   * - Allowed: `running` → `done` | `cancelled` | `error`.
-   * - Rejected with **409** (or equivalent conflict): any write when status is already
-   *   terminal — including done→cancelled, cancelled→done, error→*, terminal→running.
-   * - Missing turn → 404 / not-found.
-   *
-   * Check under the same concurrency control as other turn mutations (lock/CAS) —
-   * not a racy read-then-write outside the critical section.
+   * First terminal write wins (`running` → done/cancelled/error); otherwise 409.
+   * Winning write also folds cost/duration into `session.metrics`. Missing → 404.
+   * Must use the same lock/CAS as other turn mutations.
    */
   updateTurnState(input: UpdateTurnStateInput): Promise<void>;
 

--- a/packages/trueforge-core/src/agent-session/store/InMemorySessionStore.ts
+++ b/packages/trueforge-core/src/agent-session/store/InMemorySessionStore.ts
@@ -337,6 +337,7 @@ export class InMemorySessionStore<
     this.events.set(tKey, []);
     stored.turnIds.push(input.turn.turn_id);
     stored.record.last_turn_id = input.turn.turn_id;
+    stored.record.metrics.total_turns += 1;
     stored.record.last_activity_timestamp_ms = Date.now();
     stored.record.updated_at = new Date();
     if (input.update_session_title_if_not_exist !== null && stored.record.title === null) {
@@ -360,6 +361,7 @@ export class InMemorySessionStore<
       if (list) {
         list.push(deepCopy(input.turn_done_event));
       }
+      this.addTerminalSessionMetrics(input.session_id, turn.created_at, cancelledState);
     }
 
     return deepCopy(turn);
@@ -402,6 +404,7 @@ export class InMemorySessionStore<
     if (list) {
       list.push(deepCopy(input.turn_done_event));
     }
+    this.addTerminalSessionMetrics(input.session_id, turn.created_at, input.state);
   }
 
   async appendToEvents(input: AppendToEventsInput): Promise<void> {
@@ -413,6 +416,17 @@ export class InMemorySessionStore<
     }
     list.push(...deepCopy(input.events));
     return;
+  }
+
+  /** Cost from turn metrics; duration is completed_at − created_at, floored at 0. */
+  private addTerminalSessionMetrics(sessionId: string, created_at: Date, state: TerminalTurnState): void {
+    const stored = this.sessions.get(sessionKey(sessionId));
+    if (!stored) {
+      throw new SessionNotFoundError(sessionId);
+    }
+    const elapsed_ms = Date.parse(state.completed_at) - created_at.getTime();
+    stored.record.metrics.total_cost_in_usd += state.metrics?.total_cost_in_usd ?? 0;
+    stored.record.metrics.total_duration_ms += elapsed_ms > 0 ? Math.trunc(elapsed_ms) : 0;
   }
 
   private requireTurn(sessionId: string, turnId: string): TurnRecord<TTurnCustom> {

--- a/packages/trueforge-core/tests/agent-session/store/storeContractSuite.ts
+++ b/packages/trueforge-core/tests/agent-session/store/storeContractSuite.ts
@@ -840,6 +840,24 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       expect(mustGet(after).last_activity_timestamp_ms).toBeGreaterThan(mustGet(before).last_activity_timestamp_ms);
     });
 
+    it('increments session.metrics.total_turns without cost or duration', async () => {
+      const store = createStore();
+      await seedSession(store);
+      await store.createTurn(makeCreateTurnInput({ sessionId, turnId: 'turn-1' }));
+      const afterFirst = await store.getSession({ tenant_id: tenant, session_id: sessionId });
+      expect(mustGet(afterFirst).metrics).toEqual({
+        total_cost_in_usd: 0,
+        total_duration_ms: 0,
+        total_turns: 1,
+      });
+      await finishTurn(store, 'turn-1');
+      await store.createTurn(
+        makeCreateTurnInput({ sessionId, turnId: 'turn-2', previousTurnId: 'turn-1', firstTurnId: 'turn-1' }),
+      );
+      const afterSecond = await store.getSession({ tenant_id: tenant, session_id: sessionId });
+      expect(mustGet(afterSecond).metrics.total_turns).toBe(2);
+    });
+
     it('update_session_title_if_not_exist sets once and never overwrites', async () => {
       const store = createStore();
       await seedSession(store);
@@ -1322,6 +1340,38 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       });
     });
 
+    it('folds duration into session.metrics when cancel applies, not on a second freeze', async () => {
+      const store = createStore();
+      await seedSession(store);
+      await store.createTurn(makeCreateTurnInput({ sessionId, turnId: 'turn-1' }));
+      const cancelledState = makeCancelledTurnState(CancellationReason.CancelledForNextTurn);
+      const record = await store.freezeAndGetTurn({
+        session_id: sessionId,
+        turn_id: 'turn-1',
+        reason: CancellationReason.CancelledForNextTurn,
+        turn_done_event: makeTurnDoneEvent(cancelledState),
+      });
+      if (record.state.status !== 'cancelled') {
+        throw new Error(`expected cancelled turn, got ${record.state.status}`);
+      }
+      const afterCancel = await store.getSession({ tenant_id: tenant, session_id: sessionId });
+      const elapsed_ms = Date.parse(record.state.completed_at) - record.created_at.getTime();
+      expect(mustGet(afterCancel).metrics).toEqual({
+        total_cost_in_usd: 0,
+        total_duration_ms: elapsed_ms > 0 ? Math.trunc(elapsed_ms) : 0,
+        total_turns: 1,
+      });
+
+      await store.freezeAndGetTurn({
+        session_id: sessionId,
+        turn_id: 'turn-1',
+        reason: CancellationReason.CancelledForNextTurn,
+        turn_done_event: makeTurnDoneEvent(cancelledState),
+      });
+      const afterSecond = await store.getSession({ tenant_id: tenant, session_id: sessionId });
+      expect(mustGet(afterSecond).metrics).toEqual(mustGet(afterCancel).metrics);
+    });
+
     it('on an already-terminal turn is a plain read without duplicating turn.done', async () => {
       const store = createStore();
       await seedSession(store);
@@ -1458,6 +1508,115 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       const doneEvents = data.filter(e => e.type === EventType.TURN_DONE);
       expect(doneEvents).toHaveLength(1);
       expect(doneEvents[0]).toEqual(turnDone);
+    });
+
+    it('adds cost and duration into session.metrics on running → terminal', async () => {
+      const store = createStore();
+      await seedSession(store);
+      await store.createTurn(makeCreateTurnInput({ sessionId, turnId: 'turn-1' }));
+      const turn = await store.getTurn({ session_id: sessionId, turn_id: 'turn-1' });
+      const createdAt = mustGet(turn).created_at;
+      const completedAt = new Date(createdAt.getTime() + 1500).toISOString();
+      const state = {
+        ...makeDoneTurnState(),
+        completed_at: completedAt,
+        metrics: { total_cost_in_usd: 1.25 },
+      };
+      await store.updateTurnState({
+        session_id: sessionId,
+        turn_id: 'turn-1',
+        state,
+        turn_done_event: makeTurnDoneEvent(state),
+      });
+      const session = await store.getSession({ tenant_id: tenant, session_id: sessionId });
+      expect(mustGet(session).metrics).toEqual({
+        total_cost_in_usd: 1.25,
+        total_duration_ms: 1500,
+        total_turns: 1,
+      });
+    });
+
+    it('does not add session.metrics again on a losing terminal write', async () => {
+      const store = createStore();
+      await seedSession(store);
+      await store.createTurn(makeCreateTurnInput({ sessionId, turnId: 'turn-1' }));
+      const turn = await store.getTurn({ session_id: sessionId, turn_id: 'turn-1' });
+      const createdAt = mustGet(turn).created_at;
+      const doneState = {
+        ...makeDoneTurnState(),
+        completed_at: new Date(createdAt.getTime() + 1500).toISOString(),
+        metrics: { total_cost_in_usd: 1.25 },
+      };
+      await store.updateTurnState({
+        session_id: sessionId,
+        turn_id: 'turn-1',
+        state: doneState,
+        turn_done_event: makeTurnDoneEvent(doneState),
+      });
+      const afterFirst = mustGet(await store.getSession({ tenant_id: tenant, session_id: sessionId })).metrics;
+
+      const losingState = {
+        ...makeCancelledTurnState(CancellationReason.ClientCancelled),
+        completed_at: new Date(createdAt.getTime() + 8000).toISOString(),
+        metrics: { total_cost_in_usd: 9.99 },
+      };
+      await expect(
+        store.updateTurnState({
+          session_id: sessionId,
+          turn_id: 'turn-1',
+          state: losingState,
+          turn_done_event: makeTurnDoneEvent(losingState),
+        }),
+      ).rejects.toBeInstanceOf(SessionStoreConflictError);
+
+      const afterSecond = await store.getSession({ tenant_id: tenant, session_id: sessionId });
+      expect(mustGet(afterSecond).metrics).toEqual(afterFirst);
+      expect(afterFirst).toEqual({
+        total_cost_in_usd: 1.25,
+        total_duration_ms: 1500,
+        total_turns: 1,
+      });
+    });
+
+    it('adds cost and duration from a second done turn onto existing session.metrics', async () => {
+      const store = createStore();
+      await seedSession(store);
+      await store.createTurn(makeCreateTurnInput({ sessionId, turnId: 'turn-1' }));
+      const turn1 = await store.getTurn({ session_id: sessionId, turn_id: 'turn-1' });
+      const turn1Done = {
+        ...makeDoneTurnState(),
+        completed_at: new Date(mustGet(turn1).created_at.getTime() + 1500).toISOString(),
+        metrics: { total_cost_in_usd: 1.25 },
+      };
+      await store.updateTurnState({
+        session_id: sessionId,
+        turn_id: 'turn-1',
+        state: turn1Done,
+        turn_done_event: makeTurnDoneEvent(turn1Done),
+      });
+
+      await store.createTurn(
+        makeCreateTurnInput({ sessionId, turnId: 'turn-2', previousTurnId: 'turn-1', firstTurnId: 'turn-1' }),
+      );
+      const turn2 = await store.getTurn({ session_id: sessionId, turn_id: 'turn-2' });
+      const turn2Done = {
+        ...makeDoneTurnState(),
+        completed_at: new Date(mustGet(turn2).created_at.getTime() + 800).toISOString(),
+        metrics: { total_cost_in_usd: 0.5 },
+      };
+      await store.updateTurnState({
+        session_id: sessionId,
+        turn_id: 'turn-2',
+        state: turn2Done,
+        turn_done_event: makeTurnDoneEvent(turn2Done),
+      });
+
+      const session = await store.getSession({ tenant_id: tenant, session_id: sessionId });
+      expect(mustGet(session).metrics).toEqual({
+        total_cost_in_usd: 1.75,
+        total_duration_ms: 2300,
+        total_turns: 2,
+      });
     });
 
     it('missing turn → not found', async () => {

--- a/packages/trueforge-core/tests/agent-session/store/storeContractSuite.ts
+++ b/packages/trueforge-core/tests/agent-session/store/storeContractSuite.ts
@@ -1619,6 +1619,54 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       });
     });
 
+    it('accumulates session.metrics across turn1 done, turn2 cancel, and turn3 create', async () => {
+      const store = createStore();
+      await seedSession(store);
+
+      await store.createTurn(makeCreateTurnInput({ sessionId, turnId: 'turn-1' }));
+      const turn1 = await store.getTurn({ session_id: sessionId, turn_id: 'turn-1' });
+      const turn1Done = {
+        ...makeDoneTurnState(),
+        completed_at: new Date(mustGet(turn1).created_at.getTime() + 1000).toISOString(),
+        metrics: { total_cost_in_usd: 1.0 },
+      };
+      await store.updateTurnState({
+        session_id: sessionId,
+        turn_id: 'turn-1',
+        state: turn1Done,
+        turn_done_event: makeTurnDoneEvent(turn1Done),
+      });
+
+      await store.createTurn(
+        makeCreateTurnInput({ sessionId, turnId: 'turn-2', previousTurnId: 'turn-1', firstTurnId: 'turn-1' }),
+      );
+      const cancelledState = makeCancelledTurnState(CancellationReason.CancelledForNextTurn);
+      const turn2 = await store.freezeAndGetTurn({
+        session_id: sessionId,
+        turn_id: 'turn-2',
+        reason: CancellationReason.CancelledForNextTurn,
+        turn_done_event: makeTurnDoneEvent(cancelledState),
+      });
+      if (turn2.state.status !== 'cancelled') {
+        throw new Error(`expected cancelled turn, got ${turn2.state.status}`);
+      }
+      const turn2DurationMs = Math.max(
+        0,
+        Math.trunc(Date.parse(turn2.state.completed_at) - turn2.created_at.getTime()),
+      );
+
+      await store.createTurn(
+        makeCreateTurnInput({ sessionId, turnId: 'turn-3', previousTurnId: 'turn-2', firstTurnId: 'turn-1' }),
+      );
+
+      const session = await store.getSession({ tenant_id: tenant, session_id: sessionId });
+      expect(mustGet(session).metrics).toEqual({
+        total_cost_in_usd: 1.0,
+        total_duration_ms: 1000 + turn2DurationMs,
+        total_turns: 3,
+      });
+    });
+
     it('missing turn → not found', async () => {
       const store = createStore();
       await seedSession(store);

--- a/packages/trueforge/src/db/postgres/session-store/queries/turns.ts
+++ b/packages/trueforge/src/db/postgres/session-store/queries/turns.ts
@@ -136,8 +136,9 @@ async function addSessionCostAndDuration(
           sql`'{total_cost_in_usd}'`,
           sql`to_jsonb((metrics->>'total_cost_in_usd')::double precision + ${total_cost_in_usd}::double precision)`,
         ),
+        // bigint: ::int overflows at ~24.8 days of summed ms and would roll back the terminal tx.
         sql`'{total_duration_ms}'`,
-        sql`to_jsonb((metrics->>'total_duration_ms')::int + ${total_duration_ms}::int)`,
+        sql`to_jsonb((metrics->>'total_duration_ms')::bigint + ${total_duration_ms}::bigint)`,
       ),
     })
     .where('session_id', '=', input.session_id)

--- a/packages/trueforge/src/db/postgres/session-store/queries/turns.ts
+++ b/packages/trueforge/src/db/postgres/session-store/queries/turns.ts
@@ -122,10 +122,10 @@ function incrementSessionTotalTurns(): RawBuilder<SessionMetrics> {
 /** Same tx as the turn flip; the session row lock serializes concurrent terminal folds. */
 async function addSessionCostAndDuration(
   trx: Transaction<Database>,
-  input: { session_id: string; created_at: Date; state: TerminalTurnState },
+  input: { session_id: string; turn_created_at: Date; turn_state: TerminalTurnState },
 ): Promise<void> {
-  const elapsed_ms = Date.parse(input.state.completed_at) - input.created_at.getTime();
-  const total_cost_in_usd = input.state.metrics?.total_cost_in_usd ?? 0;
+  const elapsed_ms = Date.parse(input.turn_state.completed_at) - input.turn_created_at.getTime();
+  const total_cost_in_usd = input.turn_state.metrics?.total_cost_in_usd ?? 0;
   const total_duration_ms = elapsed_ms > 0 ? Math.trunc(elapsed_ms) : 0;
   await trx
     .updateTable('session')
@@ -672,8 +672,8 @@ export async function freezeAndGetTurn(db: Kysely<Database>, input: FreezeAndGet
       // Only the winning cancel folds; a freeze of an already-terminal turn is a read.
       await addSessionCostAndDuration(trx, {
         session_id: input.session_id,
-        created_at: updateResult.created_at,
-        state: cancelledState,
+        turn_created_at: updateResult.created_at,
+        turn_state: cancelledState,
       });
     }
 
@@ -770,8 +770,8 @@ export async function updateTurnState(db: Kysely<Database>, input: UpdateTurnSta
 
     await addSessionCostAndDuration(trx, {
       session_id: input.session_id,
-      created_at: result.created_at,
-      state: input.state,
+      turn_created_at: result.created_at,
+      turn_state: input.state,
     });
 
     await trx

--- a/packages/trueforge/src/db/postgres/session-store/queries/turns.ts
+++ b/packages/trueforge/src/db/postgres/session-store/queries/turns.ts
@@ -1,3 +1,4 @@
+import type { SessionMetrics } from '@truefoundry/trueforge-core/agent-session';
 import type { TurnRecord, TurnSnapshot } from '@truefoundry/trueforge-core/agent-session/models/TurnRecord';
 import {
   type TerminalTurnState,
@@ -28,7 +29,7 @@ import { getEmptyCurrentContextUsage } from '@truefoundry/trueforge-core/core/ru
 import type { SandboxInfo } from '@truefoundry/trueforge-core/core/sandbox/Sandbox';
 import { sql, type Kysely, type QueryCreator, type RawBuilder, type Transaction } from 'kysely';
 import { isUniqueViolation } from '../../client';
-import { json } from '../../sqlExpressions';
+import { json, jsonbSet } from '../../sqlExpressions';
 import type { Database, TurnCheckpoint, TurnThreadCheckpoint } from '../../types';
 import { lateralUnnestBigintArrayWithOrdinality } from '../sqlExpressions';
 
@@ -109,6 +110,39 @@ export interface ListTurnsResult {
 
 type DbOrTrx = Kysely<Database> | Transaction<Database>;
 type TurnFenceDb = DbOrTrx | QueryCreator<Database>;
+
+function incrementSessionTotalTurns(): RawBuilder<SessionMetrics> {
+  return jsonbSet<SessionMetrics>(
+    sql`metrics`,
+    sql`'{total_turns}'`,
+    sql`to_jsonb((metrics->>'total_turns')::int + 1)`,
+  );
+}
+
+/** Same tx as the turn flip; the session row lock serializes concurrent terminal folds. */
+async function addSessionCostAndDuration(
+  trx: Transaction<Database>,
+  input: { session_id: string; created_at: Date; state: TerminalTurnState },
+): Promise<void> {
+  const elapsed_ms = Date.parse(input.state.completed_at) - input.created_at.getTime();
+  const total_cost_in_usd = input.state.metrics?.total_cost_in_usd ?? 0;
+  const total_duration_ms = elapsed_ms > 0 ? Math.trunc(elapsed_ms) : 0;
+  await trx
+    .updateTable('session')
+    .set({
+      metrics: jsonbSet<SessionMetrics>(
+        jsonbSet(
+          sql`metrics`,
+          sql`'{total_cost_in_usd}'`,
+          sql`to_jsonb((metrics->>'total_cost_in_usd')::double precision + ${total_cost_in_usd}::double precision)`,
+        ),
+        sql`'{total_duration_ms}'`,
+        sql`to_jsonb((metrics->>'total_duration_ms')::int + ${total_duration_ms}::int)`,
+      ),
+    })
+    .where('session_id', '=', input.session_id)
+    .execute();
+}
 
 function terminalTurnState(state: TurnState, turn_id: string): TerminalTurnState {
   switch (state.status) {
@@ -384,6 +418,8 @@ export async function createTurn(db: Kysely<Database>, input: CreateTurnInput): 
           last_turn_id: input.turn.turn_id,
           updated_at: sql`now()`,
           last_activity_timestamp_ms: input.last_activity_timestamp_ms,
+          // total_turns rides the same tip UPDATE so a later failure in this tx rolls it back.
+          metrics: incrementSessionTotalTurns(),
           ...(input.update_session_title_if_not_exist !== null
             ? {
                 title: sql`COALESCE(title, ${input.update_session_title_if_not_exist})`,
@@ -618,9 +654,10 @@ export async function freezeAndGetTurn(db: Kysely<Database>, input: FreezeAndGet
       .where('session_id', '=', input.session_id)
       .where('turn_id', '=', input.turn_id)
       .where(sql<boolean>`state->>'status' = 'running'`)
+      .returning(['created_at'])
       .executeTakeFirst();
 
-    if (Number(updateResult.numUpdatedRows) > 0) {
+    if (updateResult !== undefined) {
       await trx
         .insertInto('session_event')
         .values({
@@ -631,6 +668,12 @@ export async function freezeAndGetTurn(db: Kysely<Database>, input: FreezeAndGet
           created_at: new Date(input.turn_done_event.created_at),
         })
         .execute();
+      // Only the winning cancel folds; a freeze of an already-terminal turn is a read.
+      await addSessionCostAndDuration(trx, {
+        session_id: input.session_id,
+        created_at: updateResult.created_at,
+        state: cancelledState,
+      });
     }
 
     const record = await assembleTurnRecord(trx, input);
@@ -706,10 +749,11 @@ export async function updateTurnState(db: Kysely<Database>, input: UpdateTurnSta
       .where('session_id', '=', input.session_id)
       .where('turn_id', '=', input.turn_id)
       .where(sql<boolean>`state->>'status' = 'running'`)
+      .returning(['created_at'])
       .executeTakeFirst();
 
-    const numUpdated = Number(result.numUpdatedRows);
-    if (numUpdated === 0) {
+    // No RETURNING row: UPDATE matched 0 running turns.
+    if (result === undefined) {
       const existing = await trx
         .selectFrom('turn')
         .select('state')
@@ -722,6 +766,12 @@ export async function updateTurnState(db: Kysely<Database>, input: UpdateTurnSta
       }
       throw new TurnNotRunningError(input.turn_id, terminalTurnState(existing.state, input.turn_id));
     }
+
+    await addSessionCostAndDuration(trx, {
+      session_id: input.session_id,
+      created_at: result.created_at,
+      state: input.state,
+    });
 
     await trx
       .insertInto('session_event')

--- a/packages/trueforge/src/db/sqlite/session-store/queries/turns.ts
+++ b/packages/trueforge/src/db/sqlite/session-store/queries/turns.ts
@@ -112,10 +112,10 @@ type DbOrTrx = Kysely<Database> | Transaction<Database>;
 /** Same tx as the turn flip; BEGIN IMMEDIATE serializes concurrent terminal folds. */
 async function addSessionCostAndDuration(
   trx: Transaction<Database>,
-  input: { session_id: string; created_at: Date; state: TerminalTurnState },
+  input: { session_id: string; turn_created_at: Date; turn_state: TerminalTurnState },
 ): Promise<void> {
-  const elapsed_ms = Date.parse(input.state.completed_at) - input.created_at.getTime();
-  const total_cost_in_usd = input.state.metrics?.total_cost_in_usd ?? 0;
+  const elapsed_ms = Date.parse(input.turn_state.completed_at) - input.turn_created_at.getTime();
+  const total_cost_in_usd = input.turn_state.metrics?.total_cost_in_usd ?? 0;
   const total_duration_ms = elapsed_ms > 0 ? Math.trunc(elapsed_ms) : 0;
   await trx
     .updateTable('session')
@@ -709,8 +709,8 @@ export async function freezeAndGetTurn(db: Kysely<Database>, input: FreezeAndGet
       // Only the winning cancel folds; a freeze of an already-terminal turn is a read.
       await addSessionCostAndDuration(trx, {
         session_id: input.session_id,
-        created_at: new Date(updateResult.created_at),
-        state: cancelledState,
+        turn_created_at: new Date(updateResult.created_at),
+        turn_state: cancelledState,
       });
     }
 
@@ -816,8 +816,8 @@ export async function updateTurnState(db: Kysely<Database>, input: UpdateTurnSta
 
     await addSessionCostAndDuration(trx, {
       session_id: input.session_id,
-      created_at: new Date(result.created_at),
-      state: input.state,
+      turn_created_at: new Date(result.created_at),
+      turn_state: input.state,
     });
 
     await trx

--- a/packages/trueforge/src/db/sqlite/session-store/queries/turns.ts
+++ b/packages/trueforge/src/db/sqlite/session-store/queries/turns.ts
@@ -109,6 +109,27 @@ export interface ListTurnsResult {
 
 type DbOrTrx = Kysely<Database> | Transaction<Database>;
 
+/** Same tx as the turn flip; BEGIN IMMEDIATE serializes concurrent terminal folds. */
+async function addSessionCostAndDuration(
+  trx: Transaction<Database>,
+  input: { session_id: string; created_at: Date; state: TerminalTurnState },
+): Promise<void> {
+  const elapsed_ms = Date.parse(input.state.completed_at) - input.created_at.getTime();
+  const total_cost_in_usd = input.state.metrics?.total_cost_in_usd ?? 0;
+  const total_duration_ms = elapsed_ms > 0 ? Math.trunc(elapsed_ms) : 0;
+  await trx
+    .updateTable('session')
+    .set({
+      metrics: sql`jsonb_set(
+        jsonb_set(metrics, '$.total_cost_in_usd', jsonb((metrics->>'total_cost_in_usd') + ${total_cost_in_usd})),
+        '$.total_duration_ms',
+        jsonb((metrics->>'total_duration_ms') + ${total_duration_ms})
+      )`,
+    })
+    .where('session_id', '=', input.session_id)
+    .execute();
+}
+
 function terminalTurnState(state: TurnState, turn_id: string): TerminalTurnState {
   switch (state.status) {
     case 'running':
@@ -334,6 +355,8 @@ export async function createTurn(db: Kysely<Database>, input: CreateTurnInput): 
           last_turn_id: input.turn.turn_id,
           updated_at: nowIso(),
           last_activity_timestamp_ms: input.last_activity_timestamp_ms,
+          // total_turns rides the same tip UPDATE so a later failure in this tx rolls it back.
+          metrics: sql`jsonb_set(metrics, '$.total_turns', jsonb((metrics->>'total_turns') + 1))`,
         })
         .where('session_id', '=', input.session_id);
 
@@ -669,9 +692,10 @@ export async function freezeAndGetTurn(db: Kysely<Database>, input: FreezeAndGet
       .where('session_id', '=', input.session_id)
       .where('turn_id', '=', input.turn_id)
       .where(sql<boolean>`state->>'status' = 'running'`)
+      .returning(['created_at'])
       .executeTakeFirst();
 
-    if (Number(updateResult.numUpdatedRows) > 0) {
+    if (updateResult !== undefined) {
       await trx
         .insertInto('session_event')
         .values({
@@ -682,6 +706,12 @@ export async function freezeAndGetTurn(db: Kysely<Database>, input: FreezeAndGet
           created_at: input.turn_done_event.created_at,
         })
         .execute();
+      // Only the winning cancel folds; a freeze of an already-terminal turn is a read.
+      await addSessionCostAndDuration(trx, {
+        session_id: input.session_id,
+        created_at: new Date(updateResult.created_at),
+        state: cancelledState,
+      });
     }
 
     const record = await assembleTurnRecord(trx, input);
@@ -766,10 +796,11 @@ export async function updateTurnState(db: Kysely<Database>, input: UpdateTurnSta
       .where('session_id', '=', input.session_id)
       .where('turn_id', '=', input.turn_id)
       .where(sql<boolean>`state->>'status' = 'running'`)
+      .returning(['created_at'])
       .executeTakeFirst();
 
-    const numUpdated = Number(result.numUpdatedRows);
-    if (numUpdated === 0) {
+    // No RETURNING row: UPDATE matched 0 running turns.
+    if (result === undefined) {
       const existing = await trx
         .selectFrom('turn')
         .select([jsonText<TurnState>(sql.ref('state')).as('state')])
@@ -782,6 +813,12 @@ export async function updateTurnState(db: Kysely<Database>, input: UpdateTurnSta
       }
       throw new TurnNotRunningError(input.turn_id, terminalTurnState(existing.state, input.turn_id));
     }
+
+    await addSessionCostAndDuration(trx, {
+      session_id: input.session_id,
+      created_at: new Date(result.created_at),
+      state: input.state,
+    });
 
     await trx
       .insertInto('session_event')


### PR DESCRIPTION
## Summary

Update `session.metrics` in the same transactions as turn writes: turn count on create, cost and duration on a winning terminal transition.

Linear: AGE-2010

## Changes

- `createTurn` increments `total_turns` on the session tip update (same tx)
- `running → terminal` (`updateTurnState`, or freeze when cancel applies) adds `total_cost_in_usd` and `completed_at − created_at`
- Postgres, SQLite, and InMemory; store contract tests for increment, cost/duration, two-turn sums, freeze once.

## How was this tested?

- Store contract (InMemory) plus `pnpm test:store:sqlite` and `scripts/test-store-local.sh`

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session-store write paths and how usage/cost totals are derived; incorrect folding or double-counting would affect session-level metrics, though behavior is transactional and covered by contract tests.
> 
> **Overview**
> **Session `metrics` are now updated in the same atomic operations as turn lifecycle writes**, so turn count, cost, and duration stay consistent with persisted turns without separate aggregation.
> 
> **`createTurn`** increments `session.metrics.total_turns` on the existing session tip update (Postgres/SQLite via `jsonb_set`, InMemory in process). Cost and duration are **not** touched at create time.
> 
> **Winning terminal transitions** (`updateTurnState` when `running →` done/cancelled/error, and `freezeAndGetTurn` only when the cancel UPDATE actually matches) fold **`total_cost_in_usd`** from terminal turn metrics and **`total_duration_ms`** as `completed_at − turn.created_at` (truncated, floored at 0). Already-terminal freezes and losing second terminal writes do **not** double-count. Postgres sums duration with **bigint** to avoid int overflow on long sessions.
> 
> The **`ISessionStore`** contract documents this behavior; shared **store contract tests** cover increment-only on create, single fold on terminal/freeze, conflict paths, and multi-turn accumulation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de3ba3e96aa5221d4d107e7491946f5abfe8b298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->