### PR TITLE
feat(mcp-servers): add DELETE endpoint to permanently remove a connector

### DIFF
--- a/.changeset/delete-mcp-server.md
+++ b/.changeset/delete-mcp-server.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": minor
+---
+
+Add `DELETE /api/v1/settings/mcp-servers/{name}` to permanently remove a configured MCP server (its OAuth tokens and pending authorizations cascade-delete). Idempotent if already gone.

--- a/packages/trueforge/src/apis/mcpServers.ts
+++ b/packages/trueforge/src/apis/mcpServers.ts
@@ -13,6 +13,7 @@ import {
   authorizeMcpServerRoute,
   createMcpServerRoute,
   deleteAuthorizationMcpServerRoute,
+  deleteMcpServerRoute,
   getMcpServerRoute,
   listAvailableMcpServersRoute,
   listMcpServersRoute,
@@ -307,11 +308,18 @@ export function createSettingsMcpServersRouter<TTransaction>(deps: McpServersRou
     }
   };
 
+  const deleteHandler: RouteHandler<typeof deleteMcpServerRoute> = async c => {
+    const { name } = c.req.valid('param');
+    await deps.mcpServerStore.deleteServer({ tenant_id: TENANT_ID, name });
+    return c.json({}, 200);
+  };
+
   const router = new OpenAPIHono();
   router.openapi(listMcpServersRoute, listHandler);
   router.openapi(createMcpServerRoute, createHandler);
   router.openapi(putMcpServerRoute, putHandler);
   router.openapi(getMcpServerRoute, getHandler);
+  router.openapi(deleteMcpServerRoute, deleteHandler);
   return router;
 }
 

--- a/packages/trueforge/src/db/mcpServerStore.ts
+++ b/packages/trueforge/src/db/mcpServerStore.ts
@@ -78,6 +78,11 @@ export interface IMcpServerStore<TTransaction = never> extends IOAuthClientStore
    * Never overwrites `id`, `oauth_server`, or `oauth_client`.
    */
   upsertServer(input: UpsertMcpServerInput, transaction?: TTransaction): Promise<McpServerRecord>;
+  /**
+   * Permanently removes the server row. OAuth tokens and pending authorizations cascade-delete
+   * via their `oauth_server_id` foreign key. Idempotent if already gone.
+   */
+  deleteServer(input: GetMcpServerInput, transaction?: TTransaction): Promise<void>;
 }
 
 /**

--- a/packages/trueforge/src/db/postgres/mcp-server-store/PostgresMcpServerStore.ts
+++ b/packages/trueforge/src/db/postgres/mcp-server-store/PostgresMcpServerStore.ts
@@ -123,6 +123,11 @@ export class PostgresMcpServerStore implements IMcpServerStore<Transaction<Datab
     return toRecord(row);
   }
 
+  async deleteServer(input: GetMcpServerInput, transaction?: Transaction<Database>): Promise<void> {
+    const db = transaction ?? this.#db;
+    await db.deleteFrom('mcp_server').where('tenant_id', '=', input.tenant_id).where('name', '=', input.name).execute();
+  }
+
   async getClient(params: { id: string }, transaction?: Transaction<Database>): Promise<OAuthClientRecord | undefined> {
     const db = transaction ?? this.#db;
     const row = await db

--- a/packages/trueforge/src/db/sqlite/mcp-server-store/SqliteMcpServerStore.ts
+++ b/packages/trueforge/src/db/sqlite/mcp-server-store/SqliteMcpServerStore.ts
@@ -127,6 +127,11 @@ export class SqliteMcpServerStore implements IMcpServerStore<Transaction<Databas
       .executeTakeFirstOrThrow();
   }
 
+  async deleteServer(input: GetMcpServerInput, transaction?: Transaction<Database>): Promise<void> {
+    const db = transaction ?? this.#db;
+    await db.deleteFrom('mcp_server').where('tenant_id', '=', input.tenant_id).where('name', '=', input.name).execute();
+  }
+
   async getClient(params: { id: string }, transaction?: Transaction<Database>): Promise<OAuthClientRecord | undefined> {
     const db = transaction ?? this.#db;
     const row = await db

--- a/packages/trueforge/src/routes/mcpServerRoutes.ts
+++ b/packages/trueforge/src/routes/mcpServerRoutes.ts
@@ -7,6 +7,7 @@ import { createRoute, z } from '@hono/zod-openapi';
 import { RequestErrorResponseSchema } from '../schemas/errors';
 import {
   CreateMcpServerRequestSchema,
+  DeleteMcpServerResponseSchema,
   GetMcpServerResponseSchema,
   ListAvailableMcpServersResponseSchema,
   ListMcpServersResponseSchema,
@@ -153,6 +154,35 @@ export const putMcpServerRoute = createRoute({
     422: {
       content: { 'application/json': { schema: RequestErrorResponseSchema } },
       description: 'The server cannot satisfy `auth.type: dcr` (e.g. it advertises no registration_endpoint).',
+    },
+  },
+});
+
+export const deleteMcpServerRoute = createRoute({
+  method: 'delete',
+  path: '/{name}',
+  tags: [OpenApiTag.MCP_SERVERS],
+  summary: 'Delete an MCP server',
+  description:
+    'Permanently removes the configured MCP server by name, including any stored OAuth tokens and ' +
+    'pending authorizations. Idempotent if already gone.',
+  'x-fern-sdk-group-name': ['settings', 'mcpServers'],
+  'x-fern-sdk-method-name': 'delete',
+  request: {
+    params: McpServerNameParamsSchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: DeleteMcpServerResponseSchema } },
+      description: 'MCP server deleted.',
+    },
+    401: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'OIDC is configured and the request has no valid session cookie.',
+    },
+    403: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'OIDC is configured and the caller is authenticated but not an admin.',
     },
   },
 });

--- a/packages/trueforge/src/schemas/mcpServer.ts
+++ b/packages/trueforge/src/schemas/mcpServer.ts
@@ -102,6 +102,7 @@ export const GetMcpServerResponseSchema = z.object({ data: ConfiguredMcpServerSc
 export const ListMcpServersResponseSchema = z
   .object({ data: z.array(ConfiguredMcpServerSchema) })
   .openapi('ListMCPServersResponse');
+export const DeleteMcpServerResponseSchema = z.object({}).openapi('DeleteMCPServerResponse');
 
 /** Public auth mechanism for chat/composer (no secrets). */
 export const McpServerAuthPublicSchema = z

