### PR TITLE
feat(sandbox): allow configuring a self-hosted Daytona API URL

### DIFF
--- a/.changeset/self-hosted-daytona-api-url.md
+++ b/.changeset/self-hosted-daytona-api-url.md
@@ -1,0 +1,7 @@
+---
+"@truefoundry/trueforge": minor
+"@truefoundry/trueforge-ui": minor
+"@truefoundry/trueforge-sdk": patch
+---
+
+Add an optional `api_url` to the Daytona sandbox provider manifest, with a matching field in the sandbox settings form, so TrueForge can be pointed at a self-hosted Daytona instance. When omitted, the default cloud endpoint is used and behaviour is unchanged.

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -519,6 +519,11 @@
       "CatalogSandboxProvider": {
         "additionalProperties": false,
         "properties": {
+          "api_url": {
+            "description": "Daytona API base URL. If omitted, uses the default cloud endpoint.",
+            "format": "uri",
+            "type": "string"
+          },
           "auto_archive_interval_in_minutes": {
             "description": "Minutes before Daytona auto-archives the sandbox (0 disables).",
             "minimum": 0,
@@ -2757,6 +2762,11 @@
       "SandboxProviderManifest": {
         "additionalProperties": false,
         "properties": {
+          "api_url": {
+            "description": "Daytona API base URL. If omitted, uses the default cloud endpoint.",
+            "format": "uri",
+            "type": "string"
+          },
           "auth": {
             "$ref": "#/components/schemas/DaytonaSandboxProviderAuth"
           },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -519,6 +519,11 @@
       "CatalogSandboxProvider": {
         "additionalProperties": false,
         "properties": {
+          "api_url": {
+            "description": "Daytona API base URL. If omitted, uses the default cloud endpoint.",
+            "format": "uri",
+            "type": "string"
+          },
           "auto_archive_interval_in_minutes": {
             "description": "Minutes before Daytona auto-archives the sandbox (0 disables).",
             "minimum": 0,
@@ -2757,6 +2762,11 @@
       "SandboxProviderManifest": {
         "additionalProperties": false,
         "properties": {
+          "api_url": {
+            "description": "Daytona API base URL. If omitted, uses the default cloud endpoint.",
+            "format": "uri",
+            "type": "string"
+          },
           "auth": {
             "$ref": "#/components/schemas/DaytonaSandboxProviderAuth"
           },

--- a/packages/trueforge-sdk/src/api/types/SandboxProviderManifest.ts
+++ b/packages/trueforge-sdk/src/api/types/SandboxProviderManifest.ts
@@ -4,6 +4,8 @@ import type * as TrueForge from "../index.js";
 
 export interface SandboxProviderManifest {
     auth: TrueForge.DaytonaSandboxProviderAuth;
+    /** Daytona API base URL. If omitted, uses the default cloud endpoint. */
+    apiUrl?: string;
     /** Minutes before Daytona auto-archives the sandbox (0 disables). */
     autoArchiveIntervalInMinutes: number;
     /** Minutes before Daytona auto-deletes the sandbox (0 disables). */

--- a/packages/trueforge-sdk/src/serialization/types/SandboxProviderManifest.ts
+++ b/packages/trueforge-sdk/src/serialization/types/SandboxProviderManifest.ts
@@ -10,6 +10,7 @@ export const SandboxProviderManifest: core.serialization.ObjectSchema<
     TrueForge.SandboxProviderManifest
 > = core.serialization.object({
     auth: DaytonaSandboxProviderAuth,
+    apiUrl: core.serialization.property("api_url", core.serialization.string().optional()),
     autoArchiveIntervalInMinutes: core.serialization.property(
         "auto_archive_interval_in_minutes",
         core.serialization.number(),
@@ -29,6 +30,7 @@ export const SandboxProviderManifest: core.serialization.ObjectSchema<
 export declare namespace SandboxProviderManifest {
     export interface Raw {
         auth: DaytonaSandboxProviderAuth.Raw;
+        api_url?: string | null;
         auto_archive_interval_in_minutes: number;
         auto_delete_interval_in_minutes: number;
         auto_stop_interval_in_minutes: number;

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/ConfigureSandboxForm.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/ConfigureSandboxForm.tsx
@@ -12,6 +12,7 @@ import type { SandboxProviderConfig } from '../../server/types.js';
 
 export type SandboxConfigDraft = SandboxProviderConfig & {
   apiKey: string;
+  apiUrl?: string;
 };
 
 type ConfigureSandboxFormProps = {
@@ -21,7 +22,7 @@ type ConfigureSandboxFormProps = {
   title: string;
   description?: string;
   /** Prefills config fields; apiKey is never autofilled. */
-  initialConfig?: SandboxProviderConfig | null;
+  initialConfig?: (SandboxProviderConfig & { apiUrl?: string }) | null;
   /** When false (updates), empty apiKey means keep the existing key. */
   requireApiKey?: boolean;
   busy?: boolean;
@@ -62,6 +63,7 @@ const ConfigureSandboxForm = ({
   const [autoArchiveIntervalInMinutes, setAutoArchiveIntervalInMinutes] = useState('');
   const [autoDeleteIntervalInMinutes, setAutoDeleteIntervalInMinutes] = useState('');
   const [apiKey, setApiKey] = useState('');
+  const [apiUrl, setApiUrl] = useState('');
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const resetForm = () => {
@@ -70,6 +72,7 @@ const ConfigureSandboxForm = ({
     setAutoArchiveIntervalInMinutes('');
     setAutoDeleteIntervalInMinutes('');
     setApiKey('');
+    setApiUrl('');
     setAdvancedOpen(false);
   };
 
@@ -81,6 +84,7 @@ const ConfigureSandboxForm = ({
     setAutoArchiveIntervalInMinutes(String(config.autoArchiveIntervalInMinutes));
     setAutoDeleteIntervalInMinutes(String(config.autoDeleteIntervalInMinutes));
     setApiKey('');
+    setApiUrl((config as SandboxProviderConfig & { apiUrl?: string }).apiUrl ?? '');
     setAdvancedOpen(false);
   }, [open, initialConfig]);
 
@@ -116,6 +120,7 @@ const ConfigureSandboxForm = ({
         autoArchiveIntervalInMinutes: autoArchive,
         autoDeleteIntervalInMinutes: autoDelete,
         apiKey: trimmedKey,
+        apiUrl: apiUrl.trim() || undefined,
       });
       resetForm();
       onOpenChange(false);
@@ -157,6 +162,23 @@ const ConfigureSandboxForm = ({
               }}
               placeholder={requireApiKey ? 'dtn_...' : 'Leave blank to keep existing'}
               autoFocus
+              className={inputClassName}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="sandbox-api-url" className="mb-1.5 block text-sm font-medium text-text-primary">
+              API URL
+              <span className="font-normal text-text-secondary"> (optional)</span>
+            </label>
+            <input
+              id="sandbox-api-url"
+              type="url"
+              value={apiUrl}
+              onChange={event => {
+                setApiUrl(event.target.value);
+              }}
+              placeholder="https://app.daytona.io/api"
               className={inputClassName}
             />
           </div>

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/SandboxSettings.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/SandboxSettings.tsx
@@ -20,16 +20,14 @@ import ConfigureSandboxForm, { type SandboxConfigDraft } from './ConfigureSandbo
 
 const SNAPSHOT_STATUS_POLL_INTERVAL_MS = 10000;
 
-const configFrom = ({
-  execTimeoutMs,
-  autoStopIntervalInMinutes,
-  autoArchiveIntervalInMinutes,
-  autoDeleteIntervalInMinutes,
-}: SandboxProviderConfig): SandboxProviderConfig => ({
-  execTimeoutMs,
-  autoStopIntervalInMinutes,
-  autoArchiveIntervalInMinutes,
-  autoDeleteIntervalInMinutes,
+const configFrom = (
+  provider: SandboxProviderConfig & { apiUrl?: string },
+): SandboxProviderConfig & { apiUrl?: string } => ({
+  execTimeoutMs: provider.execTimeoutMs,
+  autoStopIntervalInMinutes: provider.autoStopIntervalInMinutes,
+  autoArchiveIntervalInMinutes: provider.autoArchiveIntervalInMinutes,
+  autoDeleteIntervalInMinutes: provider.autoDeleteIntervalInMinutes,
+  apiUrl: provider.apiUrl,
 });
 
 const statusPresentation = (status: SandboxSnapshotSyncStatus['status']): { label: string; className: string } => {
@@ -177,7 +175,7 @@ const SandboxSettings = () => {
         type: createEntry.type,
         ...configFrom(draft),
         apiKey: draft.apiKey,
-      });
+      } as any);
     }, setFormError);
     setCreateEntry(null);
     setTimeout(() => {

--- a/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/catalogs/sandboxProviderCatalog.ts
+++ b/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/catalogs/sandboxProviderCatalog.ts
@@ -9,16 +9,29 @@
 import type { TrueForge } from '@truefoundry/trueforge-sdk';
 import { TrueForgeApi } from '@truefoundry/trueforge-sdk';
 import type {
+  CreateSandboxProviderRequest,
   SandboxCatalogServer,
   SandboxProviderBase,
   SandboxProviderCatalogEntry,
   SandboxProviderConfig,
   SandboxProviderListEntry,
+  UpdateSandboxProviderRequest,
 } from '../../../server/types.js';
 
-export type UiSandboxProvider = SandboxProviderBase;
-export type UiSandboxProviderCatalogEntry = SandboxProviderCatalogEntry;
-export type UiSandboxProviderListEntry = SandboxProviderListEntry;
+export interface UiSandboxProvider extends SandboxProviderBase {
+  apiUrl?: string;
+}
+export interface UiSandboxProviderCatalogEntry extends SandboxProviderCatalogEntry {
+  apiUrl?: string;
+}
+export interface UiSandboxProviderListEntry extends SandboxProviderListEntry<UiSandboxProvider> {}
+
+export interface UiCreateSandboxRequest extends CreateSandboxProviderRequest {
+  apiUrl?: string;
+}
+export interface UiUpdateSandboxRequest extends UpdateSandboxProviderRequest {
+  apiUrl?: string;
+}
 
 const DAYTONA_TYPE = 'daytona';
 const DAYTONA_DISPLAY_NAME = 'Daytona';
@@ -32,12 +45,13 @@ function displayNameForType(type: string): string {
 
 export function configFromHarness(
   provider: TrueForgeApi.CatalogSandboxProvider | TrueForgeApi.SandboxProviderManifest,
-): SandboxProviderConfig {
+) {
   return {
     execTimeoutMs: provider.execTimeoutMs,
     autoStopIntervalInMinutes: provider.autoStopIntervalInMinutes,
     autoArchiveIntervalInMinutes: provider.autoArchiveIntervalInMinutes,
     autoDeleteIntervalInMinutes: provider.autoDeleteIntervalInMinutes,
+    apiUrl: 'apiUrl' in provider ? provider.apiUrl : undefined,
   };
 }
 
@@ -94,6 +108,7 @@ export function toHarnessManifest(
   req: {
     type: string;
     apiKey: string;
+    apiUrl?: string;
   } & SandboxProviderConfig,
 ): TrueForgeApi.SandboxProviderManifest {
   if (req.type !== DAYTONA_TYPE) {
@@ -106,11 +121,20 @@ export function toHarnessManifest(
     autoArchiveIntervalInMinutes: req.autoArchiveIntervalInMinutes,
     autoDeleteIntervalInMinutes: req.autoDeleteIntervalInMinutes,
     auth: { apiKey: req.apiKey },
+    apiUrl: req.apiUrl,
   };
 }
 
 /** Settings sandbox-catalog port for `createTrueFoundryServer`. Delete omitted (no BE route). */
-export function createSandboxProviderCatalog(client: TrueForge): SandboxCatalogServer {
+export function createSandboxProviderCatalog(
+  client: TrueForge,
+): SandboxCatalogServer<
+  UiSandboxProvider,
+  UiSandboxProviderCatalogEntry,
+  UiCreateSandboxRequest,
+  UiUpdateSandboxRequest,
+  UiSandboxProviderListEntry
+> {
   async function resolveApiKey(apiKey: string | undefined): Promise<string> {
     const trimmed = apiKey?.trim();
     if (trimmed !== undefined && trimmed !== '') {
@@ -144,6 +168,7 @@ export function createSandboxProviderCatalog(client: TrueForge): SandboxCatalogS
         manifest: toHarnessManifest({
           type: req.type,
           apiKey: req.apiKey,
+          apiUrl: req.apiUrl,
           execTimeoutMs: req.execTimeoutMs,
           autoStopIntervalInMinutes: req.autoStopIntervalInMinutes,
           autoArchiveIntervalInMinutes: req.autoArchiveIntervalInMinutes,
@@ -158,6 +183,7 @@ export function createSandboxProviderCatalog(client: TrueForge): SandboxCatalogS
         manifest: toHarnessManifest({
           type: DAYTONA_TYPE,
           apiKey,
+          apiUrl: req.apiUrl,
           execTimeoutMs: req.execTimeoutMs,
           autoStopIntervalInMinutes: req.autoStopIntervalInMinutes,
           autoArchiveIntervalInMinutes: req.autoArchiveIntervalInMinutes,

--- a/packages/trueforge/src/apis/sandboxProviders.ts
+++ b/packages/trueforge/src/apis/sandboxProviders.ts
@@ -57,6 +57,7 @@ export function createSandboxProvidersRouter<TTransaction>(deps: SandboxProvider
 
   const putHandler: RouteHandler<typeof putSandboxProviderRoute> = async c => {
     const body: UpdateSandboxProviderRequest = c.req.valid('json');
+    console.log(body);
     const incoming = body.manifest;
     const resolveManifest = (existing: SandboxProviderRecord | undefined): SandboxProviderManifest => ({
       ...incoming,
@@ -100,10 +101,12 @@ export function createSandboxProvidersRouter<TTransaction>(deps: SandboxProvider
         200,
       );
     } catch (error) {
+      console.log(error);
       if (error instanceof MissingStoredSecretError) {
         return c.json({ error: { message: 'API key is required' } }, 400);
       }
       if (isDaytonaAuthError(error)) {
+        console.log(error);
         return c.json({ error: { message: 'Daytona rejected the API key — check the credentials' } }, 422);
       }
       throw error;

--- a/packages/trueforge/src/sandbox/providerUtils.ts
+++ b/packages/trueforge/src/sandbox/providerUtils.ts
@@ -37,7 +37,7 @@ export function toDaytonaSandboxProvider({
 }): DaytonaSandboxProvider {
   const { apiKey, ...settings } = toDaytonaSandboxProviderInput(manifest);
   return new DaytonaSandboxProvider({
-    client: new Daytona({ apiKey }),
+    client: new Daytona({ apiKey, ...(settings.apiUrl ? { apiUrl: settings.apiUrl } : {}) }),
     apiKey,
     ...settings,
     tenantName: tenant_id,

--- a/packages/trueforge/src/schemas/sandboxProvider.ts
+++ b/packages/trueforge/src/schemas/sandboxProvider.ts
@@ -29,6 +29,7 @@ const DaytonaSandboxProviderAuthSchema = z
 export const DaytonaSandboxProviderSchema = z
   .object({
     type: z.literal('daytona').describe('Daytona sandbox provider.'),
+    api_url: z.string().url().optional().describe('Daytona API base URL. If omitted, uses the default cloud endpoint.'),
     auth: DaytonaSandboxProviderAuthSchema,
     exec_timeout_ms: z.number().int().positive().describe('Default sandbox command exec timeout in milliseconds.'),
     auto_stop_interval_in_minutes: z
@@ -115,10 +116,11 @@ export function toDaytonaSandboxProviderInput(manifest: SandboxProviderManifest)
   apiKey: string;
 } & Pick<
   DaytonaSandboxProviderOptions,
-  'timeoutMs' | 'autoStopIntervalInMinutes' | 'autoArchiveIntervalInMinutes' | 'autoDeleteIntervalInMinutes'
+  'apiUrl' | 'timeoutMs' | 'autoStopIntervalInMinutes' | 'autoArchiveIntervalInMinutes' | 'autoDeleteIntervalInMinutes'
 > {
   return {
     apiKey: manifest.auth.api_key,
+    apiUrl: manifest.api_url,
     timeoutMs: manifest.exec_timeout_ms,
     autoStopIntervalInMinutes: manifest.auto_stop_interval_in_minutes,
     autoArchiveIntervalInMinutes: manifest.auto_archive_interval_in_minutes,


### PR DESCRIPTION
This pr is only for preview of changes i made to integrate the local daytona instance to trueforge

below is ai generated summary from the changes made please review its not for merging just reference #509 

[Daytona Local setup (daytonaio/daytona)](https://github.com/daytonaio/daytona/releases/tag/v0.190.0)

`trueforge-core` already accepts an `apiUrl` on DaytonaSandboxProviderOptions and falls back to the public cloud endpoint when it is absent, but nothing ever supplied one: the provider manifest had no field for it, so `providerUtils` built the client with the API key alone.

That leaves self-hosted Daytona unreachable from the product. It also splits the two code paths that talk to Daytona. Setting `DAYTONA_API_URL` in the environment redirects the SDK client, because the SDK reads it as a fallback, but not `DaytonaProvider`'s direct `fetch(\`${this.apiUrl}/snapshots\`)` used to register snapshots -- that keeps posting to the cloud endpoint with a self-hosted key.

Add `api_url` as an optional manifest field, thread it through `toDaytonaSandboxProviderInput` into both the SDK client and the provider, and expose it as an optional "API URL" input in the sandbox settings form.

The field is optional and the client construction is spread conditionally, so existing cloud configurations are byte-identical and stored manifests without the field keep working.

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed
