### PR TITLE
fix(core): reject approval resumes of a running turn before freezing it

### DIFF
--- a/.changeset/reject-approval-resume-of-running-turn.md
+++ b/.changeset/reject-approval-resume-of-running-turn.md
@@ -1,0 +1,6 @@
+---
+"@truefoundry/trueforge": patch
+"@truefoundry/trueforge-core": patch
+---
+
+Reject approval and tool-response resumes that target a still-running turn before the cancelled-for-next-turn freeze, so an invalid resume such as a duplicate approval no longer cancels the turn it races.

--- a/packages/trueforge-core/src/agent-session/SessionHandle.ts
+++ b/packages/trueforge-core/src/agent-session/SessionHandle.ts
@@ -1,6 +1,7 @@
 /**
  * Bound session handle: starts turns via {@link SessionHandle.createTurn}.
  */
+import { InvalidAgentSendInputError } from '../core/errors';
 import { newEventId } from '../core/events/schema';
 import type { AgentDefinition } from '../core/runtime/AgentDefinition';
 import { AgentThread } from '../core/runtime/AgentThread';
@@ -185,6 +186,29 @@ export class SessionHandle<
     update_session_title_if_not_exist?: string | undefined;
   }): Promise<TurnHandle<TTurnCustom>> {
     const previousTurnId = resolvePreviousTurnId(input.previous_turn_id, this.session.last_turn_id);
+
+    // Approval and tool-response items answer the required actions of a
+    // completed turn; a running previous turn cannot have any. Check that
+    // read-only BEFORE the freeze below, so an invalid resume (e.g. a
+    // duplicate approval racing the turn it already resumed) is rejected
+    // without cancelling a turn that is still executing (#508).
+    const items = input.input ?? [];
+    if (
+      previousTurnId !== null &&
+      items.length > 0 &&
+      items.every(msg => isApprovalDecisionMessage(msg) || isClientSideToolResponseMessage(msg))
+    ) {
+      const prior = await this.store.getTurn({
+        session_id: this.session.session_id,
+        turn_id: previousTurnId,
+      });
+      if (prior?.state.status === 'running') {
+        throw new InvalidAgentSendInputError(
+          `previous turn '${previousTurnId}' is still running and has no pending required actions`,
+        );
+      }
+    }
+
     const previous = previousTurnId
       ? await this.freezeTurn({
           turn_id: previousTurnId,

--- a/packages/trueforge-core/src/agent-session/SessionHandle.ts
+++ b/packages/trueforge-core/src/agent-session/SessionHandle.ts
@@ -204,7 +204,7 @@ export class SessionHandle<
       });
       if (prior?.state.status === 'running') {
         throw new InvalidAgentSendInputError(
-          `previous turn '${previousTurnId}' is still running and has no pending required actions`,
+          `cannot resume previous turn '${previousTurnId}' while it is still running`,
         );
       }
     }

--- a/packages/trueforge-core/tests/agent-session/sessions.test.ts
+++ b/packages/trueforge-core/tests/agent-session/sessions.test.ts
@@ -1,9 +1,11 @@
+import { MAIN_THREAD_ID } from '../../src/agent-session/models/TurnRecord';
 import { EventType } from '../../src/agent-session/schemas/events';
 import { CancellationReason } from '../../src/agent-session/schemas/turn';
 import { Sessions } from '../../src/agent-session/Sessions';
 import { InMemorySessionStore } from '../../src/agent-session/store/InMemorySessionStore';
 import { TurnNotFoundError } from '../../src/agent-session/store/SessionStoreErrors';
 import { TurnHandle } from '../../src/agent-session/TurnHandle';
