### PR TITLE
Closes #516: Daytona API key expiry is unhandled in few of the places

### DIFF
--- a/.changeset/daytona-access-refresh-failure.md
+++ b/.changeset/daytona-access-refresh-failure.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": patch
+---
+
+Mark Daytona sandbox providers failed when stored credentials are denied during status refresh.

--- a/packages/trueforge/src/apis/sandboxProviders.ts
+++ b/packages/trueforge/src/apis/sandboxProviders.ts
@@ -6,7 +6,6 @@ import type { WithTransaction } from '../db/transaction';
 import { getSandboxProviderRoute, putSandboxProviderRoute } from '../routes/sandboxProviderRoutes';
 import {
   checkSnapshotStatus,
-  daytonaAccessFailureReason,
   isDaytonaAuthError,
   isDaytonaPermissionError,
   toDaytonaSandboxProvider,
@@ -40,25 +39,11 @@ export function createSandboxProvidersRouter<TTransaction>(deps: SandboxProvider
       return c.json({ error: { message: 'No sandbox provider configured' } }, 404);
     }
     // Refresh the persisted build status (and re-activate an idle snapshot) on every GET.
-    let status;
-    try {
-      status = await checkSnapshotStatus({
-        store: deps.sandboxProviderStore,
-        tenant_id: TENANT_ID,
-        logger: deps.logger,
-      });
-    } catch (error) {
-      const status_reason = daytonaAccessFailureReason(error);
-      if (status_reason === undefined) {
-        throw error;
-      }
-      status = await deps.sandboxProviderStore.updateSandboxStatus({
-        tenant_id: TENANT_ID,
-        status: 'failed',
-        status_reason,
-        build_metadata: record.build_metadata,
-      });
-    }
+    const status = await checkSnapshotStatus({
+      store: deps.sandboxProviderStore,
+      tenant_id: TENANT_ID,
+      logger: deps.logger,
+    });
     return c.json(
       {
         data: {

--- a/packages/trueforge/src/apis/sandboxProviders.ts
+++ b/packages/trueforge/src/apis/sandboxProviders.ts
@@ -6,6 +6,7 @@ import type { WithTransaction } from '../db/transaction';
 import { getSandboxProviderRoute, putSandboxProviderRoute } from '../routes/sandboxProviderRoutes';
 import {
   checkSnapshotStatus,
+  daytonaAccessFailureReason,
   isDaytonaAuthError,
   isDaytonaPermissionError,
   toDaytonaSandboxProvider,
@@ -39,11 +40,25 @@ export function createSandboxProvidersRouter<TTransaction>(deps: SandboxProvider
       return c.json({ error: { message: 'No sandbox provider configured' } }, 404);
     }
     // Refresh the persisted build status (and re-activate an idle snapshot) on every GET.
-    const status = await checkSnapshotStatus({
-      store: deps.sandboxProviderStore,
-      tenant_id: TENANT_ID,
-      logger: deps.logger,
-    });
+    let status;
+    try {
+      status = await checkSnapshotStatus({
+        store: deps.sandboxProviderStore,
+        tenant_id: TENANT_ID,
+        logger: deps.logger,
+      });
+    } catch (error) {
+      const status_reason = daytonaAccessFailureReason(error);
+      if (status_reason === undefined) {
+        throw error;
+      }
+      status = await deps.sandboxProviderStore.updateSandboxStatus({
+        tenant_id: TENANT_ID,
+        status: 'failed',
+        status_reason,
+        build_metadata: record.build_metadata,
+      });
+    }
     return c.json(
       {
         data: {

--- a/packages/trueforge/src/sandbox/providerUtils.ts
+++ b/packages/trueforge/src/sandbox/providerUtils.ts
@@ -25,6 +25,16 @@ export function isDaytonaPermissionError(error: unknown): boolean {
   return error instanceof DaytonaError && error.statusCode === 403;
 }
 
+export function daytonaAccessFailureReason(error: unknown): string | undefined {
+  if (isDaytonaAuthError(error)) {
+    return 'Daytona rejected the configured API key.';
+  }
+  if (isDaytonaPermissionError(error)) {
+    return 'Daytona denied access to the configured API key.';
+  }
+  return undefined;
+}
+
 /**
  * Builds the runtime provider for a stored manifest. No network I/O until a method is called.
  *
@@ -109,11 +119,29 @@ export async function checkSnapshotStatus({
     build_metadata: record.build_metadata,
   });
   let build: SandboxBuild;
-  if (record.status === 'ready') {
-    // this is because image may have deactivated
-    build = await withTimeout(provider.buildImage(), STATUS_REFRESH_TIMEOUT_MS, 'sandbox buildImage');
-  } else {
-    build = await withTimeout(provider.getImageBuildStatus(), STATUS_REFRESH_TIMEOUT_MS, 'sandbox getImageBuildStatus');
+  try {
+    if (record.status === 'ready') {
+      // this is because image may have deactivated
+      build = await withTimeout(provider.buildImage(), STATUS_REFRESH_TIMEOUT_MS, 'sandbox buildImage');
+    } else {
+      build = await withTimeout(
+        provider.getImageBuildStatus(),
+        STATUS_REFRESH_TIMEOUT_MS,
+        'sandbox getImageBuildStatus',
+      );
+    }
+  } catch (error) {
+    const status_reason = daytonaAccessFailureReason(error);
+    if (status_reason === undefined) {
+      throw error;
+    }
+    const failed: SandboxStatus = {
+      status: 'failed',
+      status_reason,
+      build_metadata: record.build_metadata,
+    };
+    const updated = await store.updateSandboxStatus({ tenant_id, ...failed });
+    return updated ? sandboxStatusFromRecord(updated) : failed;
   }
   const next = toSandboxStatus(build);
   const updated = await store.updateSandboxStatus({ tenant_id, ...next });

--- a/packages/trueforge/tests/unit/apis/sandboxProviders.test.ts
+++ b/packages/trueforge/tests/unit/apis/sandboxProviders.test.ts
@@ -149,25 +149,6 @@ describe('sandboxProviders router', () => {
     expect(stored?.manifest).toEqual(putBody);
   });
 
-  it('GET marks the provider failed when Daytona denies status refresh access', async () => {
-    const { settingsRouter: router } = await createRouters();
-    expect((await router.request('/', putInit(putBody))).status).toBe(200);
-
-    mockCheckStatus.mockRejectedValue(new DaytonaError('Access denied', 403));
-    const get = await router.request('/');
-    expect(get.status).toBe(200);
-    expect(await get.json()).toEqual({
-      data: {
-        manifest: {
-          ...putBody,
-          auth: { api_key: toRedactedSecretValue(putBody.auth.api_key) },
-        },
-        status: 'failed',
-        status_reason: 'Daytona denied access to the configured API key.',
-      },
-    });
-  });
-
   it('PUT returns 422 when Daytona rejects the API key', async () => {
     mockProviderFactory.mockReturnValue(
       stubProvider({ buildImage: jest.fn().mockRejectedValue(new DaytonaError('unauthorized', 401)) }),

--- a/packages/trueforge/tests/unit/apis/sandboxProviders.test.ts
+++ b/packages/trueforge/tests/unit/apis/sandboxProviders.test.ts
@@ -149,13 +149,23 @@ describe('sandboxProviders router', () => {
     expect(stored?.manifest).toEqual(putBody);
   });
 
-  it('GET surfaces an error (500) when the status refresh throws', async () => {
+  it('GET marks the provider failed when Daytona denies status refresh access', async () => {
     const { settingsRouter: router } = await createRouters();
     expect((await router.request('/', putInit(putBody))).status).toBe(200);
 
-    mockCheckStatus.mockRejectedValue(new DaytonaError('unreachable', 500));
+    mockCheckStatus.mockRejectedValue(new DaytonaError('Access denied', 403));
     const get = await router.request('/');
-    expect(get.status).toBe(500);
+    expect(get.status).toBe(200);
+    expect(await get.json()).toEqual({
+      data: {
+        manifest: {
+          ...putBody,
+          auth: { api_key: toRedactedSecretValue(putBody.auth.api_key) },
+        },
+        status: 'failed',
+        status_reason: 'Daytona denied access to the configured API key.',
+      },
+    });
   });
 
   it('PUT returns 422 when Daytona rejects the API key', async () => {

--- a/packages/trueforge/tests/unit/sandbox/providerUtils.test.ts
+++ b/packages/trueforge/tests/unit/sandbox/providerUtils.test.ts
@@ -1,0 +1,104 @@
+let mockDaytonaProvider: {
+  buildImage: jest.Mock;
+  getImageBuildStatus: jest.Mock;
+};
+
+jest.mock('@truefoundry/trueforge-core/core', () => {
+  const actual = jest.requireActual('@truefoundry/trueforge-core/core');
+  return {
+    ...actual,
+    DaytonaSandboxProvider: jest.fn(function DaytonaSandboxProvider() {
+      return mockDaytonaProvider;
+    }),
+  };
+});
+
+import { DaytonaError } from '@daytona/sdk';
+import { createLogger } from 'winston';
+import type { ISandboxProviderStore, SandboxProviderRecord } from '../../../src/db/sandboxProviderStore';
+import type { SandboxProviderManifest } from '../../../src/schemas/sandboxProvider';
+import { checkSnapshotStatus } from '../../../src/sandbox/providerUtils';
+
+const silentLogger = createLogger({ silent: true });
+const tenantId = 'tenant-1';
+const buildMetadata = { build_ref: 'trueforge-build-1', image_uri: 'tfy.example/sandbox:1' };
+const manifest: SandboxProviderManifest = {
+  type: 'daytona',
+  auth: { api_key: 'dtn-test-secret' },
+  exec_timeout_ms: 60000,
+  auto_stop_interval_in_minutes: 5,
+  auto_archive_interval_in_minutes: 60,
+  auto_delete_interval_in_minutes: 7200,
+};
+
+function pendingRecord(): SandboxProviderRecord {
+  return {
+    tenant_id: tenantId,
+    manifest,
+    status: 'pending',
+    status_reason: null,
+    build_metadata: buildMetadata,
+    created_at: '2026-08-01T00:00:00.000Z',
+    updated_at: '2026-08-01T00:00:00.000Z',
+  };
+}
+
+function storeWithRecord({ record }: { record: SandboxProviderRecord }): ISandboxProviderStore {
+  let current: SandboxProviderRecord | undefined = record;
+  return {
+    async getSandboxProvider() {
+      return current;
+    },
+    async getSandboxProviderForUpdate() {
+      return current;
+    },
+    async upsertSandboxProvider(input) {
+      current = {
+        ...input,
+        created_at: current?.created_at ?? '2026-08-01T00:00:00.000Z',
+        updated_at: '2026-08-01T00:00:01.000Z',
+      };
+      return current;
+    },
+    async updateSandboxStatus(input) {
+      if (current === undefined) {
+        return undefined;
+      }
+      current = {
+        ...current,
+        status: input.status,
+        status_reason: input.status_reason,
+        build_metadata: input.build_metadata,
+        updated_at: '2026-08-01T00:00:01.000Z',
+      };
+      return current;
+    },
+  };
+}
+
+beforeEach(() => {
+  mockDaytonaProvider = {
+    buildImage: jest.fn(),
+    getImageBuildStatus: jest.fn(),
+  };
+});
+
+describe('checkSnapshotStatus', () => {
+  it('marks the provider failed when Daytona denies status refresh access', async () => {
+    const store = storeWithRecord({ record: pendingRecord() });
+    mockDaytonaProvider.getImageBuildStatus.mockRejectedValue(new DaytonaError('Access denied', 403));
+
+    await expect(checkSnapshotStatus({ store, tenant_id: tenantId, logger: silentLogger })).resolves.toEqual({
+      status: 'failed',
+      status_reason: 'Daytona denied access to the configured API key.',
+      build_metadata: buildMetadata,
+    });
+    await expect(store.getSandboxProvider(tenantId)).resolves.toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        status_reason: 'Daytona denied access to the configured API key.',
+        build_metadata: buildMetadata,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Closes #516.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_Y0kf4xqN34p2Ad-sPYWryg -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted sandbox status on every status refresh GET when Daytona returns auth errors, affecting settings and capability flows that depend on `checkSnapshotStatus`.
> 
> **Overview**
> **Sandbox status refresh** no longer surfaces a hard error when Daytona rejects stored credentials during GET-driven refresh (`checkSnapshotStatus`). **401/403** responses are mapped via new `daytonaAccessFailureReason` to clear `status_reason` strings, the provider is **persisted as `failed`**, and callers still get a normal 200 with that status instead of a 500.
> 
> PUT-time auth handling is unchanged; this closes the gap for **expired or permission-denied keys** on background refresh paths (settings GET, capabilities, turns). Router tests drop the expectation that refresh throws 500; unit coverage asserts 403 refresh updates the store to failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c1b1574df0a17354b30a1075bea77c8058254b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->