### PR TITLE
feat(skills): add DELETE endpoint to permanently remove a skill

### DIFF
--- a/.changeset/delete-skill.md
+++ b/.changeset/delete-skill.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": minor
+---
+
+Add `DELETE /api/v1/settings/skills/{name}` to permanently remove a configured skill. Idempotent if already gone.

--- a/packages/trueforge/src/apis/skills.ts
+++ b/packages/trueforge/src/apis/skills.ts
@@ -3,6 +3,7 @@ import { SkillNameConflictError, type ISkillStore, type SkillRecord } from '../d
 import type { WithTransaction } from '../db/transaction';
 import {
   createSkillRoute,
+  deleteSkillRoute,
   listAvailableSkillsRoute,
   listConfiguredSkillsRoute,
   putSkillRoute,
@@ -59,10 +60,17 @@ export function createSkillsRouter<TTransaction>(deps: SkillsRouterDeps<TTransac
     return c.json({ data: toConfiguredSkill(record) }, 200);
   };
 
+  const deleteHandler: RouteHandler<typeof deleteSkillRoute> = async c => {
+    const { name } = c.req.valid('param');
+    await deps.skillStore.deleteSkill({ tenant_id: TENANT_ID, name });
+    return c.json({}, 200);
+  };
+
   const router = new OpenAPIHono();
   router.openapi(listConfiguredSkillsRoute, listConfiguredHandler);
   router.openapi(createSkillRoute, createHandler);
   router.openapi(putSkillRoute, putHandler);
+  router.openapi(deleteSkillRoute, deleteHandler);
   return router;
 }
 

--- a/packages/trueforge/src/db/postgres/skill-store/PostgresSkillStore.ts
+++ b/packages/trueforge/src/db/postgres/skill-store/PostgresSkillStore.ts
@@ -97,4 +97,9 @@ export class PostgresSkillStore implements ISkillStore<Transaction<Database>> {
       .executeTakeFirstOrThrow();
     return toRecord(row);
   }
+
+  async deleteSkill(input: GetSkillInput, transaction?: Transaction<Database>): Promise<void> {
+    const db = transaction ?? this.#db;
+    await db.deleteFrom('skill').where('tenant_id', '=', input.tenant_id).where('name', '=', input.name).execute();
+  }
 }

--- a/packages/trueforge/src/db/skillStore.ts
+++ b/packages/trueforge/src/db/skillStore.ts
@@ -56,4 +56,6 @@ export interface ISkillStore<TTransaction = never> {
   createSkill(input: CreateSkillInput, transaction?: TTransaction): Promise<SkillRecord>;
   /** Single-row write: creates the skill or replaces the whole manifest. */
   upsertSkill(input: UpsertSkillInput, transaction?: TTransaction): Promise<SkillRecord>;
+  /** Permanently removes the skill row. Idempotent if already gone. */
+  deleteSkill(input: GetSkillInput, transaction?: TTransaction): Promise<void>;
 }

--- a/packages/trueforge/src/db/sqlite/skill-store/SqliteSkillStore.ts
+++ b/packages/trueforge/src/db/sqlite/skill-store/SqliteSkillStore.ts
@@ -97,4 +97,9 @@ export class SqliteSkillStore implements ISkillStore<Transaction<Database>> {
       .returning(recordColumns)
       .executeTakeFirstOrThrow();
   }
+
+  async deleteSkill(input: GetSkillInput, transaction?: Transaction<Database>): Promise<void> {
+    const db = transaction ?? this.#db;
+    await db.deleteFrom('skill').where('tenant_id', '=', input.tenant_id).where('name', '=', input.name).execute();
+  }
 }

--- a/packages/trueforge/src/routes/skillRoutes.ts
+++ b/packages/trueforge/src/routes/skillRoutes.ts
@@ -4,10 +4,11 @@
  * /api/v1/skills.
  * Discovery catalog lives at GET /api/v1/catalogs/skills.
  */
