### PR TITLE
feat(model-providers): add DELETE endpoint to permanently remove a provider

### DIFF
--- a/.changeset/delete-model-provider.md
+++ b/.changeset/delete-model-provider.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": minor
+---
+
+Add `DELETE /api/v1/settings/model-providers/{name}` to permanently remove a configured model provider. Idempotent if already gone.

--- a/packages/trueforge/src/apis/modelProviders.ts
+++ b/packages/trueforge/src/apis/modelProviders.ts
@@ -7,6 +7,7 @@ import {
 import type { WithTransaction } from '../db/transaction';
 import {
   createModelProviderRoute,
+  deleteModelProviderRoute,
   listModelProvidersRoute,
   putModelProviderRoute,
 } from '../routes/modelProviderRoutes';
@@ -116,9 +117,16 @@ export function createModelProvidersRouter<TTransaction>(deps: ModelProvidersRou
     }
   };
 
+  const deleteHandler: RouteHandler<typeof deleteModelProviderRoute> = async c => {
+    const { name } = c.req.valid('param');
+    await deps.modelProviderStore.deleteProvider({ tenant_id: TENANT_ID, name });
+    return c.json({}, 200);
+  };
+
   const router = new OpenAPIHono();
   router.openapi(listModelProvidersRoute, listHandler);
   router.openapi(createModelProviderRoute, createHandler);
   router.openapi(putModelProviderRoute, putHandler);
+  router.openapi(deleteModelProviderRoute, deleteHandler);
   return router;
 }

--- a/packages/trueforge/src/db/modelProviderStore.ts
+++ b/packages/trueforge/src/db/modelProviderStore.ts
@@ -62,6 +62,8 @@ export interface IModelProviderStore<TTransaction = never> {
   upsertProvider(input: UpsertModelProviderInput, transaction?: TTransaction): Promise<ModelProviderRecord>;
   /** Flattens manifests into the FQN read view for GET /models. */
   listModels(tenantId: string, transaction?: TTransaction): Promise<AvailableModel[]>;
+  /** Permanently removes the provider row. Idempotent if already gone. */
+  deleteProvider(input: GetModelProviderInput, transaction?: TTransaction): Promise<void>;
 }
 
 /** Application-side flatten shared by both store implementations. */

--- a/packages/trueforge/src/db/postgres/model-provider-store/PostgresModelProviderStore.ts
+++ b/packages/trueforge/src/db/postgres/model-provider-store/PostgresModelProviderStore.ts
@@ -123,4 +123,13 @@ export class PostgresModelProviderStore implements IModelProviderStore<Transacti
   async listModels(tenantId: string, transaction?: Transaction<Database>): Promise<AvailableModel[]> {
     return flattenProviderModels(await this.listProviders(tenantId, transaction));
   }
+
+  async deleteProvider(input: GetModelProviderInput, transaction?: Transaction<Database>): Promise<void> {
+    const db = transaction ?? this.#db;
+    await db
+      .deleteFrom('model_provider')
+      .where('tenant_id', '=', input.tenant_id)
+      .where('name', '=', input.name)
+      .execute();
+  }
 }

--- a/packages/trueforge/src/db/sqlite/model-provider-store/SqliteModelProviderStore.ts
+++ b/packages/trueforge/src/db/sqlite/model-provider-store/SqliteModelProviderStore.ts
@@ -124,4 +124,13 @@ export class SqliteModelProviderStore implements IModelProviderStore<Transaction
   async listModels(tenantId: string, transaction?: Transaction<Database>): Promise<AvailableModel[]> {
     return flattenProviderModels(await this.listProviders(tenantId, transaction));
   }
+
+  async deleteProvider(input: GetModelProviderInput, transaction?: Transaction<Database>): Promise<void> {
+    const db = transaction ?? this.#db;
+    await db
+      .deleteFrom('model_provider')
+      .where('tenant_id', '=', input.tenant_id)
+      .where('name', '=', input.name)
+      .execute();
+  }
 }

