### PR TITLE
Fixed dockerfile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -44,10 +44,14 @@ COPY packages/trueforge-core/src/core/sandbox/scripts packages/trueforge-core/sr
 
 # ---------------------------------------------------------------------------
 # builder: install all deps (incl. dev) and build trueforge-core + server.
+# The server imports @truefoundry/trueforge-sdk (schedule dispatch), so the SDK
+# must be built before `pnpm --filter @truefoundry/trueforge build` (tsc).
 # ---------------------------------------------------------------------------
 FROM workspace AS builder
 RUN pnpm install --frozen-lockfile --offline --filter @truefoundry/trueforge...
 COPY packages/trueforge-core packages/trueforge-core
+COPY packages/trueforge-sdk packages/trueforge-sdk
+RUN pnpm --filter @truefoundry/trueforge-sdk build
 COPY packages/trueforge packages/trueforge
 RUN pnpm --filter @truefoundry/trueforge-core build && pnpm --filter @truefoundry/trueforge build
 
@@ -82,9 +86,11 @@ COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=prod-deps /app/packages/trueforge-core/node_modules ./packages/trueforge-core/node_modules
 COPY --from=prod-deps /app/packages/trueforge/node_modules ./packages/trueforge/node_modules
 
-# Built workspace dependency (@truefoundry/trueforge-core).
+# Built workspace dependencies (@truefoundry/trueforge-core + SDK).
 COPY --from=builder /app/packages/trueforge-core/package.json ./packages/trueforge-core/package.json
 COPY --from=builder /app/packages/trueforge-core/dist ./packages/trueforge-core/dist
+COPY --from=builder /app/packages/trueforge-sdk/package.json ./packages/trueforge-sdk/package.json
+COPY --from=builder /app/packages/trueforge-sdk/dist ./packages/trueforge-sdk/dist
 
 # Built server (JS). UI is copied below from the parallel frontend stage into
 # dist/_frontend — same path as the npm tarball / `pnpm build` copy step.


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docker dev build ordering and artifact copy only; no application logic or runtime behavior changes beyond fixing a broken image build.
> 
> **Overview**
> **Fixes dev Docker image builds** when `@truefoundry/trueforge` depends on the workspace `@truefoundry/trueforge-sdk` (e.g. schedule dispatch).
> 
> The **builder** stage now copies `packages/trueforge-sdk`, runs `pnpm --filter @truefoundry/trueforge-sdk build` **before** compiling trueforge-core and the server, with a comment documenting that ordering requirement.
> 
> The **runner** stage now includes the built SDK (`package.json` + `dist`) alongside trueforge-core so production `node_modules` symlinks resolve at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f1bf5287c060609e6ef4498ba55b531a121644d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->