-import { createRoute } from '@hono/zod-openapi';
+import { createRoute, z } from '@hono/zod-openapi';
 import { RequestErrorResponseSchema } from '../schemas/errors';
 import {
   CreateSkillRequestSchema,
+  DeleteSkillResponseSchema,
   GetSkillResponseSchema,
   ListAvailableSkillsResponseSchema,
   ListSkillsResponseSchema,
@@ -112,6 +113,37 @@ export const putSkillRoute = createRoute({
     400: {
       content: { 'application/json': { schema: RequestErrorResponseSchema } },
       description: 'Invalid request body.',
+    },
+  },
+});
+
+const SkillNameParamsSchema = z.object({
+  name: z.string().min(1).describe('Skill name.'),
+});
+
+export const deleteSkillRoute = createRoute({
+  method: 'delete',
+  path: '/{name}',
+  tags: [OpenApiTag.SKILLS],
+  summary: 'Delete a skill',
+  description: 'Permanently removes the configured skill by name. Idempotent if already gone.',
+  'x-fern-sdk-group-name': ['settings', 'skills'],
+  'x-fern-sdk-method-name': 'delete',
+  request: {
+    params: SkillNameParamsSchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: DeleteSkillResponseSchema } },
+      description: 'Skill deleted.',
+    },
+    401: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'OIDC is configured and the request has no valid session cookie.',
+    },
+    403: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'OIDC is configured and the caller is authenticated but not an admin.',
     },
   },
 });

--- a/packages/trueforge/src/schemas/skill.ts
+++ b/packages/trueforge/src/schemas/skill.ts
@@ -98,6 +98,7 @@ export const GetSkillResponseSchema = z.object({ data: ConfiguredSkillSchema }).
 export const ListSkillsResponseSchema = z
   .object({ data: z.array(ConfiguredSkillSchema) })
   .openapi('ListSkillsResponse');
+export const DeleteSkillResponseSchema = z.object({}).openapi('DeleteSkillResponse');
 
 /** Chat/composer read view — discovery fields only. */
 export const AvailableSkillSchema = z

--- a/packages/trueforge/tests/db/skillStoreContractSuite.ts
+++ b/packages/trueforge/tests/db/skillStoreContractSuite.ts
@@ -134,4 +134,25 @@ export function runSkillStoreContractSuite(getStore: () => ISkillStore): void {
 
     await expect(store.listSkills({ tenant_id: TENANT, names: [] })).resolves.toEqual([]);
   });
+
+  it('deleteSkill removes the row', async () => {
+    const store = getStore();
+    await store.upsertSkill({ tenant_id: TENANT, name: 'algorithmic-art', manifest: manifest() });
+
+    await store.deleteSkill({ tenant_id: TENANT, name: 'algorithmic-art' });
+
+    await expect(store.getSkill({ tenant_id: TENANT, name: 'algorithmic-art' })).resolves.toBeUndefined();
+  });
+
+  it('deleteSkill is idempotent for an unknown skill and leaves other tenants untouched', async () => {
+    const store = getStore();
+    const otherTenant = await store.upsertSkill({
+      tenant_id: 'other-tenant',
+      name: 'algorithmic-art',
+      manifest: manifest(),
+    });
+
+    await expect(store.deleteSkill({ tenant_id: TENANT, name: 'algorithmic-art' })).resolves.toBeUndefined();
+    await expect(store.getSkill({ tenant_id: 'other-tenant', name: 'algorithmic-art' })).resolves.toEqual(otherTenant);
+  });
 }

--- a/packages/trueforge/tests/unit/apis/skills.test.ts
+++ b/packages/trueforge/tests/unit/apis/skills.test.ts
@@ -129,4 +129,20 @@ describe('skills routers', () => {
     );
     expect(badUrl.status).toBe(400);
   });
