### PR TITLE
feat(connectors): add Remove button, wiring deleteConnector

### DIFF
--- a/.changeset/connector-remove-button.md
+++ b/.changeset/connector-remove-button.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge-ui": patch
+---
+
+Add a "Remove" button to configured connectors in Settings → Connectors, wiring the previously-unimplemented `deleteConnector` now that `DELETE /api/v1/settings/mcp-servers/{name}` exists (#495).

--- a/.changeset/delete-mcp-server.md
+++ b/.changeset/delete-mcp-server.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": minor
+---
+
+Add `DELETE /api/v1/settings/mcp-servers/{name}` to permanently remove a configured MCP server (its OAuth tokens and pending authorizations cascade-delete). Idempotent if already gone.

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/ConnectorSettings.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/ConnectorSettings.tsx
@@ -227,6 +227,14 @@ const ConnectorSettings = () => {
     }).catch(() => {});
   };
 
+  const handleRemoveConnector = (connector: ConnectorBase) => {
+    const deleteConnector = connectorCatalog.deleteConnector;
+    if (!deleteConnector) return;
+    void runMutation(async () => {
+      await deleteConnector({ id: connector.id });
+    }).catch(() => {});
+  };
+
   const handleConnectorRefreshed = (refreshedConnector: ConnectorBase) => {
     setSelectedConnector(current => (current?.id === refreshedConnector.id ? refreshedConnector : current));
     setConnectors(current => {
@@ -310,6 +318,22 @@ const ConnectorSettings = () => {
               >
                 <Icon name="wrench" className="size-3" />
                 Replace Key
+              </Button>
+            ) : null}
+            {connectorCatalog.deleteConnector ? (
+              <Button
+                variant="secondary"
+                size="sm"
+                type="button"
+                className="transition-colors hover:bg-failure-bg/10 hover:text-failure-bg"
+                disabled={busy}
+                aria-label={`Remove ${connector.name}`}
+                onClick={event => {
+                  event.stopPropagation();
+                  handleRemoveConnector(connector);
+                }}
+              >
+                Remove
               </Button>
             ) : null}
             <Icon name="chevron-right" className="size-4" />

--- a/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/catalogs/connectorCatalog.ts
+++ b/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/catalogs/connectorCatalog.ts
@@ -113,7 +113,7 @@ export function toHarnessManifest(req: {
   };
 }
 
-/** Settings connector port for `createTrueFoundryServer`. Delete omitted; disconnect unsupported. */
+/** Settings connector port for `createTrueFoundryServer`. */
 export function createConnectorCatalog(
   client: TrueForge,
 ): ConnectorCatalogServer<
@@ -227,6 +227,9 @@ export function createConnectorCatalog(
       }
       const body = await client.mcpServers.deleteAuthorization(req.id);
       return toUiConnector(body.data);
+    },
+    deleteConnector: async req => {
+      await client.settings.mcpServers.delete(req.id);
     },
   };
 }

