### PR TITLE
feat(agents): add Delete Agent button with confirmation

### DIFF
--- a/.changeset/delete-agent-button.md
+++ b/.changeset/delete-agent-button.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge-ui": patch
+---
+
+Add a "Delete Agent" button next to "Update Agent" when editing an existing agent, with a confirmation dialog before permanently deleting it.

--- a/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
+++ b/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
@@ -195,6 +195,9 @@ function SaveAgentButtonContent({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const errorRef = useRef<HTMLParagraphElement>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const mcpMounts = useMemo(() => editableMountsFromSpec(draftSpec?.mcpServers), [draftSpec?.mcpServers]);
   const skillMounts = useMemo(() => editableMountsFromSpec(draftSpec?.skills), [draftSpec?.skills]);
@@ -291,11 +294,46 @@ function SaveAgentButtonContent({
     shell.mode.isMutable &&
     (shell.mode.agentName !== undefined || shell.mode.agentId !== undefined);
   const triggerLabel = isUpdateMode && children === 'Save Agent' ? 'Update Agent' : children;
+  const currentAgentName = shell?.mode.status === 'active' ? (shell.mode.agentName ?? shell.mode.agentId) : undefined;
+
+  const deleteAgent = async () => {
+    if (builder === null || currentAgentName === undefined) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await builder.deleteAgent?.({ agentName: currentAgentName });
+      shell?.invalidateAgentsList();
+      // clearChat() preserves the current edit binding — the agent it points to no longer
+      // exists, so drop the binding entirely and land on a fresh draft instead.
+      shell?.selectLibraryAgent({ isMutable: true });
+      setDeleteOpen(false);
+    } catch (caught) {
+      setDeleteError(getErrorMessage(caught, 'Could not delete agent'));
+    } finally {
+      setDeleting(false);
+    }
+  };
 
   if (!visible) return null;
 
   return (
     <>
+      {isUpdateMode ? (
+        <button
+          type="button"
+          disabled={disabled || builder === null}
+          aria-label="Delete Agent"
+          className={auiButtonClass({ variant: 'outline', size: 'sm' })}
+          onClick={() => {
+            setDeleteError(null);
+            setDeleteOpen(true);
+          }}
+        >
+          <Icon name="trash" className="size-3.5" />
+          Delete Agent
+        </button>
+      ) : null}
+
       <button
         type="button"
         disabled={disabled || builder === null || agentSpec === null}
@@ -565,6 +603,53 @@ function SaveAgentButtonContent({
             </div>
           </div>
         ) : null}
+      </CenteredModal>
+
+      <CenteredModal
+        open={deleteOpen}
+        onOpenChange={next => {
+          if (!next && !deleting) {
+            setDeleteOpen(false);
+            setDeleteError(null);
+          }
+        }}
+        title="Delete agent"
+        className="md:max-w-md"
+        contentSized
+        aria-label="Delete agent"
+      >
+        <div className="px-5 py-5">
+          <p className="text-text-primary text-sm">
+            Delete <span className="font-medium">{currentAgentName}</span>? This permanently removes the agent. This
+            can&apos;t be undone.
+          </p>
+          {deleteError ? (
+            <p role="alert" className="text-failure-bg mt-3 text-sm wrap-break-word whitespace-pre-wrap">
+              {deleteError}
+            </p>
+          ) : null}
+        </div>
+        <div className="bg-card-bg sticky bottom-0 z-10 flex shrink-0 justify-end gap-2 border-t border-border px-5 py-4">
+          <button
+            type="button"
+            disabled={deleting}
+            className={auiButtonClass({ variant: 'secondary' })}
+            onClick={() => {
+              setDeleteOpen(false);
+              setDeleteError(null);
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={deleting}
+            className={auiButtonClass({ variant: 'destructive' })}
+            onClick={() => void deleteAgent()}
+          >
+            {deleting ? 'Deleting…' : 'Delete Agent'}
+          </button>
+        </div>
       </CenteredModal>
     </>
   );

--- a/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/builderServer.ts
+++ b/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/builderServer.ts
@@ -111,5 +111,12 @@ export function createHarnessBuilderServer(
       const created = await client.agents.create({ name: agentName, manifest });
       return { agentId: created.data.id };
     },
+
+    async deleteAgent({ agentName }) {
+      const { data } = await client.agents.list();
+      const existing = data.find(agent => agent.name === agentName);
+      if (!existing) return;
+      await client.agents.delete(existing.id);
+    },
   };
 }

--- a/packages/trueforge-ui/test/atoms/SaveAgentButton.test.tsx
+++ b/packages/trueforge-ui/test/atoms/SaveAgentButton.test.tsx
@@ -234,6 +234,61 @@ describe('SaveAgentButton', () => {
     );
   });
 
+  it('hides Delete Agent for a new (unnamed) draft', () => {
+    renderButton();
+    expect(screen.queryByRole('button', { name: 'Delete Agent' })).not.toBeInTheDocument();
+  });
+
+  it('shows Delete Agent for an existing mutable binding and deletes on confirm', async () => {
+    const deleteAgent = vi.fn(async () => undefined);
+    renderButton({
+      serverOverrides: { deleteAgent },
+      children: <BoundMutableSaveButton agentId="writer" />,
+    });
+
+    const trigger = await screen.findByRole('button', { name: 'Delete Agent' });
+    fireEvent.click(trigger);
+    const dialog = await screen.findByRole('dialog', { name: 'Delete agent' });
+    expect(within(dialog).getByText('writer')).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete Agent' }));
+
+    await waitFor(() => expect(deleteAgent).toHaveBeenCalledWith({ agentName: 'writer' }));
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Delete agent' })).not.toBeInTheDocument());
+  });
+
+  it('cancelling the delete confirmation does not call deleteAgent', async () => {
+    const deleteAgent = vi.fn(async () => undefined);
+    renderButton({
+      serverOverrides: { deleteAgent },
+      children: <BoundMutableSaveButton agentId="writer" />,
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete Agent' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Delete agent' });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Delete agent' })).not.toBeInTheDocument());
+    expect(deleteAgent).not.toHaveBeenCalled();
+  });
+
+  it('shows an error and keeps the dialog open when deleteAgent fails', async () => {
+    const deleteAgent = vi.fn(async () => {
+      throw new Error('Agent is in use');
+    });
+    renderButton({
+      serverOverrides: { deleteAgent },
+      children: <BoundMutableSaveButton agentId="writer" />,
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete Agent' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Delete agent' });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete Agent' }));
+
+    expect(await within(dialog).findByRole('alert')).toHaveTextContent('Agent is in use');
+    expect(dialog).toBeInTheDocument();
+  });
+
   it('discards modal-only changes when closed', async () => {
     renderButton();
     fireEvent.click(screen.getByRole('button', { name: 'Save Agent' }));

--- a/packages/trueforge-ui/test/plugins/trueforge-agent-server-adapter/harnessBuilderServer.test.ts
+++ b/packages/trueforge-ui/test/plugins/trueforge-agent-server-adapter/harnessBuilderServer.test.ts
@@ -300,4 +300,46 @@ describe('harnessBuilderServer', () => {
       },
     });
   });
+
+  it('deleteAgent looks up the id by name and issues DELETE', async () => {
+    const requests: { method: string; url: string }[] = [];
+    const fetchMock: typeof fetch = async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/api/v1/agents') && method === 'GET') {
+        return Response.json({
+          data: [{ id: 'agt_1', name: 'writer', manifest: { model: { name: 'test/model' } } }],
+        });
+      }
+      if (url.endsWith('/api/v1/agents/agt_1') && method === 'DELETE') {
+        requests.push({ method, url });
+        return Response.json({});
+      }
+      return new Response(`Unexpected request: ${method} ${url}`, { status: 500 });
+    };
+
+    const builder = createHarnessBuilderServer({ fetch: fetchMock });
+    await builder.deleteAgent?.({ agentName: 'writer' });
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0]?.method, 'DELETE');
+  });
+
+  it('deleteAgent is a no-op when the name is unknown', async () => {
+    const requests: { method: string; url: string }[] = [];
+    const fetchMock: typeof fetch = async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/api/v1/agents') && method === 'GET') {
+        return Response.json({ data: [] });
+      }
+      requests.push({ method, url });
+      return new Response(`Unexpected request: ${method} ${url}`, { status: 500 });
+    };
+
+    const builder = createHarnessBuilderServer({ fetch: fetchMock });
+    await builder.deleteAgent?.({ agentName: 'missing' });
+
+    assert.equal(requests.length, 0);
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #496.