--- a/packages/trueforge/tests/db/mcpServerStoreContractSuite.ts
+++ b/packages/trueforge/tests/db/mcpServerStoreContractSuite.ts
@@ -137,6 +137,25 @@ export function runMcpServerStoreContractSuite(getStore: () => IMcpServerStore):
     await expect(store.listServers({ tenant_id: TENANT, names: [] })).resolves.toEqual([]);
   });
 
+  it('deleteServer removes the row and cascade-clears its saved OAuth client', async () => {
+    const store = getStore();
+    const created = await store.upsertServer({ tenant_id: TENANT, name: 'linear', manifest: manifest() });
+    await store.saveClient({ id: created.id, record: sampleOAuthClient });
+
+    await store.deleteServer({ tenant_id: TENANT, name: 'linear' });
+
+    await expect(store.getServer({ tenant_id: TENANT, name: 'linear' })).resolves.toBeUndefined();
+    await expect(store.getClient({ id: created.id })).resolves.toBeUndefined();
+  });
+
+  it('deleteServer is idempotent for an unknown server and leaves other tenants untouched', async () => {
+    const store = getStore();
+    const otherTenant = await store.upsertServer({ tenant_id: 'other-tenant', name: 'linear', manifest: manifest() });
+
+    await expect(store.deleteServer({ tenant_id: TENANT, name: 'linear' })).resolves.toBeUndefined();
+    await expect(store.getServer({ tenant_id: 'other-tenant', name: 'linear' })).resolves.toEqual(otherTenant);
+  });
+
   it('upsert leaves oauth columns null and does not clear a saved OAuth client', async () => {
     const store = getStore();
     const created = await store.upsertServer({

--- a/packages/trueforge/tests/unit/apis/mcpServers.test.ts
+++ b/packages/trueforge/tests/unit/apis/mcpServers.test.ts
@@ -870,4 +870,35 @@ describe('mcp-servers routers', () => {
     const missing = await mcpServersRouter.request('/missing/authorize', { method: 'DELETE' });
     expect(missing.status).toBe(404);
   });
+
+  it('DELETE /{name} permanently removes the server and cascades its OAuth token', async () => {
+    const record = await seedDcrServerWithClient({ ...putBodyWithDcr, name: 'to-delete' });
+    await tokenStore.saveToken({
+      id: record.id,
+      userRef: LOCAL_USER_CONTEXT.userRef,
+      token: {
+        accessToken: 'access-1',
+        refreshToken: null,
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        scope: null,
+      },
+    });
+
+    const response = await settingsRouter.request('/to-delete', { method: 'DELETE' });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+
+    expect(await mcpServerStore.getServer({ tenant_id: TENANT_ID, name: 'to-delete' })).toBeUndefined();
+    expect(await tokenStore.getToken({ id: record.id, userRef: LOCAL_USER_CONTEXT.userRef })).toBeUndefined();
+
+    const listed = await settingsRouter.request('/');
+    const names = ((await listed.json()) as { data: { name: string }[] }).data.map(server => server.name);
+    expect(names).not.toContain('to-delete');
+  });
+
+  it('DELETE /{name} is idempotent for an unknown server', async () => {
+    const response = await settingsRouter.request('/never-existed', { method: 'DELETE' });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #494.

There is currently no way to permanently remove a configured MCP connector:
- Header-auth connectors (Bright Data, GitHub, Tavily, custom "Add MCP Server" entries) have no removal option at all — only "Replace Key".
- OAuth (`dcr`) connectors' "Disconnect" only clears the stored token (`DELETE /{name}/authorize`); the row stays in "Configured" with an `auth_required` badge forever.

This PR adds the missing backend piece: `DELETE /api/v1/settings/mcp-servers/{name}`.

- `IMcpServerStore.deleteServer` implemented for both Postgres and SQLite (`DELETE FROM mcp_server WHERE tenant_id = ? AND name = ?`).
- OAuth tokens and pending authorizations cascade-delete automatically via the existing `oauth_server_id` foreign key (`ON DELETE CASCADE`, already in place from the DCR migrations) — no extra cleanup code needed.
- Route + handler follow the exact same pattern as the existing `deleteAgentRoute`/`deleteAgentHandler`: idempotent, `200` with `{}` on success.

## Scope: backend only
`packages/trueforge-sdk` is Fern-generated in CI (`.github/workflows/generate-sdk.yaml`), and that workflow explicitly cannot push its regen commit to a fork PR's branch — it only runs after merge to `main` (or same-repo PRs). I actually ran the generator locally to check: it produced a **447-file, ~15k-line diff** that's almost entirely unrelated generator-version churn (e.g. `import type X` → `import X`, modifier reordering) that has nothing to do with this endpoint — not something that belongs in this PR, and `AGENTS.md` forbids hand-editing `packages/trueforge-sdk` besides.

So this PR is the backend endpoint only, fully implemented and tested. The Connect UI's "Remove" button is a fast-follow PR once this merges and the SDK regenerates on `main` (either automatically via the same workflow, or a maintainer running `pnpm sdk:generate`).

**API docs**: no manual doc changes needed — Mintlify's API reference (`docs/docs.json`) reads directly from `docs/openapi.json`, which regenerates alongside the SDK and will pick up the new endpoint automatically.

## Test plan
- [x] New tests in `mcpServerStoreContractSuite.ts` (runs against both backends): delete removes the row and cascades the OAuth client; idempotent for an unknown server, other tenants untouched.
- [x] `pnpm test:store:sqlite` — 133 passed (was 131), 1 skipped.
- [x] New tests in `tests/unit/apis/mcpServers.test.ts`: `DELETE /{name}` removes the server and cascades a saved token; idempotent for an unknown server.
- [x] `pnpm test` (trueforge unit suite) — 294/294 pass.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm eslint` on changed files — clean.
- [x] Added a changeset (`@truefoundry/trueforge` minor — new endpoint).
- [ ] Postgres store contract suite (`pnpm test:store:postgres`) — implementation is a verbatim mirror of the SQLite one using the same Kysely pattern already used for every other method in that file; couldn't verify locally (this sandbox blocks raw TCP to a local Postgres container), but CI runs it with a real `postgres:17-alpine` service against this exact test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxyEPwQ73B27NTr83U69Ba

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Permanently deletes connector rows and cascades OAuth tokens/authorizations; impact is limited to the admin settings API with existing auth gates and tests.
> 
> **Overview**
> Adds **`DELETE /api/v1/settings/mcp-servers/{name}`** so admins can fully remove a configured MCP connector instead of only disconnecting OAuth (which left DCR servers in settings forever).
> 
> The settings router calls new **`IMcpServerStore.deleteServer`** on Postgres and SQLite (delete by `tenant_id` + `name`). Stored OAuth tokens and pending authorizations are dropped via existing **`ON DELETE CASCADE`** on `oauth_server_id`—no extra cleanup in the handler. The endpoint is **idempotent**: **`200`** with **`{}`** whether or not the server existed, matching other admin delete routes.
> 
> OpenAPI/Fern metadata and **`DeleteMcpServerResponseSchema`** are included; store contract and API unit tests cover cascade behavior and idempotency. Minor **`@truefoundry/trueforge`** changeset; SDK/UI follow separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b80860a94d40df2b015862328b40ca888620e0da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->