--- a/packages/trueforge-ui/test/containers/SettingsBuilder/ConnectorSettings.test.tsx
+++ b/packages/trueforge-ui/test/containers/SettingsBuilder/ConnectorSettings.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import ConnectorSettings from '@/containers/SettingsBuilder/ConnectorSettings.js';
+import { ServerProvider } from '@/server/ServerContext.js';
+import type { ConnectorBase } from '@/server/types.js';
+import { createMockAgentUIServer, createMockCatalog } from '../../server/mockServer.js';
+
+const connectedLinear: ConnectorBase = {
+  id: 'linear',
+  name: 'linear',
+  description: 'Search, read, and create Linear issues.',
+  url: 'https://mcp.linear.app/mcp',
+  auth: { type: 'dcr' },
+  requiresAuth: false,
+  authenticated: true,
+};
+
+function renderConnectorSettings({ deleteConnector }: { deleteConnector?: (req: { id: string }) => Promise<void> }) {
+  const server = createMockAgentUIServer({
+    catalog: createMockCatalog({
+      connectorCatalog: {
+        getConnectorCatalog: async () => [],
+        listConnectors: async () => [connectedLinear],
+        getConnector: async () => connectedLinear,
+        getToolsByConnectorId: async () => [],
+        createConnector: async () => connectedLinear,
+        updateConnector: async () => connectedLinear,
+        authenticateConnector: async () => ({ authorization_endpoint: '' }),
+        disconnectConnector: async () => connectedLinear,
+        ...(deleteConnector ? { deleteConnector } : {}),
+      },
+    }),
+  });
+
+  render(
+    <ServerProvider server={server}>
+      <ConnectorSettings />
+    </ServerProvider>,
+  );
+}
+
+describe('ConnectorSettings Remove button (fixes #494)', () => {
+  it('hides Remove when the host has not wired deleteConnector', async () => {
+    renderConnectorSettings({});
+    await screen.findByText('linear');
+    expect(screen.queryByRole('button', { name: 'Remove linear' })).not.toBeInTheDocument();
+  });
+
+  it('shows Remove and calls deleteConnector when the host supports it', async () => {
+    const deleteConnector = vi.fn(async () => undefined);
+    renderConnectorSettings({ deleteConnector });
+
+    const row = await screen.findByText('linear');
+    const removeButton = within(row.closest('article') as HTMLElement).getByRole('button', { name: 'Remove linear' });
+    fireEvent.click(removeButton);
+
+    await waitFor(() => expect(deleteConnector).toHaveBeenCalledWith({ id: 'linear' }));
+  });
+
+  it('Remove does not open the connector details view (stops propagation)', async () => {
+    const deleteConnector = vi.fn(async () => undefined);
+    renderConnectorSettings({ deleteConnector });
+
+    const row = await screen.findByText('linear');
+    const removeButton = within(row.closest('article') as HTMLElement).getByRole('button', { name: 'Remove linear' });
+    fireEvent.click(removeButton);
+
+    await waitFor(() => expect(deleteConnector).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: 'Connectors' })).not.toBeInTheDocument();
+  });
+});

--- a/packages/trueforge/src/apis/mcpServers.ts
+++ b/packages/trueforge/src/apis/mcpServers.ts
@@ -13,6 +13,7 @@ import {
   authorizeMcpServerRoute,
   createMcpServerRoute,
   deleteAuthorizationMcpServerRoute,
+  deleteMcpServerRoute,
   getMcpServerRoute,
   listAvailableMcpServersRoute,
   listMcpServersRoute,
@@ -307,11 +308,18 @@ export function createSettingsMcpServersRouter<TTransaction>(deps: McpServersRou
     }
   };
 
+  const deleteHandler: RouteHandler<typeof deleteMcpServerRoute> = async c => {
+    const { name } = c.req.valid('param');
+    await deps.mcpServerStore.deleteServer({ tenant_id: TENANT_ID, name });
+    return c.json({}, 200);
+  };
+
   const router = new OpenAPIHono();
   router.openapi(listMcpServersRoute, listHandler);
   router.openapi(createMcpServerRoute, createHandler);
   router.openapi(putMcpServerRoute, putHandler);
   router.openapi(getMcpServerRoute, getHandler);
+  router.openapi(deleteMcpServerRoute, deleteHandler);
   return router;
 }
 

--- a/packages/trueforge/src/db/mcpServerStore.ts
+++ b/packages/trueforge/src/db/mcpServerStore.ts
@@ -78,6 +78,11 @@ export interface IMcpServerStore<TTransaction = never> extends IOAuthClientStore
    * Never overwrites `id`, `oauth_server`, or `oauth_client`.
    */
   upsertServer(input: UpsertMcpServerInput, transaction?: TTransaction): Promise<McpServerRecord>;