--- a/packages/trueforge/src/routes/modelProviderRoutes.ts
+++ b/packages/trueforge/src/routes/modelProviderRoutes.ts
@@ -3,10 +3,11 @@
  * Discovery catalog lives at GET /api/v1/catalogs/model-providers.
  * Handlers are registered in apis/modelProviders.ts.
  */
-import { createRoute } from '@hono/zod-openapi';
+import { createRoute, z } from '@hono/zod-openapi';
 import { RequestErrorResponseSchema } from '../schemas/errors';
 import {
   CreateModelProviderRequestSchema,
+  DeleteModelProviderResponseSchema,
   GetModelProviderResponseSchema,
   ListModelProvidersResponseSchema,
   UpdateModelProviderRequestSchema,
@@ -93,6 +94,37 @@ export const putModelProviderRoute = createRoute({
     400: {
       content: { 'application/json': { schema: RequestErrorResponseSchema } },
       description: 'Invalid request body, or redacted API key with no stored secret to keep.',
+    },
+  },
+});
+
+const ModelProviderNameParamsSchema = z.object({
+  name: z.string().min(1).describe('Model provider name.'),
+});
+
+export const deleteModelProviderRoute = createRoute({
+  method: 'delete',
+  path: '/{name}',
+  tags: [OpenApiTag.MODELS],
+  summary: 'Delete a model provider',
+  description: 'Permanently removes the configured model provider by name. Idempotent if already gone.',
+  'x-fern-sdk-group-name': ['settings', 'modelProviders'],
+  'x-fern-sdk-method-name': 'delete',
+  request: {
+    params: ModelProviderNameParamsSchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: DeleteModelProviderResponseSchema } },
+      description: 'Model provider deleted.',
+    },
+    401: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'OIDC is configured and the request has no valid session cookie.',
+    },
+    403: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'OIDC is configured and the caller is authenticated but not an admin.',
     },
   },
 });

--- a/packages/trueforge/src/schemas/modelProvider.ts
+++ b/packages/trueforge/src/schemas/modelProvider.ts
@@ -211,6 +211,8 @@ export const ListModelProvidersResponseSchema = z
   })
   .openapi('ListModelProvidersResponse');
 
