### PR TITLE
feat: Support Vite base path for reverse proxy configuration

### DIFF
--- a/.changeset/frontend-vite-base-path.md
+++ b/.changeset/frontend-vite-base-path.md
@@ -2,4 +2,4 @@
 "@truefoundry/trueforge": patch
 ---
 
-Honor Vite `VITE_BASE_PATH` / `import.meta.env.BASE_URL` so the UI can mount under a reverse-proxy path prefix (assets, router basename, and auth/API URLs). `Dockerfile.dev` forwards the same value as a build-arg into the frontend build.
+Honor build-time `ROOT_PATH` (Vite `base` → `import.meta.env.BASE_URL`) for reverse-proxy mounts, and load Swagger UI's OpenAPI URL as a relative `openapi.json` so docs work behind a strip-prefix path.

--- a/.changeset/frontend-vite-base-path.md
+++ b/.changeset/frontend-vite-base-path.md
@@ -2,4 +2,4 @@
 "@truefoundry/trueforge": patch
 ---
 
-Honor build-time `ROOT_PATH` (Vite `base` → `import.meta.env.BASE_URL`) for reverse-proxy mounts, and load Swagger UI's OpenAPI URL as a relative `openapi.json` so docs work behind a strip-prefix path.
+Honor `ROOT_PATH` for reverse-proxy mounts: frontend Vite base (Dockerfile.dev build-arg), runtime Swagger OpenAPI URL, and OIDC redirect defaults.

--- a/.changeset/frontend-vite-base-path.md
+++ b/.changeset/frontend-vite-base-path.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": patch
+---
+
+Honor Vite `VITE_BASE_PATH` / `import.meta.env.BASE_URL` so the UI can mount under a reverse-proxy path prefix (assets, router basename, and auth/API URLs). `Dockerfile.dev` forwards the same value as a build-arg into the frontend build.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -61,8 +61,8 @@ RUN pnpm --filter @truefoundry/trueforge-core build && pnpm --filter @truefoundr
 # tsc needs, so this stage never compiles SDK JavaScript.
 # ---------------------------------------------------------------------------
 FROM workspace AS frontend-builder
-ARG VITE_BASE_PATH=/
-ENV VITE_BASE_PATH=$VITE_BASE_PATH
+ARG ROOT_PATH=/
+ENV ROOT_PATH=$ROOT_PATH
 RUN pnpm install --frozen-lockfile --offline --filter frontend...
 COPY packages/trueforge-sdk packages/trueforge-sdk
 COPY packages/trueforge-ui packages/trueforge-ui

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -61,6 +61,8 @@ RUN pnpm --filter @truefoundry/trueforge-core build && pnpm --filter @truefoundr
 # tsc needs, so this stage never compiles SDK JavaScript.
 # ---------------------------------------------------------------------------
 FROM workspace AS frontend-builder
+ARG VITE_BASE_PATH=/
+ENV VITE_BASE_PATH=$VITE_BASE_PATH
 RUN pnpm install --frozen-lockfile --offline --filter frontend...
 COPY packages/trueforge-sdk packages/trueforge-sdk
 COPY packages/trueforge-ui packages/trueforge-ui

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -13,9 +13,12 @@ import { parseAuthErrorReason, shouldShowAuthErrorScreen, stripAuthErrorSearch }
 import { GetStartedScreen } from './GetStartedScreen';
 import { LogoutButton } from './LogoutButton';
 
+const baseUrl = import.meta.env?.BASE_URL ?? '/';
+const routerBasename = baseUrl === '/' ? '' : baseUrl.replace(/\/$/, '');
+
 /** Shared cookie/OIDC fetch for boot helpers and `<TrueForgeUI server />`. */
 const authAwareFetch = createAuthAwareFetch();
-const bootClient = createTrueForgeClient({ fetch: authAwareFetch });
+const bootClient = createTrueForgeClient({ baseUrl, fetch: authAwareFetch });
 
 type BootState =
   | { status: 'loading' }