+
+  it('DELETE /{name} removes the skill', async () => {
+    const response = await settingsRouter.request('/create-only-skill', { method: 'DELETE' });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+
+    const list = await settingsRouter.request('/');
+    const names = ((await list.json()) as { data: { name: string }[] }).data.map(skill => skill.name);
+    expect(names).not.toContain('create-only-skill');
+  });
+
+  it('DELETE /{name} is idempotent for an unknown skill', async () => {
+    const response = await settingsRouter.request('/never-existed', { method: 'DELETE' });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #498.

There is currently no way to disable/remove a configured skill. In Settings → Skills, the "Enabled" list's flush-right action slot is wired to a `Remove` button (`SkillSettings.tsx`), but it's gated on `skillCatalog.deleteSkill`, which was never implemented — the adapter's own comment says why: `"Delete omitted (no BE route)"`. There is no `DELETE` route for skills at all today (`packages/trueforge/src/routes/skillRoutes.ts` only has list/create/put), so the button silently never renders.

This PR adds the missing backend piece: `DELETE /api/v1/settings/skills/{name}`.

- `ISkillStore.deleteSkill` implemented for both Postgres and SQLite (`DELETE FROM skill WHERE tenant_id = ? AND name = ?`).
- Route + handler are an exact mirror of the existing `deleteAgentRoute`/`deleteMcpServerRoute` (#495) pattern: idempotent, `200` with `{}` on success.

## Scope: backend only (same reason as #495)
`packages/trueforge-sdk` is Fern-generated in CI and that workflow can't push its regen commit to a fork PR branch. A local regen attempt produces the same ~450-file unrelated-churn diff I hit on #495 (different pinned generator behavior than what's currently committed), which doesn't belong in this PR, and `AGENTS.md` forbids hand-editing `packages/trueforge-sdk`.

So this PR is the backend endpoint only, tested. Two follow-ups, both filed as part of #498:
1. Wire `skillCatalog.deleteSkill` + an "Edit"-styled button in `SkillSettings.tsx` once this merges and the SDK regenerates on `main` — same sequencing as the connector "Remove" button after #495.
2. Full field editing (description, and repo/path/ref for GitHub-imported skills) needs a real port/data-shape change: the `SkillCatalogServer` port has no `updateSkill` method at all, and `listSkills()` only returns `{ id, name, description }` — a custom-imported skill's current source isn't visible client-side to safely pre-fill or resubmit an edit form. That's out of scope for a UI-only change.

## Test plan
- [x] New tests in `skillStoreContractSuite.ts` (runs against both backends): delete removes the row; idempotent for an unknown skill, other tenants untouched.
- [x] New tests in `tests/unit/apis/skills.test.ts`: `DELETE /{name}` removes the skill; idempotent for an unknown skill.
- [x] `pnpm test:store:sqlite` — 133 passed (was 131), 1 skipped; confirmed the two new `deleteSkill` cases ran via `--verbose`.
- [x] `pnpm test` (trueforge unit suite) — 294/294 pass, including `skills.test.ts`.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm eslint` on changed files — clean.
- [x] Added a changeset (`@truefoundry/trueforge` minor — new endpoint).
- [ ] Postgres store contract suite — same as #495, couldn't verify locally (sandbox blocks raw TCP to a local Postgres container), but CI runs it against this exact test file with a real `postgres:17-alpine` service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxyEPwQ73B27NTr83U69Ba

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tenant-scoped row delete behind existing settings admin auth; behavior matches other delete endpoints and is covered by contract/API tests.
> 
> **Overview**
> Adds **`DELETE /api/v1/settings/skills/{name}`** so configured skills can be removed from the backend (unblocks Settings “Remove” once the SDK catches up).
> 
> The flow mirrors existing admin delete routes: OpenAPI route with `name` path param, handler returns **`200` and `{}`**, and **`ISkillStore.deleteSkill`** deletes by `(tenant_id, name)` in both Postgres and SQLite with **idempotent** behavior when the row is already missing. A **`DeleteSkillResponseSchema`** documents the empty success body; store contract and API unit tests cover removal, idempotency, and tenant isolation. **`@truefoundry/trueforge`** gets a minor changeset for the new endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d06cd36d4f28352e1d4317faede2cf1b1087b553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->