### PR TITLE
fix: remove `x-tfy-mcp-headers` from the error message.

### DIFF
--- a/packages/trueforge-core/src/core/mcp/remoteMcpClient.ts
+++ b/packages/trueforge-core/src/core/mcp/remoteMcpClient.ts
@@ -90,7 +90,7 @@ function toConnectError(error: unknown): McpConnectionError {
     return error;
   }
   if (isAuthError(error)) {
-    return new McpConnectionError('upstream returned 401 Unauthorized (check x-tfy-mcp-headers credentials)', 401, {
+    return new McpConnectionError('upstream returned 401 Unauthorized', 401, {
       cause: error,
     });
   }


### PR DESCRIPTION
TrueForge does not have a concept of `x-tfy-mcp-headers` today.

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error string only; no connection, auth, or credential handling logic changed.
> 
> **Overview**
> When remote MCP connection fails with **401 Unauthorized**, the wrapped `McpConnectionError` message no longer tells users to check **`x-tfy-mcp-headers`** credentials. The text is now simply **`upstream returned 401 Unauthorized`**, matching current TrueForge behavior where that header concept does not exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b643241f050a87cb3b1acc98086a4712455181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->