### PR TITLE
Share VITE_BASE_PATH with API and auth URLs

### DIFF
--- a/.changeset/frontend-base-path-env.md
+++ b/.changeset/frontend-base-path-env.md
@@ -2,4 +2,4 @@
 "@truefoundry/trueforge": patch
 ---
 
-Make the frontend UI public path configurable via optional `VITE_BASE_PATH` (defaults to `/`), keep API calls at `/`, and return OIDC login/logout to the UI base.
+Make optional `VITE_BASE_PATH` apply to both the UI public path and API/auth URLs (defaults to `/`).

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -12,13 +12,12 @@ import { probeSession, type SessionState } from './authSession';
 import { parseAuthErrorReason, shouldShowAuthErrorScreen, stripAuthErrorSearch } from './authStatusSearch';
 import { GetStartedScreen } from './GetStartedScreen';
 import { LogoutButton } from './LogoutButton';
-import { uiRouterBasename } from './publicPath';
+import { API_BASE_URL, uiRouterBasename } from './publicPath';
 
 /** Shared cookie/OIDC fetch for boot helpers and `<TrueForgeUI server />`. */
 const authAwareFetch = createAuthAwareFetch();
-// API stays at site root (`/api/...`). Caddy strips the UI public path before Harness;
-// only assets + React Router use `VITE_BASE_PATH` / `import.meta.env.BASE_URL`.
-const bootClient = createTrueForgeClient({ fetch: authAwareFetch });
+// UI + API share `VITE_BASE_PATH` / `BASE_URL`; Caddy strips it before Harness.
+const bootClient = createTrueForgeClient({ baseUrl: API_BASE_URL, fetch: authAwareFetch });
 const routerBasename = uiRouterBasename();
 
 type BootState =