When editing an existing agent, the composer only offered "Update Agent" (top right) — there was no way to delete the agent from the chat UI at all, even though:
- The registry already supports `DELETE /api/v1/agents/{agent_id}` (`packages/trueforge/src/routes/agentRoutes.ts` / `apis/agents.ts`), and the SDK already has `client.agents.delete(...)`.
- The `AgentBuilderServer` port (`@truefoundry/assistant-ui-runtime`) already has an optional `deleteAgent?(req: { agentName: string })` hook — nothing in `packages/trueforge-ui` called it.

## Changes
- **`SaveAgentButton.tsx`**: a "Delete Agent" button now renders to the left of "Update Agent", visible only while editing an existing (named, mutable) agent. Clicking it opens a confirmation dialog — reusing the same `CenteredModal` primitive and the existing `destructive` button variant already used elsewhere in the app, not a native `confirm()` — before permanently deleting. On success it invalidates the Agents Library list and drops the now-dangling edit binding, landing on a fresh draft (rather than `clearChat()`, which deliberately *preserves* the edit binding for the "still editing the same agent" case — wrong here, since the agent no longer exists).
- **`builderServer.ts`**: implements `deleteAgent` in `createHarnessBuilderServer` by looking up the agent's id by name (same pattern `saveAgent`'s update path already uses) and calling the SDK's existing `client.agents.delete(id)`. No new backend or SDK surface needed — this was already there, just unwired.

