### PR TITLE
Add optional ARG and ENV for VITE_BASE_PATH in Dockerfile.dev to support UI public path configuration.

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -61,6 +61,9 @@ RUN pnpm --filter @truefoundry/trueforge-core build && pnpm --filter @truefoundr
 # tsc needs, so this stage never compiles SDK JavaScript.
 # ---------------------------------------------------------------------------
 FROM workspace AS frontend-builder
+# Optional UI public path for reverse-proxy mounts (e.g. /trueforge). See VITE_BASE_PATH.
+ARG VITE_BASE_PATH=/
+ENV VITE_BASE_PATH=$VITE_BASE_PATH
 RUN pnpm install --frozen-lockfile --offline --filter frontend...
 COPY packages/trueforge-sdk packages/trueforge-sdk
 COPY packages/trueforge-ui packages/trueforge-ui


### PR DESCRIPTION
…

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docker build wiring only; default behavior is unchanged and no runtime server or auth logic is modified in this diff.
> 
> **Overview**
> **Dev Docker images** can now set the UI’s public path at build time when the app is served behind a reverse proxy on a subpath (e.g. `/trueforge`).
> 
> The `frontend-builder` stage in `Dockerfile.dev` adds `ARG VITE_BASE_PATH=/` and `ENV VITE_BASE_PATH=$VITE_BASE_PATH` so `pnpm --filter frontend build` sees the same variable the Vite config already reads locally. Default stays `/`; override with `docker build --build-arg VITE_BASE_PATH=/your-path`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1043b701f5e5401db7d591afd48f7557874cff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->