### PR TITLE
feat: add OrcaRouter as a first-class model provider

### DIFF
--- a/.changeset/orcarouter-provider.md
+++ b/.changeset/orcarouter-provider.md
@@ -1,0 +1,6 @@
+---
+"@truefoundry/trueforge": minor
+"@truefoundry/trueforge-core": minor
+---
+
+Add OrcaRouter as a first-class model provider: an OpenAI-compatible AI gateway covering model routing, failover, guardrails and agent tool governance behind one endpoint. Mirrors the existing well-known provider wiring (`buildLanguageModel` compatible-adapter case, manifest schema with a default base URL, and shipped catalog presets).

--- a/docs/models.mdx
+++ b/docs/models.mdx
@@ -18,6 +18,7 @@ TrueForge works with the major model providers and any OpenAI-compatible endpoin
 | `moonshot`      | Moonshot AI (Kimi)                                                     |
 | `zai`           | Z.ai (GLM)                                                             |
 | `alibaba`       | Alibaba (Qwen)                                                         |
+| `orcarouter`    | [OrcaRouter](https://www.orcarouter.ai) — OpenAI-compatible AI gateway |
 | `custom`        | Any OpenAI-compatible endpoint — self-hosted models, gateways, proxies |
 
 ## Configuring a standard provider

--- a/packages/trueforge-core/src/core/llm/VercelAILLM.ts
+++ b/packages/trueforge-core/src/core/llm/VercelAILLM.ts
@@ -62,6 +62,7 @@ export const VERCEL_AI_PROVIDER_NAMES = [
   'moonshot',
   'alibaba',
   'together',
+  'orcarouter',
   'custom',
 ] as const;
 
@@ -121,9 +122,9 @@ function isFunctionToolCall<T extends { type: string }>(toolCall: T): toolCall i
 
 /**
  * Shared by every OpenAI-compatible provider, which differ only by endpoint. The provider type
- * doubles as the `providerOptions` key. Fireworks, Together and Z AI stay here rather than on their
- * own packages: those drop `json_schema`, and Fireworks also clamps efforts its models do accept.
- * TODO: move Z AI to @ai-sdk/zai once https://github.com/vercel/ai/pull/17340 ships.
+ * doubles as the `providerOptions` key. Fireworks, Together, Z AI and OrcaRouter stay here rather
+ * than on their own packages: those drop `json_schema`, and Fireworks also clamps efforts its
+ * models do accept. TODO: move Z AI to @ai-sdk/zai once https://github.com/vercel/ai/pull/17340 ships.
  */
 function compatibleModel(config: VercelAIProviderConfig): LanguageModel {
   const { provider, model, apiKey, headers, baseUrl } = config;
@@ -195,6 +196,7 @@ export function buildLanguageModel(config: VercelAIProviderConfig): LanguageMode
     case 'fireworks':
     case 'zai':
     case 'together':
+    case 'orcarouter':
     case 'custom': {
       return compatibleModel(config);
     }

--- a/packages/trueforge/catalog/model-catalog.yaml
+++ b/packages/trueforge/catalog/model-catalog.yaml
@@ -366,3 +366,40 @@ providers:
           reasoning_efforts:
             - high
             - max
+  - type: orcarouter
+    models:
+      - model_id: orcarouter/auto
+        name: auto
+        properties:
+          reasoning_efforts:
+            - none
+            - low
+            - medium
+            - high
+      - model_id: orcarouter/fusion
+        name: fusion
+        properties:
+          context_length: 1000000
+          reasoning_efforts:
+            - none
+            - low
+            - medium
+            - high
+      - model_id: orcarouter/fusion-mini
+        name: fusion-mini
+        properties:
+          context_length: 1000000
+          reasoning_efforts:
+            - none
+            - low
+            - medium
+            - high
+      - model_id: orcarouter/fusion-flash
+        name: fusion-flash
+        properties:
+          context_length: 200000
+          reasoning_efforts:
+            - none
+            - low
+            - medium
+            - high

--- a/packages/trueforge/src/schemas/modelProvider.ts
+++ b/packages/trueforge/src/schemas/modelProvider.ts
@@ -127,6 +127,11 @@ const TogetherAIModelProviderSchema = wellKnownProviderSchema({
   base_url: 'https://api.together.xyz/v1',
 }).openapi('TogetherAIModelProvider');
 
+const OrcaRouterModelProviderSchema = wellKnownProviderSchema({
+  type: 'orcarouter',
+  base_url: 'https://api.orcarouter.ai/v1',
+}).openapi('OrcaRouterModelProvider');
+
 const AlibabaModelProviderSchema = wellKnownProviderSchema({
   type: 'alibaba',
   base_url: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
@@ -165,6 +170,7 @@ const ModelProviderBodySchema = z
     MoonshotModelProviderSchema,
     TogetherAIModelProviderSchema,
     AlibabaModelProviderSchema,
+    OrcaRouterModelProviderSchema,
     CustomModelProviderSchema,
   ])
   .superRefine(refineModelProviderManifest);


### PR DESCRIPTION
## Summary

TrueForge is *"the open-source agent harness — the runtime layer that turns an LLM into a working agent"*, and its model layer already speaks "OpenAI, Anthropic, Google Gemini, and other catalog providers, or any OpenAI-compatible endpoint." This PR adds **[OrcaRouter](https://www.orcarouter.ai)** as a first-class, named catalog provider, mirroring how the existing well-known providers (OpenAI, Anthropic, Together, Z AI, …) are wired end-to-end — not as an anonymous `custom` base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means TrueForge users can use that stack directly, without treating OrcaRouter as a bare custom endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

Every well-known provider in TrueForge touches five places, and this PR follows that same parallel structure for `orcarouter`:

| Existing provider wiring (e.g. `together`) | New `orcarouter` change |
| --- | --- |
| `packages/trueforge-core/src/core/llm/VercelAILLM.ts` — `VERCEL_AI_PROVIDER_NAMES` entry + `buildLanguageModel` case (OpenAI-compatible adapter) | `orcarouter` added to the provider registry and to the same `compatibleModel` case shared by Fireworks / Z AI / Together |
| `packages/trueforge/src/schemas/modelProvider.ts` — `wellKnownProviderSchema` with a default `base_url` | `OrcaRouterModelProviderSchema` (`https://api.orcarouter.ai/v1`), registered in the `ModelProviderManifest` discriminated union |
| `packages/trueforge/catalog/model-catalog.yaml` — discovery presets | `orcarouter` preset with its gateway-native models (`orcarouter/auto`, `orcarouter/fusion`, `orcarouter/fusion-mini`, `orcarouter/fusion-flash`) |
| `docs/models.mdx` — "Supported providers" table | `orcarouter` row with the provider link |
| `.changeset/*.md` | `orcarouter-provider.md` (minor for `@truefoundry/trueforge` and `@truefoundry/trueforge-core`) |

No new dependencies: OrcaRouter speaks the OpenAI-compatible protocol, so it reuses the existing `@ai-sdk/openai-compatible` adapter that Fireworks and Together already go through. `packages/trueforge-sdk` is generated in CI from the OpenAPI spec, so this fork PR omits SDK regeneration per the contributing guide.

## How was this tested?

- `pnpm --filter @truefoundry/trueforge-core typecheck` and `pnpm --filter @truefoundry/trueforge typecheck` pass (includes the tests `tsconfig`s).
- `pnpm --filter @truefoundry/trueforge-core test` — 388 tests pass, including `VercelAILLM.model.test.ts` and the manifest schema tests that iterate every `VERCEL_AI_PROVIDER_NAMES` entry.
- `pnpm --filter @truefoundry/trueforge test` — 293 tests pass, including the `catalog presets are configurable` suite that PUTs every shipped catalog preset (the new `orcarouter` one included) and the "can configure every adapter the harness can build" schema test.
- ESLint and Prettier pass on all changed files.
- **Live integration**: a real streaming completion through the new `buildLanguageModel` `orcarouter` path against `https://api.orcarouter.ai/v1` with `orcarouter/fusion-flash` returned a successful turn.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally (see note below)
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / `.env.example` updated if configuration or behavior changed

> Note: `pnpm lint:ci` surfaces pre-existing `@typescript-eslint/no-unsafe-*` errors in `packages/frontend/src/{App,LogoutButton,authSession}`. These are untouched by this PR (the diff only touches `trueforge-core`, `trueforge` schemas/catalog, `docs/models.mdx`, and a changeset); ESLint on every changed file passes clean.

---

I'm an engineer on the OrcaRouter team. Feedback welcome — Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider registration and catalog/docs only; reuses the existing OpenAI-compatible adapter with no changes to auth, persistence, or agent runtime logic.
> 
> **Overview**
> Adds **`orcarouter`** as a named catalog provider so users can configure [OrcaRouter](https://www.orcarouter.ai) with a default API base URL instead of a generic `custom` endpoint.
> 
> Wiring matches other OpenAI-compatible well-known providers: it is registered in `VERCEL_AI_PROVIDER_NAMES`, routed through the shared `compatibleModel` path in `buildLanguageModel`, and exposed via `OrcaRouterModelProviderSchema` (`https://api.orcarouter.ai/v1`) in the model-provider manifest union. The shipped catalog gains presets for `orcarouter/auto`, `fusion`, `fusion-mini`, and `fusion-flash` (with context/reasoning metadata where applicable). Docs and a minor changeset for `@truefoundry/trueforge` and `@truefoundry/trueforge-core` are included; no new dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bc7d42e9cd11c9f206759f77432624f629ffbb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->