+import { InvalidAgentSendInputError } from '../../src/core/errors';
 import { makeAgentSpec, makeTestResolver, mintTestTurnId } from './testHelpers';
 
 describe('Sessions / SessionHandle / TurnHandle (storage + createTurn)', () => {
@@ -126,6 +128,59 @@ describe('Sessions / SessionHandle / TurnHandle (storage + createTurn)', () => {
     await expect(
       session.freezeTurn({ turn_id: 'missing-turn', reason: CancellationReason.ClientCancelled }),
     ).rejects.toBeInstanceOf(TurnNotFoundError);
+  });
+
+  it('rejects an approval-only resume of a running turn without cancelling it', async () => {
+    const store = new InMemorySessionStore();
+    const sessions = new Sessions({ sessionStore: store });
+    const session = await sessions.create({
+      tenant_id: tenant,
+      session_id: 's1',
+      created_by: 'user-1',
+      agent: { type: 'inline', spec: makeAgentSpec() },
+    });
+    const running = await session.createTurn({
+      turn_id: mintTestTurnId(),
+      input: [{ type: EventType.USER_MESSAGE, content: 'hello' }],
+      previous_turn_id: 'none',
+      signal: new AbortController().signal,
+      resolver: makeTestResolver(),
+    });
+
+    // A duplicate or stray approval must not kill the turn it races (#508).
+    await expect(
+      session.createTurn({
+        turn_id: mintTestTurnId(),
+        input: [
+          {
+            type: EventType.USER_TOOL_APPROVAL,
+            thread_id: MAIN_THREAD_ID,
+            tool_call_id: 'call-1',
+            approval: { status: 'allow' },
+          },
+        ],
+        previous_turn_id: 'auto',
+        signal: new AbortController().signal,
+        resolver: makeTestResolver(),
+      }),
+    ).rejects.toBeInstanceOf(InvalidAgentSendInputError);
+    const untouched = await store.getTurn({ session_id: 's1', turn_id: running.id });
+    expect(untouched?.state.status).toBe('running');
+
+    // A user message still barges in and cancels the running turn.
+    const barged = await session.createTurn({
+      turn_id: mintTestTurnId(),
+      input: [{ type: EventType.USER_MESSAGE, content: 'interrupt' }],
+      previous_turn_id: 'auto',
+      signal: new AbortController().signal,
+      resolver: makeTestResolver(),
+    });
+    expect(barged.state.status).toBe('running');
+    const cancelled = await store.getTurn({ session_id: 's1', turn_id: running.id });
+    expect(cancelled?.state).toMatchObject({
+      status: 'cancelled',
+      reason: CancellationReason.CancelledForNextTurn,
+    });
   });
 
   it('custom value vs merge-fn', async () => {


### PR DESCRIPTION
Fixes #508.

`SessionHandle.createTurn` freezes the previous turn with `cancelled-for-next-turn` before the new request is validated, and there is no rollback. A request that later fails validation therefore kills the in-flight turn and leaves no successor. The issue has a live repro: a duplicate Allow click sends a second `user.tool_approval` turn, the server rejects it with 422, and the turn that is executing the approved tool is cancelled anyway, after the tool's side effect already ran.

The fix leans on an existing invariant: approval and tool-response items answer the required actions of a completed turn, and a running turn cannot have any. So when the input consists only of approval or tool-response items, `createTurn` now peeks at the previous turn read-only and throws `InvalidAgentSendInputError` if it is still running, before the freeze. The running turn is untouched. Inputs containing a user message keep today's barge-in behavior, and valid resumes are unaffected because their previous turn is always terminal.

Added a test covering both sides: an approval-only resume of a running turn is rejected and the turn stays running, while a user message still cancels it with `cancelled-for-next-turn`. Full `trueforge-core` jest suite (389 passing), tsc, and eslint are clean.

On process: I know CONTRIBUTING asks community PRs to wait for maintainer approval. Opening this anyway since it is small and directly tied to the repro in #508; happy to close it or rework the approach if you prefer to handle it differently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn-lifecycle ordering in a core session path; behavior is narrowly scoped to approval/tool-response resumes but affects concurrency and cancellation semantics.
> 
> **Overview**
> Fixes a race where **`SessionHandle.createTurn`** froze the previous turn with **`cancelled-for-next-turn`** before validating the new input, so a rejected duplicate approval (e.g. second Allow click → 422) could cancel an in-flight turn after the tool had already run (#508).
> 
> **`createTurn`** now, for input that is **only** approval or client tool-response messages, does a read-only check on the previous turn and throws **`InvalidAgentSendInputError`** if it is still **`running`**, **before** any freeze. Invalid resumes no longer touch the executing turn; user-message barge-in and valid resumes (previous turn already terminal) behave as before.
> 
> Adds a session test that an approval-only resume against a running turn is rejected and stays running, while a user message still cancels with **`cancelled-for-next-turn`**. Patch changeset for **`@truefoundry/trueforge`** / **`trueforge-core`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a56d1aa98cbf699c7445841fc67bb0b3b11a61b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->