+export const DeleteModelProviderResponseSchema = z.object({}).openapi('DeleteModelProviderResponse');
+
 /** Provider identity on the models list read view. */
 export const AvailableModelProviderSchema = z
   .object({

--- a/packages/trueforge/tests/db/modelProviderStoreContractSuite.ts
+++ b/packages/trueforge/tests/db/modelProviderStoreContractSuite.ts
@@ -106,6 +106,27 @@ export function runModelProviderStoreContractSuite(getStore: () => IModelProvide
     expect(providers.every(record => record.tenant_id === TENANT)).toBe(true);
   });
 
+  it('deleteProvider removes the row', async () => {
+    const store = getStore();
+    await store.upsertProvider({ tenant_id: TENANT, name: 'anthropic', manifest: anthropic });
+
+    await store.deleteProvider({ tenant_id: TENANT, name: 'anthropic' });
+
+    await expect(store.getProvider({ tenant_id: TENANT, name: 'anthropic' })).resolves.toBeUndefined();
+  });
+
+  it('deleteProvider is idempotent for an unknown provider and leaves other tenants untouched', async () => {
+    const store = getStore();
+    const otherTenant = await store.upsertProvider({
+      tenant_id: 'other-tenant',
+      name: 'anthropic',
+      manifest: anthropic,
+    });
+
+    await expect(store.deleteProvider({ tenant_id: TENANT, name: 'anthropic' })).resolves.toBeUndefined();
+    await expect(store.getProvider({ tenant_id: 'other-tenant', name: 'anthropic' })).resolves.toEqual(otherTenant);
+  });
+
   it('stores custom providers with base_url', async () => {
     const store = getStore();
     const created = await store.upsertProvider({ tenant_id: TENANT, name: custom.name, manifest: custom });

--- a/packages/trueforge/tests/unit/apis/modelProviders.test.ts
+++ b/packages/trueforge/tests/unit/apis/modelProviders.test.ts
@@ -400,6 +400,26 @@ describe('model-provider secret redaction and strict PUT', () => {
     const stored = await modelProviderStore.getProvider({ tenant_id: TENANT_ID, name: 'anthropic' });
     expect(stored?.manifest.auth?.api_key).toBe(rotatedKey);
   });
+
+  it('DELETE /model-providers/{name} removes the provider', async () => {
+    const { settingsRouter, modelProviderStore } = await createRouters();
+    await settingsRouter.request('/model-providers', putInit(anthropicBody));
+
+    const response = await settingsRouter.request('/model-providers/anthropic', { method: 'DELETE' });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+
+    expect(await modelProviderStore.getProvider({ tenant_id: TENANT_ID, name: 'anthropic' })).toBeUndefined();
+    const list = await settingsRouter.request('/model-providers');
+    expect(await list.json()).toEqual({ data: [] });
+  });
+
+  it('DELETE /model-providers/{name} is idempotent for an unknown provider', async () => {
+    const { settingsRouter } = await createRouters();
+    const response = await settingsRouter.request('/model-providers/never-existed', { method: 'DELETE' });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+  });
 });
 
 describe('catalog presets are configurable', () => {


### PR DESCRIPTION
## Summary
Fixes #500.

In Settings → Models, each configured provider (openai, anthropic, custom, …) has a "Remove" button, gated on `modelCatalog.deleteModelProvider`. That method is never implemented in the adapter — no backend `DELETE` route exists for model providers at all — so the button silently never renders. Same shape as the MCP connector (#494/#495) and skill (#498/#499) gaps.

This PR adds `DELETE /api/v1/settings/model-providers/{name}`.

- `IModelProviderStore.deleteProvider` implemented for both Postgres and SQLite.
- Route + handler mirror the existing `deleteAgentRoute`/`deleteMcpServerRoute`/`deleteSkillRoute` pattern exactly: idempotent, `200` with `{}` on success.

## Scope: backend only (same reason as #495/#499)
`packages/trueforge-sdk` is Fern-generated in CI and can't receive that regen commit on a fork PR. So this is the backend endpoint only, tested. Frontend wiring (`modelProviderCatalog.ts`'s `deleteModelProvider`) is a fast-follow once this merges and the SDK regenerates on `main`.

## Test plan
- [x] New tests in `modelProviderStoreContractSuite.ts` (runs against both backends): delete removes the row; idempotent for an unknown provider, other tenants untouched.
- [x] New tests in `tests/unit/apis/modelProviders.test.ts`: `DELETE /model-providers/{name}` removes the provider (and confirms it drops out of the list); idempotent for an unknown provider.
- [x] `pnpm test:store:sqlite` — 133 passed (was 131), 1 skipped; confirmed the two new `deleteProvider` cases ran via `--verbose`.
- [x] `pnpm test` (trueforge unit suite) — 294/294 pass, including the two new `modelProviders.test.ts` cases.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm eslint` on changed files — clean.
- [x] Added a changeset (`@truefoundry/trueforge` minor — new endpoint).
- [ ] Postgres store contract suite — same as #495/#499, couldn't verify locally (sandbox blocks raw TCP to a local Postgres container), but CI runs it against this exact test file with a real `postgres:17-alpine` service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxyEPwQ73B27NTr83U69Ba

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a destructive admin settings operation that permanently removes provider configuration (including stored API keys) and drops models from the tenant catalog; behavior is tenant-scoped and matches other idempotent delete routes.
> 
> **Overview**
> Adds **`DELETE /api/v1/settings/model-providers/{name}`** so admins can permanently remove a configured model provider (unblocks Settings → Models “Remove” once the SDK regenerates).
> 
> The handler follows the existing settings delete pattern: tenant-scoped row delete, **200** with `{}`, and **idempotent** when the name is already gone. Storage goes through new **`IModelProviderStore.deleteProvider`**, implemented in both Postgres and SQLite with a straight `model_provider` delete by `(tenant_id, name)`.
> 
> OpenAPI/Fern metadata and **`DeleteModelProviderResponseSchema`** are added alongside contract and API tests for successful delete, list emptying, and idempotent unknown names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2faf9a86b0f3cb77a653e5cbafa775c5909185e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->