+  /**
+   * Permanently removes the server row. OAuth tokens and pending authorizations cascade-delete
+   * via their `oauth_server_id` foreign key. Idempotent if already gone.
+   */
+  deleteServer(input: GetMcpServerInput, transaction?: TTransaction): Promise<void>;
 }
 
 /**

--- a/packages/trueforge/src/db/postgres/mcp-server-store/PostgresMcpServerStore.ts
+++ b/packages/trueforge/src/db/postgres/mcp-server-store/PostgresMcpServerStore.ts
@@ -123,6 +123,11 @@ export class PostgresMcpServerStore implements IMcpServerStore<Transaction<Datab
     return toRecord(row);
   }
 
+  async deleteServer(input: GetMcpServerInput, transaction?: Transaction<Database>): Promise<void> {
+    const db = transaction ?? this.#db;
+    await db.deleteFrom('mcp_server').where('tenant_id', '=', input.tenant_id).where('name', '=', input.name).execute();
+  }
+
   async getClient(params: { id: string }, transaction?: Transaction<Database>): Promise<OAuthClientRecord | undefined> {
     const db = transaction ?? this.#db;
     const row = await db

--- a/packages/trueforge/src/db/sqlite/mcp-server-store/SqliteMcpServerStore.ts
+++ b/packages/trueforge/src/db/sqlite/mcp-server-store/SqliteMcpServerStore.ts
@@ -127,6 +127,11 @@ export class SqliteMcpServerStore implements IMcpServerStore<Transaction<Databas
       .executeTakeFirstOrThrow();
   }
 
+  async deleteServer(input: GetMcpServerInput, transaction?: Transaction<Database>): Promise<void> {
+    const db = transaction ?? this.#db;
+    await db.deleteFrom('mcp_server').where('tenant_id', '=', input.tenant_id).where('name', '=', input.name).execute();
+  }
+
   async getClient(params: { id: string }, transaction?: Transaction<Database>): Promise<OAuthClientRecord | undefined> {
     const db = transaction ?? this.#db;
     const row = await db

--- a/packages/trueforge/src/routes/mcpServerRoutes.ts
+++ b/packages/trueforge/src/routes/mcpServerRoutes.ts
@@ -7,6 +7,7 @@ import { createRoute, z } from '@hono/zod-openapi';
 import { RequestErrorResponseSchema } from '../schemas/errors';
 import {
   CreateMcpServerRequestSchema,
+  DeleteMcpServerResponseSchema,
   GetMcpServerResponseSchema,
   ListAvailableMcpServersResponseSchema,
   ListMcpServersResponseSchema,
@@ -153,6 +154,35 @@ export const putMcpServerRoute = createRoute({
     422: {
       content: { 'application/json': { schema: RequestErrorResponseSchema } },
       description: 'The server cannot satisfy `auth.type: dcr` (e.g. it advertises no registration_endpoint).',
+    },
+  },
+});
+
+export const deleteMcpServerRoute = createRoute({
+  method: 'delete',
+  path: '/{name}',
+  tags: [OpenApiTag.MCP_SERVERS],
+  summary: 'Delete an MCP server',
+  description:
+    'Permanently removes the configured MCP server by name, including any stored OAuth tokens and ' +
+    'pending authorizations. Idempotent if already gone.',
+  'x-fern-sdk-group-name': ['settings', 'mcpServers'],
+  'x-fern-sdk-method-name': 'delete',
+  request: {
+    params: McpServerNameParamsSchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: DeleteMcpServerResponseSchema } },
+      description: 'MCP server deleted.',
+    },
+    401: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'OIDC is configured and the request has no valid session cookie.',
+    },
+    403: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'OIDC is configured and the caller is authenticated but not an admin.',
     },
   },
 });

--- a/packages/trueforge/src/schemas/mcpServer.ts
+++ b/packages/trueforge/src/schemas/mcpServer.ts
@@ -102,6 +102,7 @@ export const GetMcpServerResponseSchema = z.object({ data: ConfiguredMcpServerSc
 export const ListMcpServersResponseSchema = z
   .object({ data: z.array(ConfiguredMcpServerSchema) })
   .openapi('ListMCPServersResponse');
+export const DeleteMcpServerResponseSchema = z.object({}).openapi('DeleteMCPServerResponse');
 
 /** Public auth mechanism for chat/composer (no secrets). */
 export const McpServerAuthPublicSchema = z