@@ -161,9 +164,10 @@ export function App() {
   return (
     <div className="app-root">
       <TrueForgeUI
-        server={{ type: 'trueforge', baseUrl: '/', fetch: authAwareFetch }}
+        server={{ type: 'trueforge', baseUrl, fetch: authAwareFetch }}
         layout="sidebar"
         withRouter
+        {...(routerBasename === '' ? {} : { routes: { basename: routerBasename } })}
         agentConfig={{
           mode: 'AgentLibraryWithComposer',
           defaultAgentSpec: boot.defaultAgentSpec,

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -13,7 +13,7 @@ import { parseAuthErrorReason, shouldShowAuthErrorScreen, stripAuthErrorSearch }
 import { GetStartedScreen } from './GetStartedScreen';
 import { LogoutButton } from './LogoutButton';
 
-const baseUrl = import.meta.env?.BASE_URL ?? '/';
+const baseUrl = import.meta.env.BASE_URL || '/';
 const routerBasename = baseUrl === '/' ? '' : baseUrl.replace(/\/$/, '');
 
 /** Shared cookie/OIDC fetch for boot helpers and `<TrueForgeUI server />`. */

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -12,8 +12,9 @@ import { probeSession, type SessionState } from './authSession';
 import { parseAuthErrorReason, shouldShowAuthErrorScreen, stripAuthErrorSearch } from './authStatusSearch';
 import { GetStartedScreen } from './GetStartedScreen';
 import { LogoutButton } from './LogoutButton';
+import { viteBaseUrl } from './viteBaseUrl';
 
-const baseUrl = import.meta.env.BASE_URL || '/';
+const baseUrl = viteBaseUrl();
 const routerBasename = baseUrl === '/' ? '' : baseUrl.replace(/\/$/, '');
 
 /** Shared cookie/OIDC fetch for boot helpers and `<TrueForgeUI server />`. */

--- a/packages/frontend/src/authFetch.ts
+++ b/packages/frontend/src/authFetch.ts
@@ -3,11 +3,13 @@
  * On any HTTP 401, redirect to OIDC login (session required).
  */
 
+const basePrefix = (import.meta.env?.BASE_URL ?? '/').replace(/\/$/, '');
+
 /** Browser entry for OIDC login (not available as an SDK method). */
-export const AUTH_LOGIN_HREF = '/api/v1/auth/login';
+export const AUTH_LOGIN_HREF = `${basePrefix}/api/v1/auth/login`;
 
 /** Clears the local session cookie (not available as an SDK method). */
-export const AUTH_LOGOUT_HREF = '/api/v1/auth/logout';
+export const AUTH_LOGOUT_HREF = `${basePrefix}/api/v1/auth/logout`;
 
 export function createAuthAwareFetch(baseFetch: typeof fetch = globalThis.fetch.bind(globalThis)): typeof fetch {
   let redirecting = false;

--- a/packages/frontend/src/authFetch.ts
+++ b/packages/frontend/src/authFetch.ts
@@ -2,8 +2,9 @@
  * Browser auth entry points. Login and logout are not SDK methods (cookie session).
  * On any HTTP 401, redirect to OIDC login (session required).
  */
+import { viteBaseUrl } from './viteBaseUrl';
 
-const basePrefix = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+const basePrefix = viteBaseUrl().replace(/\/$/, '');
 
 /** Browser entry for OIDC login (not available as an SDK method). */
 export const AUTH_LOGIN_HREF = `${basePrefix}/api/v1/auth/login`;

--- a/packages/frontend/src/authFetch.ts
+++ b/packages/frontend/src/authFetch.ts
@@ -3,7 +3,7 @@
  * On any HTTP 401, redirect to OIDC login (session required).
  */
 
-const basePrefix = (import.meta.env?.BASE_URL ?? '/').replace(/\/$/, '');
+const basePrefix = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
 
 /** Browser entry for OIDC login (not available as an SDK method). */
 export const AUTH_LOGIN_HREF = `${basePrefix}/api/v1/auth/login`;

--- a/packages/frontend/src/authSession.ts
+++ b/packages/frontend/src/authSession.ts
@@ -5,7 +5,7 @@
 import { TrueForge as TrueForgeClient, type TrueForge } from '@truefoundry/trueforge-sdk';
 import { AUTH_LOGOUT_HREF, createAuthAwareFetch } from './authFetch';
 
-const DEFAULT_BASE_URL = '/';
+const DEFAULT_BASE_URL = import.meta.env?.BASE_URL ?? '/';
 
 /** Authenticated API client — 401 redirects to OIDC login. */
 const authClient = new TrueForgeClient({

--- a/packages/frontend/src/authSession.ts
+++ b/packages/frontend/src/authSession.ts
@@ -4,8 +4,9 @@
  */
 import { TrueForge as TrueForgeClient, type TrueForge } from '@truefoundry/trueforge-sdk';
 import { AUTH_LOGOUT_HREF, createAuthAwareFetch } from './authFetch';
+import { viteBaseUrl } from './viteBaseUrl';
 
-const DEFAULT_BASE_URL = import.meta.env.BASE_URL || '/';
+const DEFAULT_BASE_URL = viteBaseUrl();
 
 /** Authenticated API client — 401 redirects to OIDC login. */
 const authClient = new TrueForgeClient({

--- a/packages/frontend/src/authSession.ts
+++ b/packages/frontend/src/authSession.ts
@@ -5,7 +5,7 @@
 import { TrueForge as TrueForgeClient, type TrueForge } from '@truefoundry/trueforge-sdk';
 import { AUTH_LOGOUT_HREF, createAuthAwareFetch } from './authFetch';
 
-const DEFAULT_BASE_URL = import.meta.env?.BASE_URL ?? '/';
+const DEFAULT_BASE_URL = import.meta.env.BASE_URL || '/';
 
 /** Authenticated API client — 401 redirects to OIDC login. */
 const authClient = new TrueForgeClient({

--- a/packages/frontend/src/viteBaseUrl.ts
+++ b/packages/frontend/src/viteBaseUrl.ts
@@ -1,0 +1,9 @@
+/** Vite injects `import.meta.env`; node --test does not. */
+export function viteBaseUrl(): string {
+  const env: unknown = Reflect.get(import.meta, 'env');
+  if (typeof env !== 'object' || env === null) {
+    return '/';
+  }
+  const baseUrl: unknown = Reflect.get(env, 'BASE_URL');
+  return typeof baseUrl === 'string' && baseUrl.length > 0 ? baseUrl : '/';
+}

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -16,6 +16,10 @@ if (!Number.isInteger(PORT)) {
   throw new Error(`FRONTEND_PORT must be an integer, got "${process.env.FRONTEND_PORT}"`);
 }
 
+/** Subpath mount, e.g. `/trueforge/`. Default `/`. */
+const BASE = process.env.VITE_BASE_PATH || '/';
+const BASE_PREFIX = BASE === '/' ? '' : BASE.replace(/\/$/, '');
+
 const apiProxy: ProxyOptions = {
   target: SERVER,
   changeOrigin: true,
@@ -28,9 +32,11 @@ const apiProxy: ProxyOptions = {
       }
     });
   },
+  ...(BASE_PREFIX === '' ? {} : { rewrite: (p: string) => p.slice(BASE_PREFIX.length) }),
 };
 
 export default defineConfig({
+  base: BASE,
   plugins: [
     react(),
     monacoEditorPlugin({
@@ -61,8 +67,8 @@ export default defineConfig({
     strictPort: true,
     // Proxy both public SDK routes and internal UI-only routes to the Harness.
     proxy: {
-      '/api': apiProxy,
-      '/internal': apiProxy,
+      [`${BASE_PREFIX}/api`]: apiProxy,
+      [`${BASE_PREFIX}/internal`]: apiProxy,
     },
   },
 });

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -16,8 +16,8 @@ if (!Number.isInteger(PORT)) {
   throw new Error(`FRONTEND_PORT must be an integer, got "${process.env.FRONTEND_PORT}"`);
 }
 
-/** Subpath mount, e.g. `/trueforge/`. Default `/`. */
-const BASE = process.env.VITE_BASE_PATH || '/';
+/** Reverse-proxy mount prefix, e.g. `/trueforge/`. Default `/`. */
+const BASE = process.env.ROOT_PATH || '/';
 const BASE_PREFIX = BASE === '/' ? '' : BASE.replace(/\/$/, '');
 
 const apiProxy: ProxyOptions = {

--- a/packages/trueforge/.env.example
+++ b/packages/trueforge/.env.example
@@ -95,8 +95,13 @@ REDIS_URL=redis://localhost:6379
 # TURN_SUBSCRIBE_TIMEOUT_MS=600000
 
 ## Used when STANDALONE=false (ignored in standalone). Public origin of the
-## fixed callback routes for server OIDC and MCP OAuth/DCR. 
+## fixed callback routes for server OIDC and MCP OAuth/DCR.
+## When mounted under a path prefix, include it (e.g. https://host/trueforge).
 # PUBLIC_BASE_URL=http://localhost:3000
+
+## External path prefix when reverse-proxied (e.g. /trueforge). Empty = site root.
+## Must match the frontend ROOT_PATH build-arg and the proxy strip prefix.
+# ROOT_PATH=/trueforge
 
 ## Base URL the dedicated controller process (dist/controller-main.js) uses to
 ## reach the server API. Only used when running the controller as its own process

--- a/packages/trueforge/src/apis/auth.ts
+++ b/packages/trueforge/src/apis/auth.ts
@@ -8,12 +8,13 @@ import { resolveUserContext } from '../auth/identity';
 import { authMiddleware, resolveAuthUser } from '../auth/middleware';
 import { buildLoginAuthorization, exchangeAuthorizationCode, getOidcVerify } from '../auth/oidc';
 import { safeReturnTo } from '../auth/safeReturnTo';
+import configuration from '../config';
 import { authLoginRoute, authLogoutRoute, meRoute, oAuthCallbackRoute } from '../routes/authRoutes';
 import type { GetMeResponse } from '../schemas/auth';
 
-/** Login / OIDC failures land on `/?error=<reason>`. */
+/** Login / OIDC failures land on `{ROOT_PATH}/?error=<reason>`. */
 function oauthErrorRedirect(reason: string): string {
-  return `/?error=${encodeURIComponent(reason)}`;
+  return `${configuration.ROOT_PATH}/?error=${encodeURIComponent(reason)}`;
 }
 
 /**
@@ -46,7 +47,7 @@ export function createAuthRouter(params: { oidcClient: Configuration | undefined
   router.openapi(authLoginRoute, async c => {
     // TODO: remove this checks once the middleware is implemented
     if (!params.oidcClient) {
-      return c.redirect('/', 302);
+      return c.redirect(configuration.ROOT_PATH || '/', 302);
     }
 
     try {
@@ -64,7 +65,7 @@ export function createAuthRouter(params: { oidcClient: Configuration | undefined
 
   router.openapi(oAuthCallbackRoute, async c => {
     if (!params.oidcClient) {
-      return c.redirect('/', 302);
+      return c.redirect(configuration.ROOT_PATH || '/', 302);
     }
 
     const query = c.req.valid('query');
@@ -73,7 +74,10 @@ export function createAuthRouter(params: { oidcClient: Configuration | undefined
 
     if (pending?.state !== query.state || query.error || !query.code) {
       // If already authenticated, redirect home instead of showing an error.
-      const soft = await redirectIfAlreadyAuthenticated({ context: c, whenAuthenticated: '/' });
+      const soft = await redirectIfAlreadyAuthenticated({
+        context: c,
+        whenAuthenticated: configuration.ROOT_PATH || '/',
+      });
       if (soft) {
         return soft;
       }

--- a/packages/trueforge/src/app.ts
+++ b/packages/trueforge/src/app.ts
@@ -378,7 +378,9 @@ export function createServerApp<TTransaction>(deps: ServerDeps<TTransaction>) {
     ),
   );
 
-  app.get('/api/v1/docs', swaggerUI({ url: '/api/v1/openapi.json' }));
+  // Relative so a strip-prefix proxy (e.g. /trueforge) still loads the spec from
+  // the same mount; an absolute `/api/v1/openapi.json` would miss the prefix.
+  app.get('/api/v1/docs', swaggerUI({ url: 'openapi.json' }));
   app.get('/api/v1/openapi.json', c => c.json(buildOpenApiDocument(app, { authEnabled })));
 
   app.notFound(routeNotFound);

--- a/packages/trueforge/src/app.ts
+++ b/packages/trueforge/src/app.ts
@@ -378,9 +378,7 @@ export function createServerApp<TTransaction>(deps: ServerDeps<TTransaction>) {
     ),
   );
 
-  // Relative so a strip-prefix proxy (e.g. /trueforge) still loads the spec from
-  // the same mount; an absolute `/api/v1/openapi.json` would miss the prefix.
-  app.get('/api/v1/docs', swaggerUI({ url: 'openapi.json' }));
+  app.get('/api/v1/docs', swaggerUI({ url: `${configuration.ROOT_PATH}/api/v1/openapi.json` }));
   app.get('/api/v1/openapi.json', c => c.json(buildOpenApiDocument(app, { authEnabled })));
 
   app.notFound(routeNotFound);

--- a/packages/trueforge/src/auth/safeReturnTo.ts
+++ b/packages/trueforge/src/auth/safeReturnTo.ts
@@ -4,16 +4,18 @@
  * - not `//…` (open redirect)
  * - not `/api` or `/api/…`
  */
+import configuration from '../config';
+
 const SAFE_RETURN_TO = /^\/(?!\/|api(?:\/|$)).*/;
 
 function isSafeReturnTo(value: string): boolean {
   return SAFE_RETURN_TO.test(value);
 }
 
-/** Same-origin path, or `/` when missing or unsafe. */
+/** Same-origin path, or `ROOT_PATH` / `/` when missing or unsafe. */
 export function safeReturnTo(value: string | undefined): string {
   if (value && isSafeReturnTo(value)) {
     return value;
   }
-  return '/';
+  return configuration.ROOT_PATH || '/';
 }

--- a/packages/trueforge/src/config.ts
+++ b/packages/trueforge/src/config.ts
@@ -433,6 +433,11 @@ export interface SharedServerConfiguration {
    */
   PUBLIC_BASE_URL: string;
   /**
+   * External path prefix when reverse-proxied (e.g. `/trueforge`). Empty when
+   * mounted at the site root. Env: `ROOT_PATH`.
+   */
+  ROOT_PATH: string;
+  /**
    * Base URL the controller uses to reach the server's HTTP API when it runs as its
    * own process (`STANDALONE=false`, `dist/controller-main.js`). The control loops call
    * the server over HTTP. Env: `SERVER_URL`. Default: `http://localhost:$PORT`,
@@ -617,6 +622,7 @@ const shared: SharedServerConfiguration = {
     defaultValue: 500,
   }),
   PUBLIC_BASE_URL: getEnv('PUBLIC_BASE_URL', { defaultValue: '' }) ?? '',
+  ROOT_PATH: getEnv('ROOT_PATH', { defaultValue: '' }) ?? '',
   SERVER_URL:
     getEnv('SERVER_URL', { defaultValue: `http://localhost:${String(port)}` }) ?? `http://localhost:${String(port)}`,
   TRUEFOUNDRY_SERVICEFOUNDRY_SERVER_URL: getEnv('TRUEFOUNDRY_SERVICEFOUNDRY_SERVER_URL', { required: false }),

--- a/packages/trueforge/tests/unit/apis/auth.test.ts
+++ b/packages/trueforge/tests/unit/apis/auth.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../../src/config', () => {
   const config = {
     STANDALONE: false as const,
     PUBLIC_BASE_URL: 'https://harness.example.com',
+    ROOT_PATH: '',
     NODE_ENV: 'development',
     OIDC,
     PORT: 8790,


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OIDC redirect and return URLs; a mismatched `ROOT_PATH` between build, proxy, and server would break login and routing.
> 
> **Overview**
> Adds **`ROOT_PATH`** so TrueForge can run behind a reverse proxy at a subpath (e.g. `/trueforge`) instead of only at the site root.
> 
> The **frontend** reads Vite’s `BASE_URL` (set from `ROOT_PATH` in `vite.config.ts` and `Dockerfile.dev`), uses it for the SDK/`TrueForgeUI` `baseUrl`, React Router `basename`, and login/logout links. Dev proxy keys and path rewriting follow the same prefix.
> 
> The **server** exposes `ROOT_PATH` in config and uses it for OIDC/auth redirects, default `return_to` in `safeReturnTo`, and the Swagger UI OpenAPI URL. **`.env.example`** documents aligning `ROOT_PATH`, `PUBLIC_BASE_URL`, and the frontend build arg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5268c056f2bc7ebea5e0506323d9dab954f19d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->