## Test plan
- [x] New tests in `harnessBuilderServer.test.ts`: `deleteAgent` looks up the id and issues `DELETE`; no-op when the name is unknown.
- [x] New tests in `SaveAgentButton.test.tsx`: hidden for a new/unnamed draft; shown + calls `deleteAgent` on confirm for an existing binding; Cancel does not call it; a rejected `deleteAgent` shows an inline error and keeps the dialog open.
- [x] `pnpm vitest run` in `packages/trueforge-ui` — 871/871 pass.
- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm eslint` on changed files — clean.
- [x] Added a changeset (`@truefoundry/trueforge-ui` patch).
- [x] Verified end-to-end against the real running app (`pnpm standalone:dev`) — see screenshots below, including a direct SQLite check that the `agent` row count actually goes to 0 after confirming delete (not just a UI-only removal).

## Screenshots (local run against the real app)

**1. Editing an existing agent — "Delete Agent" now sits to the left of "Update Agent":**
![Update and Delete buttons](https://raw.githubusercontent.com/kristopolous/trueforge/delete-agent-screenshots/screenshots/01-update-and-delete-buttons.png)

**2. Confirmation dialog before the permanent delete:**
![Delete confirmation dialog](https://raw.githubusercontent.com/kristopolous/trueforge/delete-agent-screenshots/screenshots/02-delete-confirmation-dialog.png)

**3. After confirming — Agents Library count drops to 0 and the composer lands on a fresh draft (not still "Editing" a now-deleted agent):**
![After delete, fresh draft](https://raw.githubusercontent.com/kristopolous/trueforge/delete-agent-screenshots/screenshots/03-after-delete-fresh-draft.png)

*(Screenshots hosted on an orphan `delete-agent-screenshots` branch on my fork, not merged into this PR's diff.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxyEPwQ73B27NTr83U69Ba

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Permanent agent deletion is user-facing and irreversible; implementation reuses existing APIs but wrong name/id handling could delete the wrong row or leave inconsistent UI state.
> 
> **Overview**
> Adds **Delete Agent** in the composer when editing an existing mutable agent (beside **Update Agent**), hidden for new drafts. A confirmation modal runs the optional `deleteAgent` builder hook; on success the agents list refreshes and the shell moves to a fresh mutable draft instead of keeping a stale edit binding.
> 
> **`createHarnessBuilderServer`** now implements `deleteAgent` by resolving the agent id from the registry name (same as update save) and calling the SDK delete API; unknown names no-op.
> 
> Component and adapter tests cover visibility, confirm/cancel, errors, and HTTP DELETE behavior. Patch changeset for `@truefoundry/trueforge-ui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07150deab3f1fba1a850272c131aefe603ddba28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->