--- a/packages/trueforge/tests/db/mcpServerStoreContractSuite.ts
+++ b/packages/trueforge/tests/db/mcpServerStoreContractSuite.ts
@@ -137,6 +137,25 @@ export function runMcpServerStoreContractSuite(getStore: () => IMcpServerStore):
     await expect(store.listServers({ tenant_id: TENANT, names: [] })).resolves.toEqual([]);
   });
 
+  it('deleteServer removes the row and cascade-clears its saved OAuth client', async () => {
+    const store = getStore();
+    const created = await store.upsertServer({ tenant_id: TENANT, name: 'linear', manifest: manifest() });
+    await store.saveClient({ id: created.id, record: sampleOAuthClient });
+
+    await store.deleteServer({ tenant_id: TENANT, name: 'linear' });
+
+    await expect(store.getServer({ tenant_id: TENANT, name: 'linear' })).resolves.toBeUndefined();
+    await expect(store.getClient({ id: created.id })).resolves.toBeUndefined();
+  });
+
+  it('deleteServer is idempotent for an unknown server and leaves other tenants untouched', async () => {
+    const store = getStore();
+    const otherTenant = await store.upsertServer({ tenant_id: 'other-tenant', name: 'linear', manifest: manifest() });
+
+    await expect(store.deleteServer({ tenant_id: TENANT, name: 'linear' })).resolves.toBeUndefined();
+    await expect(store.getServer({ tenant_id: 'other-tenant', name: 'linear' })).resolves.toEqual(otherTenant);
+  });
+
   it('upsert leaves oauth columns null and does not clear a saved OAuth client', async () => {
     const store = getStore();
     const created = await store.upsertServer({

--- a/packages/trueforge/tests/unit/apis/mcpServers.test.ts
+++ b/packages/trueforge/tests/unit/apis/mcpServers.test.ts
@@ -870,4 +870,35 @@ describe('mcp-servers routers', () => {
     const missing = await mcpServersRouter.request('/missing/authorize', { method: 'DELETE' });
     expect(missing.status).toBe(404);
   });
+
+  it('DELETE /{name} permanently removes the server and cascades its OAuth token', async () => {
+    const record = await seedDcrServerWithClient({ ...putBodyWithDcr, name: 'to-delete' });
+    await tokenStore.saveToken({
+      id: record.id,
+      userRef: LOCAL_USER_CONTEXT.userRef,
+      token: {
+        accessToken: 'access-1',
+        refreshToken: null,
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        scope: null,
+      },
+    });
+
+    const response = await settingsRouter.request('/to-delete', { method: 'DELETE' });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+
+    expect(await mcpServerStore.getServer({ tenant_id: TENANT_ID, name: 'to-delete' })).toBeUndefined();
+    expect(await tokenStore.getToken({ id: record.id, userRef: LOCAL_USER_CONTEXT.userRef })).toBeUndefined();
+
+    const listed = await settingsRouter.request('/');
+    const names = ((await listed.json()) as { data: { name: string }[] }).data.map(server => server.name);
+    expect(names).not.toContain('to-delete');
+  });
+
+  it('DELETE /{name} is idempotent for an unknown server', async () => {
+    const response = await settingsRouter.request('/never-existed', { method: 'DELETE' });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({});
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #494. **Depends on #495** — needs its `DELETE /api/v1/settings/mcp-servers/{name}` to function. GitHub won't let a PR from a fork target another fork branch as base, so this is opened against `main` directly; please merge #495 first (this diff includes it, so it'll show as already-applied once #495 lands and this rebases).

Settings → Connectors had no way to fully remove a configured connector of any auth type:
- DCR connectors' "Disconnect" only clears the OAuth token — the row stays in "Configured" with an `auth_required` badge forever.
- Header-auth and no-auth connectors had no removal option at all.

This PR wires `deleteConnector` (already optional on the `ConnectorCatalogServer` port, just unimplemented — comment in `connectorCatalog.ts` said "Delete omitted; disconnect unsupported") to the endpoint from #495, and adds a "Remove" button to every configured connector row.

Same pattern as the Remove buttons already shipped for skills (#499) and model providers (#501): single click, no confirmation dialog, gated on `connectorCatalog.deleteConnector` being present so hosts that haven't wired it don't get a dead button.

## Why this branch includes an SDK regen
`packages/trueforge-sdk` doesn't have `settings.mcpServers.delete(...)` until #495 merges and CI regenerates it on `main`. Since this PR's whole point is calling that method, I regenerated the SDK here so the branch actually builds and its tests actually run — same situation as #495/#499/#501 (Fern-generated in CI, fork PRs can't receive that regen commit). The ~450-file regen diff is *not* meant to be reviewed here; it should collapse to near-zero once this rebases onto a main that already has it (post-#495-merge).

## Test plan
- [x] New tests in `ConnectorSettings.test.tsx`: Remove is hidden when the host hasn't wired `deleteConnector`; shown and calls it with the right id when the host has; doesn't bubble the click into opening the connector details view.
- [x] `pnpm vitest run` in `packages/trueforge-ui` — 868/868 pass.
- [x] `pnpm tsc --noEmit` (src + test) — clean.
- [x] `pnpm eslint` on changed files — clean.
- [x] Added a changeset (`@truefoundry/trueforge-ui` patch).
- [x] Verified against the real running app: added a throwaway `deepwiki` (no-auth) connector, clicked Remove, confirmed it moved back from "Configured" to "Available" — screenshots below (cropped to exclude the chat-history sidebar, which had real private session titles).

## Screenshots (local run against the real app)

**1. Every configured connector now has a Remove button, regardless of auth type:**
![Connectors list with Remove](https://raw.githubusercontent.com/kristopolous/trueforge/connector-remove-screenshots/screenshots/01-connectors-list-with-remove.png)

**2. A throwaway no-auth connector added for the demo:**
![Throwaway connector added](https://raw.githubusercontent.com/kristopolous/trueforge/connector-remove-screenshots/screenshots/02-throwaway-connector-added.png)

**3. After clicking Remove — back in "Available", not "Configured":**
![After Remove clicked](https://raw.githubusercontent.com/kristopolous/trueforge/connector-remove-screenshots/screenshots/03-after-remove-clicked.png)

*(Screenshots hosted on an orphan `connector-remove-screenshots` branch on my fork, not merged into this PR's diff.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxyEPwQ73B27NTr83U69Ba

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Permanent deletion of MCP configuration and OAuth credentials from admin settings, with no confirmation UI—mitigated by settings-route admin auth and optional catalog wiring.
> 
> **Overview**
> Adds **`DELETE /api/v1/settings/mcp-servers/{name}`** so admins can permanently drop a configured MCP server; related OAuth tokens and pending authorizations are removed via DB cascade, and repeat deletes still return **200**.
> 
> **Settings → Connectors** gets a **Remove** control on every configured row (all auth types), gated on the host exposing optional **`deleteConnector`**. The TrueFoundry adapter implements that port with **`settings.mcpServers.delete`**, matching the existing skills/providers pattern (single click, no confirm dialog; click does not open connector details).
> 
> Store **`deleteServer`** is implemented for Postgres and SQLite; contract and API tests cover idempotency, tenant isolation, and token cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f5487d2a4d97c68880f6a2a428c3c733c907a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->