@@ -165,7 +164,7 @@ export function App() {
   return (
     <div className="app-root">
       <TrueForgeUI
-        server={{ type: 'trueforge', baseUrl: '/', fetch: authAwareFetch }}
+        server={{ type: 'trueforge', baseUrl: API_BASE_URL, fetch: authAwareFetch }}
         layout="sidebar"
         withRouter
         {...(routerBasename ? { routes: { basename: routerBasename } } : {})}

--- a/packages/frontend/src/authFetch.ts
+++ b/packages/frontend/src/authFetch.ts
@@ -2,17 +2,17 @@
  * Browser auth entry points. Login and logout are not SDK methods (cookie session).
  * On any HTTP 401, redirect to OIDC login (session required).
  *
- * API paths stay at `/api/...` even when the UI is mounted under a public path
- * (Caddy strips `/trueforge` before Harness). Pass `return_to` so post-login
- * lands back under that UI path.
+ * Auth URLs share `VITE_BASE_PATH` with the UI (e.g. `/trueforge/api/v1/auth/...`).
+ * Caddy strips that prefix before Harness. Pass `return_to` so post-login lands
+ * back under the UI path.
  */
-import { UI_BASE_PATH } from './publicPath';
+import { apiPath, UI_BASE_PATH } from './publicPath';
 
 /** Browser entry for OIDC login (not available as an SDK method). */
-export const AUTH_LOGIN_HREF = '/api/v1/auth/login';
+export const AUTH_LOGIN_HREF = apiPath('/api/v1/auth/login');
 
 /** Clears the local session cookie (not available as an SDK method). */
-export const AUTH_LOGOUT_HREF = '/api/v1/auth/logout';
+export const AUTH_LOGOUT_HREF = apiPath('/api/v1/auth/logout');
 
 /** Login URL with a same-origin `return_to` (defaults to the UI home). */
 export function buildLoginHref(returnTo: string = UI_BASE_PATH): string {

--- a/packages/frontend/src/authSession.ts
+++ b/packages/frontend/src/authSession.ts
@@ -1,15 +1,14 @@
 /**
- * Session helpers: SDK `auth.me()` plus POST `/api/v1/auth/logout`.
- * Login is not on the SDK (browser redirect to `/api/v1/auth/login`).
+ * Session helpers: SDK `auth.me()` plus POST logout under the public API base.
+ * Login is not on the SDK (browser redirect to the login href).
  */
 import { TrueForge as TrueForgeClient, type TrueForge } from '@truefoundry/trueforge-sdk';
 import { AUTH_LOGOUT_HREF, createAuthAwareFetch } from './authFetch';
-
-const DEFAULT_BASE_URL = '/';
+import { API_BASE_URL } from './publicPath';
 
 /** Authenticated API client — 401 redirects to OIDC login. */
 const authClient = new TrueForgeClient({
-  baseUrl: DEFAULT_BASE_URL,
+  baseUrl: API_BASE_URL,
   fetch: createAuthAwareFetch(),
 });
 
@@ -18,7 +17,7 @@ const authClient = new TrueForgeClient({
  * redirect on 401, so the welcome gate can observe the unauthenticated state.
  */
 const probeClient = new TrueForgeClient({
-  baseUrl: DEFAULT_BASE_URL,
+  baseUrl: API_BASE_URL,
   fetch: globalThis.fetch.bind(globalThis),
 });
 

--- a/packages/frontend/src/publicPath.ts
+++ b/packages/frontend/src/publicPath.ts
@@ -1,7 +1,8 @@
 /**
- * UI public path from Vite `base` (`VITE_BASE_PATH`). Always `/` or a path with a
- * trailing slash (e.g. `/trueforge/`). Distinct from the API origin: with a
- * reverse proxy that strips this prefix, API calls stay at `/api/...`.
+ * Public path from Vite `base` (`VITE_BASE_PATH`). Always `/` or a path with a
+ * trailing slash (e.g. `/trueforge/`). UI assets, React Router, and API/auth
+ * share this prefix; Caddy strips it before Harness so the server still sees
+ * `/` and `/api/...`.
  */
 export const UI_BASE_PATH =
   typeof import.meta.env === 'object' &&
@@ -10,7 +11,19 @@ export const UI_BASE_PATH =
     ? import.meta.env.BASE_URL
     : '/';
 
+/** SDK `baseUrl` — same public prefix as the UI. */
+export const API_BASE_URL = UI_BASE_PATH;
+
 /** React Router basename: no trailing slash; `undefined` when serving from `/`. */
 export function uiRouterBasename(): string | undefined {
   return UI_BASE_PATH.length > 1 ? UI_BASE_PATH.replace(/\/$/, '') : undefined;
+}
+
+/** Join the public base with an absolute app path (e.g. `/api/v1/auth/login`). */
+export function apiPath(suffix: string): string {
+  const path = suffix.startsWith('/') ? suffix : `/${suffix}`;
+  if (UI_BASE_PATH === '/') {
+    return path;
+  }
+  return `${UI_BASE_PATH.replace(/\/$/, '')}${path}`;
 }

--- a/packages/frontend/tests/publicPath.test.ts
+++ b/packages/frontend/tests/publicPath.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { API_BASE_URL, apiPath, UI_BASE_PATH, uiRouterBasename } from '../src/publicPath';
+
+describe('publicPath (default Vite BASE_URL=/)', () => {
+  it('shares one public prefix for UI and API', () => {
+    assert.equal(UI_BASE_PATH, '/');
+    assert.equal(API_BASE_URL, UI_BASE_PATH);
+    assert.equal(uiRouterBasename(), undefined);
+  });
+
+  it('apiPath leaves root-absolute API paths unchanged', () => {
+    assert.equal(apiPath('/api/v1/auth/login'), '/api/v1/auth/login');
+    assert.equal(apiPath('api/v1/auth/logout'), '/api/v1/auth/logout');
+  });
+});

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -42,6 +42,29 @@ const apiProxy: ProxyOptions = {
   },
 };
 
+/** When UI+API share a public path, strip it so Harness still sees `/api` / `/internal`. */
+const prefixedApiProxy: ProxyOptions =
+  BASE === '/'
+    ? apiProxy
+    : {
+        ...apiProxy,
+        rewrite: requestPath => requestPath.slice(BASE.length - 1),
+      };
+
+const proxy: Record<string, ProxyOptions> =
+  BASE === '/'
+    ? {
+        '/api': apiProxy,
+        '/internal': apiProxy,
+      }
+    : {
+        // Prefer the prefixed keys so `/trueforge/api` is not matched as a bare `/api` miss.
+        [`${BASE}api`]: prefixedApiProxy,
+        [`${BASE}internal`]: prefixedApiProxy,
+        '/api': apiProxy,
+        '/internal': apiProxy,
+      };
+
 export default defineConfig({
   base: BASE,
   plugins: [
@@ -73,9 +96,6 @@ export default defineConfig({
     // Fail if FRONTEND_PORT is taken — never silently hop to 3001/3010/etc.
     strictPort: true,
     // Proxy both public SDK routes and internal UI-only routes to the Harness.
-    proxy: {
-      '/api': apiProxy,
-      '/internal': apiProxy,
-    },
+    proxy,
   },
 });


### PR DESCRIPTION
## Summary
- Use the same optional `VITE_BASE_PATH` for UI assets/router and API/auth (`/trueforge/api/...` when set).
- Wire `App`, `authSession`, and `authFetch` through `API_BASE_URL` / `apiPath`.
- Vite dev proxy strips the public prefix for `/api` and `/internal` so local Harness still sees root paths.

## Test plan
- [ ] `pnpm --filter frontend test` and `pnpm --filter frontend typecheck`
- [ ] Unset `VITE_BASE_PATH`: UI and API stay at `/` and `/api/...`
- [ ] Build/run with `VITE_BASE_PATH=/trueforge`: DevTools shows `/trueforge/api/...` and assets under `/trueforge/assets/...`
- [ ] Behind Caddy strip, Harness still receives `/api/...`
- [ ] Login/logout hrefs include the public prefix when set


Made with [Cursor](https://cursor.com)