### PR TITLE
feat: Pass caller TF access token as Bearer for tfy mcp invoke

### DIFF
--- a/.changeset/tf-mcp-gateway-bearer.md
+++ b/.changeset/tf-mcp-gateway-bearer.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": patch
+---
+
+Pass the caller's TrueFoundry access token as Bearer when invoking gateway-managed MCP (tools/list and turns).

--- a/.changeset/tf-mcp-gateway-bearer.md
+++ b/.changeset/tf-mcp-gateway-bearer.md
@@ -2,4 +2,4 @@
 "@truefoundry/trueforge": patch
 ---
 
-Pass the caller's TrueFoundry access token as Bearer when invoking gateway-managed MCP (tools/list and turns).
+TrueFoundry MCP invoke headers are owned by the MCP store (`resolveInvokeHeaders`), so gateway Bearer comes from the request-scoped store rather than being threaded through turn/tools APIs.

--- a/packages/trueforge/src/apis/mcpServers.ts
+++ b/packages/trueforge/src/apis/mcpServers.ts
@@ -3,6 +3,7 @@ import { extractErrorLogFields, isAuthRequired, McpConnectionError, RemoteMCP } 
 import type { Context } from 'hono';
 import type { Logger } from 'winston';
 import type { ResolveUserContext } from '../auth/identity';
+import { readAccessToken } from '../auth/middleware';
 import { safeReturnTo } from '../auth/safeReturnTo';
 import configuration from '../config';
 import {
@@ -354,7 +355,8 @@ export function createMcpServersRouter<TTransaction>(deps: McpServersRouterDeps<
   const listToolsHandler: RouteHandler<typeof listMcpServerToolsRoute> = async c => {
     const { name } = c.req.valid('param');
     const userRef = deps.resolveUserContext(c).userRef;
-    // Same url + header resolution as turn execution (DCR via resolveMcpAuth, header/no-auth static).
+    const accessToken = readAccessToken(c);
+    // Same url + header resolution as turn execution (TF gateway Bearer, DCR, or static headers).
     const connection = await getMcpConnection({
       tenant_id: TENANT_ID,
       name,
@@ -362,6 +364,7 @@ export function createMcpServersRouter<TTransaction>(deps: McpServersRouterDeps<
       tokenStore: deps.tokenStore,
       clientName: configuration.MCP_DCR_OAUTH_CLIENT_NAME,
       userRef,
+      ...(accessToken !== undefined ? { accessToken } : {}),
     });
     if (connection === undefined) {
       return c.json({ error: { message: `MCP server not found: ${name}` } }, 404);

--- a/packages/trueforge/src/apis/mcpServers.ts
+++ b/packages/trueforge/src/apis/mcpServers.ts
@@ -3,7 +3,6 @@ import { extractErrorLogFields, isAuthRequired, McpConnectionError, RemoteMCP } 
 import type { Context } from 'hono';
 import type { Logger } from 'winston';
 import type { ResolveUserContext } from '../auth/identity';
-import { readAccessToken } from '../auth/middleware';
 import { safeReturnTo } from '../auth/safeReturnTo';
 import configuration from '../config';
 import {
@@ -355,8 +354,7 @@ export function createMcpServersRouter<TTransaction>(deps: McpServersRouterDeps<
   const listToolsHandler: RouteHandler<typeof listMcpServerToolsRoute> = async c => {
     const { name } = c.req.valid('param');
     const userRef = deps.resolveUserContext(c).userRef;
-    const accessToken = readAccessToken(c);
-    // Same url + header resolution as turn execution (TF gateway Bearer, DCR, or static headers).
+    // Same url + header resolution as turn execution (store Bearer, DCR, or static headers).
     const connection = await getMcpConnection({
       tenant_id: TENANT_ID,
       name,
@@ -364,7 +362,6 @@ export function createMcpServersRouter<TTransaction>(deps: McpServersRouterDeps<
       tokenStore: deps.tokenStore,
       clientName: configuration.MCP_DCR_OAUTH_CLIENT_NAME,
       userRef,
-      ...(accessToken !== undefined ? { accessToken } : {}),
     });
     if (connection === undefined) {
       return c.json({ error: { message: `MCP server not found: ${name}` } }, 404);

--- a/packages/trueforge/src/apis/turns.ts
+++ b/packages/trueforge/src/apis/turns.ts
@@ -129,8 +129,6 @@ export type BeginTurnExecutionDeps = Pick<
 > & {
   modelProviderStore: IModelProviderStore;
   mcpServerStore: IMcpServerStore;
-  /** Caller TF token for gateway MCP invoke; omitted for scheduler / no-request paths. */
-  accessToken?: string;
 };
 
 /**
@@ -375,8 +373,10 @@ export async function beginTurnExecution(params: {
   previous_turn_id: string | undefined;
   userRef: string;
   deps: BeginTurnExecutionDeps;
+  /** Caller TF token for gateway MCP invoke; omitted for scheduler / no-request paths. */
+  accessToken?: string;
 }): Promise<{ turn: TurnHandle; drainInput: TurnEventDrainInput }> {
-  const { session, input, previous_turn_id: previousTurnId, userRef, deps } = params;
+  const { session, input, previous_turn_id: previousTurnId, userRef, deps, accessToken } = params;
   const sessionId = session.session_id;
 
   const abortController = new AbortController();
@@ -391,7 +391,7 @@ export async function beginTurnExecution(params: {
     signal: abortController.signal,
     userRef,
     sessionId,
-    ...(deps.accessToken !== undefined ? { accessToken: deps.accessToken } : {}),
+    ...(accessToken !== undefined ? { accessToken } : {}),
   });
 
   // First turn only: derive the title from the first user message. The store
@@ -447,6 +447,7 @@ export async function startTurnInProcess(params: {
   previous_turn_id: string | undefined;
   userRef: string;
   deps: BeginTurnExecutionDeps;
+  accessToken?: string;
 }): Promise<TurnHandle> {
   const { turn, drainInput } = await beginTurnExecution(params);
 
@@ -683,8 +684,8 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
         ...deps,
         modelProviderStore: deps.resolveModelProviderStore(c),
         mcpServerStore: deps.resolveMcpServerStore(c),
-        ...(accessToken !== undefined ? { accessToken } : {}),
       },
+      ...(accessToken !== undefined ? { accessToken } : {}),
     };
 
     try {

--- a/packages/trueforge/src/apis/turns.ts
+++ b/packages/trueforge/src/apis/turns.ts
@@ -30,6 +30,7 @@ import { HTTPException } from 'hono/http-exception';
 import { streamSSE } from 'hono/streaming';
 import type { Logger } from 'winston';
 import type { ResolveUserContext, UserContext } from '../auth/identity';
+import { readAccessToken } from '../auth/middleware';
 import configuration from '../config';
 import type { IAgentStore } from '../db/agentStore';
 import type { IMcpServerStore } from '../db/mcpServerStore';
@@ -128,6 +129,8 @@ export type BeginTurnExecutionDeps = Pick<
 > & {
   modelProviderStore: IModelProviderStore;
   mcpServerStore: IMcpServerStore;
+  /** Caller TF token for gateway MCP invoke; omitted for scheduler / no-request paths. */
+  accessToken?: string;
 };
 
 /**
@@ -145,6 +148,7 @@ function createTurnResolver(deps: {
   signal: AbortSignal;
   userRef: string;
   sessionId: string;
+  accessToken?: string;
 }): TurnResourceResolver {
   const {
     mcpServerStore,
@@ -157,6 +161,7 @@ function createTurnResolver(deps: {
     signal,
     userRef,
     sessionId,
+    accessToken,
   } = deps;
   return new TurnResourceResolver({
     llm: async name => {
@@ -183,6 +188,7 @@ function createTurnResolver(deps: {
         tokenStore,
         clientName: configuration.MCP_DCR_OAUTH_CLIENT_NAME,
         userRef,
+        ...(accessToken !== undefined ? { accessToken } : {}),
       });
       if (connection === undefined) {
         throw new HTTPException(422, {
@@ -385,6 +391,7 @@ export async function beginTurnExecution(params: {
     signal: abortController.signal,
     userRef,
     sessionId,
+    ...(deps.accessToken !== undefined ? { accessToken: deps.accessToken } : {}),
   });
 
   // First turn only: derive the title from the first user message. The store
@@ -666,6 +673,7 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
     }
 
     const userRef = deps.resolveUserContext(c).userRef;
+    const accessToken = readAccessToken(c);
     const turnParams = {
       session,
       input: body.input,
@@ -675,6 +683,7 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
         ...deps,
         modelProviderStore: deps.resolveModelProviderStore(c),
         mcpServerStore: deps.resolveMcpServerStore(c),
+        ...(accessToken !== undefined ? { accessToken } : {}),
       },
     };
 

--- a/packages/trueforge/src/apis/turns.ts
+++ b/packages/trueforge/src/apis/turns.ts
@@ -30,7 +30,6 @@ import { HTTPException } from 'hono/http-exception';
 import { streamSSE } from 'hono/streaming';
 import type { Logger } from 'winston';
 import type { ResolveUserContext, UserContext } from '../auth/identity';
-import { readAccessToken } from '../auth/middleware';
 import configuration from '../config';
 import type { IAgentStore } from '../db/agentStore';
 import type { IMcpServerStore } from '../db/mcpServerStore';
@@ -146,7 +145,6 @@ function createTurnResolver(deps: {
   signal: AbortSignal;
   userRef: string;
   sessionId: string;
-  accessToken?: string;
 }): TurnResourceResolver {
   const {
     mcpServerStore,
@@ -159,7 +157,6 @@ function createTurnResolver(deps: {
     signal,
     userRef,
     sessionId,
-    accessToken,
   } = deps;
   return new TurnResourceResolver({
     llm: async name => {
@@ -186,7 +183,6 @@ function createTurnResolver(deps: {
         tokenStore,
         clientName: configuration.MCP_DCR_OAUTH_CLIENT_NAME,
         userRef,
-        ...(accessToken !== undefined ? { accessToken } : {}),
       });
       if (connection === undefined) {
         throw new HTTPException(422, {
@@ -373,10 +369,8 @@ export async function beginTurnExecution(params: {
   previous_turn_id: string | undefined;
   userRef: string;
   deps: BeginTurnExecutionDeps;
-  /** Caller TF token for gateway MCP invoke; omitted for scheduler / no-request paths. */
-  accessToken?: string;
 }): Promise<{ turn: TurnHandle; drainInput: TurnEventDrainInput }> {
-  const { session, input, previous_turn_id: previousTurnId, userRef, deps, accessToken } = params;
+  const { session, input, previous_turn_id: previousTurnId, userRef, deps } = params;
   const sessionId = session.session_id;
 
   const abortController = new AbortController();
@@ -391,7 +385,6 @@ export async function beginTurnExecution(params: {
     signal: abortController.signal,
     userRef,
     sessionId,
-    ...(accessToken !== undefined ? { accessToken } : {}),
   });
 
   // First turn only: derive the title from the first user message. The store
@@ -447,7 +440,6 @@ export async function startTurnInProcess(params: {
   previous_turn_id: string | undefined;
   userRef: string;
   deps: BeginTurnExecutionDeps;
-  accessToken?: string;
 }): Promise<TurnHandle> {
   const { turn, drainInput } = await beginTurnExecution(params);
 
@@ -674,7 +666,6 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
     }
 
     const userRef = deps.resolveUserContext(c).userRef;
-    const accessToken = readAccessToken(c);
     const turnParams = {
       session,
       input: body.input,
@@ -685,7 +676,6 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
         modelProviderStore: deps.resolveModelProviderStore(c),
         mcpServerStore: deps.resolveMcpServerStore(c),
       },
-      ...(accessToken !== undefined ? { accessToken } : {}),
     };
 
     try {

--- a/packages/trueforge/src/auth/middleware.ts
+++ b/packages/trueforge/src/auth/middleware.ts
@@ -32,10 +32,16 @@ export function readBearerToken(c: Context): string | undefined {
   return token.length > 0 ? token : undefined;
 }
 
+export function readAccessToken(c: Context): string | undefined {
+  return readBearerToken(c) ?? readAccessTokenCookie({ context: c }) ?? readIdTokenCookie({ context: c });
+}
+
 export function requireAccessToken(c: Context): string {
-  const token = readBearerToken(c) ?? readAccessTokenCookie({ context: c }) ?? readIdTokenCookie({ context: c });
+  const token = readAccessToken(c);
   if (!token) {
-    throw new HTTPException(401, { message: 'Authentication token required to list or call TrueFoundry models' });
+    throw new HTTPException(401, {
+      message: 'Authentication token required to list or call TrueFoundry models and MCP servers',
+    });
   }
   return token;
 }

--- a/packages/trueforge/src/db/McpServerWithAuthStore.ts
+++ b/packages/trueforge/src/db/McpServerWithAuthStore.ts
@@ -54,6 +54,10 @@ export class McpServerWithAuthStore<TTransaction = never> implements IMcpServerW
     return this.#store.upsertServer(input, transaction);
   }
 
+  resolveInvokeHeaders(record: McpServerRecord): Record<string, string> {
+    return this.#store.resolveInvokeHeaders(record);
+  }
+
   saveClient(params: { id: string; record: OAuthClientRecord }, transaction?: TTransaction): Promise<void> {
     return this.#store.saveClient(params, transaction);
   }

--- a/packages/trueforge/src/db/mcpServerStore.ts
+++ b/packages/trueforge/src/db/mcpServerStore.ts
@@ -113,6 +113,12 @@ export interface IMcpServerStore<TTransaction = never> extends IOAuthClientStore
    * Never overwrites `id`, `oauth_server`, or `oauth_client`.
    */
   upsertServer(input: UpsertMcpServerInput, transaction?: TTransaction): Promise<McpServerRecord>;
+  /**
+   * Static HTTP headers for MCP invoke (tools/list, turns).
+   * Local DCR is handled separately in {@link getMcpConnection}; this covers
+   * TrueFoundry gateway Bearer, configured header auth, and no-auth (`{}`).
+   */
+  resolveInvokeHeaders(record: McpServerRecord): Record<string, string>;
 }
 
 /**

--- a/packages/trueforge/src/db/postgres/mcp-server-store/PostgresMcpServerStore.ts
+++ b/packages/trueforge/src/db/postgres/mcp-server-store/PostgresMcpServerStore.ts
@@ -1,5 +1,6 @@
 import type { Kysely, Selectable, Transaction } from 'kysely';
 import type { OAuthClientRecord } from '../../../mcp/auth/types';
+import { resolveConfiguredMcpRequestHeaders } from '../../../schemas/mcpServer';
 import { newId } from '../../../utils/id';
 import {
   fromStoredOAuthClientRecord,
@@ -32,6 +33,10 @@ export class PostgresMcpServerStore implements IMcpServerStore<Transaction<Datab
 
   constructor(db: Kysely<Database>) {
     this.#db = db;
+  }
+
+  resolveInvokeHeaders(record: McpServerRecord): Record<string, string> {
+    return resolveConfiguredMcpRequestHeaders(record.manifest);
   }
 
   async listServers(input: ListMcpServersInput, transaction?: Transaction<Database>): Promise<McpServerRecord[]> {

--- a/packages/trueforge/src/db/sqlite/mcp-server-store/SqliteMcpServerStore.ts
+++ b/packages/trueforge/src/db/sqlite/mcp-server-store/SqliteMcpServerStore.ts
@@ -1,6 +1,6 @@
 import type { ExpressionBuilder, Kysely, Transaction } from 'kysely';
 import type { OAuthClientRecord } from '../../../mcp/auth/types';
-import type { McpServerManifest } from '../../../schemas/mcpServer';
+import { resolveConfiguredMcpRequestHeaders, type McpServerManifest } from '../../../schemas/mcpServer';
 import { newId } from '../../../utils/id';
 import {
   fromStoredOAuthClientRecord,
@@ -36,6 +36,10 @@ export class SqliteMcpServerStore implements IMcpServerStore<Transaction<Databas
 
   constructor(db: Kysely<Database>) {
     this.#db = db;
+  }
+
+  resolveInvokeHeaders(record: McpServerRecord): Record<string, string> {
+    return resolveConfiguredMcpRequestHeaders(record.manifest);
   }
 
   async listServers(input: ListMcpServersInput, transaction?: Transaction<Database>): Promise<McpServerRecord[]> {

--- a/packages/trueforge/src/runtime/sessionResources.ts
+++ b/packages/trueforge/src/runtime/sessionResources.ts
@@ -134,6 +134,8 @@ function dcrHeadersResolver(params: {
 
 /**
  * Load MCP url + headers for a configured server.
+ * - `truefoundry`: AI Gateway proxy — pass the caller's TF access token as Bearer
+ *   (wire `auth: dcr` is Connect UX only; do not use local DCR for invoke).
  * - `remote` + `dcr`: resolveMcpAuth via the harness token store.
  * - header / no-auth: resolveConfiguredMcpRequestHeaders.
  * Returns undefined when the server is not registered — callers choose the response.
@@ -145,6 +147,7 @@ export async function getMcpConnection({
   tokenStore,
   clientName,
   userRef,
+  accessToken,
 }: {
   tenant_id: string;
   name: string;
@@ -152,10 +155,23 @@ export async function getMcpConnection({
   tokenStore: IOAuthTokenStore;
   clientName: string;
   userRef: string;
+  /** Required when `manifest.type` is `truefoundry` (gateway invoke). */
+  accessToken?: string;
 }): Promise<McpConnection | undefined> {
   const record = await store.getServer({ tenant_id, name });
   if (record === undefined) {
     return undefined;
+  }
+  if (record.manifest.type === 'truefoundry') {
+    if (accessToken === undefined || accessToken.length === 0) {
+      throw new HTTPException(401, {
+        message: 'Authentication token required to call TrueFoundry-managed MCP servers',
+      });
+    }
+    return {
+      url: record.manifest.url,
+      headers: { Authorization: `Bearer ${accessToken}` },
+    };
   }
   if (record.manifest.auth?.type === 'dcr') {
     return {

--- a/packages/trueforge/src/runtime/sessionResources.ts
+++ b/packages/trueforge/src/runtime/sessionResources.ts
@@ -26,7 +26,6 @@ import type { IOAuthTokenStore } from '../mcp/auth/types';
 import { LocalSandboxProvider } from '../sandbox/local/provider/LocalSandboxProvider';
 import { getCachedLocalSandboxSupport, isLocalSandboxFallbackEnabled } from '../sandbox/localRuntime';
 import { toDaytonaSandboxProvider } from '../sandbox/providerUtils';
-import { resolveConfiguredMcpRequestHeaders } from '../schemas/mcpServer';
 import type { ReasoningEffort } from '../schemas/modelProvider';
 
 export interface McpConnection {
@@ -134,10 +133,9 @@ function dcrHeadersResolver(params: {
 
 /**
  * Load MCP url + headers for a configured server.
- * - `truefoundry`: AI Gateway proxy — pass the caller's TF access token as Bearer
- *   (wire `auth: dcr` is Connect UX only; do not use local DCR for invoke).
- * - `remote` + `dcr`: resolveMcpAuth via the harness token store.
- * - header / no-auth: resolveConfiguredMcpRequestHeaders.
+ * - Local `remote` + `dcr`: resolveMcpAuth via the harness token store.
+ * - Otherwise: {@link IMcpServerStore.resolveInvokeHeaders}
+ *   (TrueFoundry gateway Bearer, configured header auth, or `{}`).
  * Returns undefined when the server is not registered — callers choose the response.
  */
 export async function getMcpConnection({
@@ -147,7 +145,6 @@ export async function getMcpConnection({
   tokenStore,
   clientName,
   userRef,
-  accessToken,
 }: {
   tenant_id: string;
   name: string;
@@ -155,25 +152,13 @@ export async function getMcpConnection({
   tokenStore: IOAuthTokenStore;
   clientName: string;
   userRef: string;
-  /** Required when `manifest.type` is `truefoundry` (gateway invoke). */
-  accessToken?: string;
 }): Promise<McpConnection | undefined> {
   const record = await store.getServer({ tenant_id, name });
   if (record === undefined) {
     return undefined;
   }
-  if (record.manifest.type === 'truefoundry') {
-    if (accessToken === undefined || accessToken.length === 0) {
-      throw new HTTPException(401, {
-        message: 'Authentication token required to call TrueFoundry-managed MCP servers',
-      });
-    }
-    return {
-      url: record.manifest.url,
-      headers: { Authorization: `Bearer ${accessToken}` },
-    };
-  }
-  if (record.manifest.auth?.type === 'dcr') {
+  // TrueFoundry wire `dcr` is Connect UX only — invoke uses store Bearer, not local DCR.
+  if (record.manifest.type !== 'truefoundry' && record.manifest.auth?.type === 'dcr') {
     return {
       url: record.manifest.url,
       headers: dcrHeadersResolver({
@@ -187,7 +172,7 @@ export async function getMcpConnection({
   }
   return {
     url: record.manifest.url,
-    headers: resolveConfiguredMcpRequestHeaders(record.manifest),
+    headers: store.resolveInvokeHeaders(record),
   };
 }
 

--- a/packages/trueforge/src/truefoundry/TrueFoundryMcpServerStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryMcpServerStore.ts
@@ -41,6 +41,11 @@ export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServ
     this.#accessToken = input.accessToken;
   }
 
+  resolveInvokeHeaders(record: McpServerRecord): Record<string, string> {
+    void record;
+    return { Authorization: `Bearer ${this.#accessToken}` };
+  }
+
   async listServers(input: ListMcpServersInput, transaction?: TTransaction): Promise<McpServerRecord[]> {
     void transaction;
     if (input.names?.length === 0) {

--- a/packages/trueforge/src/truefoundry/mapSfyMcpServers.ts
+++ b/packages/trueforge/src/truefoundry/mapSfyMcpServers.ts
@@ -83,7 +83,7 @@ export function resolveMcpProxyUrl(input: { proxyUrl: string; gatewayBaseURL: st
 
 /**
  * Gateway proxy as `url`. SFY `oauth2` → wire `dcr` for Connect UX only (UI keys off auth type).
- * Invoke Bearer is intentionally not embedded as `header` auth — that breaks the UI and is a follow-up PR.
+ * Invoke uses the caller's TF access token in getMcpConnection — not wire `header` auth.
  */
 export function toTrueFoundryMcpManifest(input: {
   server: SfyMcpServerSummary;

--- a/packages/trueforge/src/truefoundry/mapSfyMcpServers.ts
+++ b/packages/trueforge/src/truefoundry/mapSfyMcpServers.ts
@@ -27,8 +27,8 @@ const SfyMcpServerRowSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
   proxyUrl: z.string().min(1),
-  createdAt: IsoInstantSchema.optional(),
-  updatedAt: IsoInstantSchema.optional(),
+  createdAt: IsoInstantSchema,
+  updatedAt: IsoInstantSchema,
   manifest: z
     .object({
       description: z.string().min(1).optional(),
@@ -55,15 +55,15 @@ export interface SfyMcpServerSummary {
 /** Parse one SFY MCP list row. Throws ZodError on contract drift. */
 export function parseSfyMcpServerSummary(row: unknown): SfyMcpServerSummary {
   const parsed = SfyMcpServerRowSchema.parse(row);
-  const now = new Date().toISOString();
   return {
     id: parsed.id,
     name: parsed.name,
     proxyUrl: parsed.proxyUrl,
+    // SFY description is optional; TrueForge manifests require a non-empty string.
     description: parsed.manifest?.description ?? parsed.name,
     authType: parsed.manifest?.auth_data?.type,
-    createdAt: parsed.createdAt ?? now,
-    updatedAt: parsed.updatedAt ?? now,
+    createdAt: parsed.createdAt,
+    updatedAt: parsed.updatedAt,
   };
 }
 

--- a/packages/trueforge/src/truefoundry/mapSfyMcpServers.ts
+++ b/packages/trueforge/src/truefoundry/mapSfyMcpServers.ts
@@ -83,7 +83,7 @@ export function resolveMcpProxyUrl(input: { proxyUrl: string; gatewayBaseURL: st
 
 /**
  * Gateway proxy as `url`. SFY `oauth2` → wire `dcr` for Connect UX only (UI keys off auth type).
- * Invoke uses the caller's TF access token in getMcpConnection — not wire `header` auth.
+ * Invoke Bearer comes from the MCP store's `resolveInvokeHeaders` — not wire `header` auth.
  */
 export function toTrueFoundryMcpManifest(input: {
   server: SfyMcpServerSummary;

--- a/packages/trueforge/tests/db/mcpServerStoreContractSuite.ts
+++ b/packages/trueforge/tests/db/mcpServerStoreContractSuite.ts
@@ -176,4 +176,29 @@ export function runMcpServerStoreContractSuite(getStore: () => IMcpServerStore):
     const store = getStore();
     expect(await store.getClient({ id: 'missing-id' })).toBeUndefined();
   });
+
+  it('resolveInvokeHeaders returns configured headers or empty', async () => {
+    const store = getStore();
+    const open = await store.upsertServer({
+      tenant_id: TENANT,
+      name: 'open',
+      manifest: {
+        type: 'remote',
+        name: 'open',
+        url: 'https://mcp.open.example/mcp',
+        description: 'Open MCP server.',
+      },
+    });
+    expect(store.resolveInvokeHeaders(open)).toEqual({});
+
+    const headered = await store.upsertServer({
+      tenant_id: TENANT,
+      name: 'headered',
+      manifest: manifest({
+        name: 'headered',
+        auth: { type: 'header', headers: { Authorization: 'Bearer static' } },
+      }),
+    });
+    expect(store.resolveInvokeHeaders(headered)).toEqual({ Authorization: 'Bearer static' });
+  });
 }

--- a/packages/trueforge/tests/unit/runtime/getMcpConnection.test.ts
+++ b/packages/trueforge/tests/unit/runtime/getMcpConnection.test.ts
@@ -211,6 +211,58 @@ describe('getMcpConnection', () => {
     expect(connection.headers).toEqual({ Authorization: 'Bearer static-token' });
   });
 
+  it('passes the caller TF token as Bearer for truefoundry servers (even when wire auth is dcr)', async () => {
+    await mcpServerStore.upsertServer({
+      tenant_id: TENANT_ID,
+      name: 'tfy-mcp',
+      manifest: {
+        type: 'truefoundry',
+        name: 'tfy-mcp',
+        url: 'https://gateway.example/mcp-server/tfy-mcp',
+        description: 'TrueFoundry-managed MCP.',
+        auth: { type: 'dcr' },
+      },
+    });
+
+    const connection = await getMcpConnection({
+      tenant_id: TENANT_ID,
+      name: 'tfy-mcp',
+      store: mcpServerStore,
+      tokenStore,
+      clientName: 'test-client',
+      userRef: LOCAL_USER_CONTEXT.userRef,
+      accessToken: 'tf-access-token',
+    });
+    expect(connection).toEqual({
+      url: 'https://gateway.example/mcp-server/tfy-mcp',
+      headers: { Authorization: 'Bearer tf-access-token' },
+    });
+  });
+
+  it('rejects truefoundry invoke without an access token', async () => {
+    await mcpServerStore.upsertServer({
+      tenant_id: TENANT_ID,
+      name: 'tfy-mcp-no-token',
+      manifest: {
+        type: 'truefoundry',
+        name: 'tfy-mcp-no-token',
+        url: 'https://gateway.example/mcp-server/tfy-mcp-no-token',
+        description: 'TrueFoundry-managed MCP.',
+      },
+    });
+
+    await expect(
+      getMcpConnection({
+        tenant_id: TENANT_ID,
+        name: 'tfy-mcp-no-token',
+        store: mcpServerStore,
+        tokenStore,
+        clientName: 'test-client',
+        userRef: LOCAL_USER_CONTEXT.userRef,
+      }),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
   it('returns undefined when the server is not registered', async () => {
     await expect(
       getMcpConnection({

--- a/packages/trueforge/tests/unit/runtime/getMcpConnection.test.ts
+++ b/packages/trueforge/tests/unit/runtime/getMcpConnection.test.ts
@@ -211,7 +211,7 @@ describe('getMcpConnection', () => {
     expect(connection.headers).toEqual({ Authorization: 'Bearer static-token' });
   });
 
-  it('passes the caller TF token as Bearer for truefoundry servers (even when wire auth is dcr)', async () => {
+  it('skips local DCR for truefoundry servers even when wire auth is dcr', async () => {
     await mcpServerStore.upsertServer({
       tenant_id: TENANT_ID,
       name: 'tfy-mcp',
@@ -231,36 +231,11 @@ describe('getMcpConnection', () => {
       tokenStore,
       clientName: 'test-client',
       userRef: LOCAL_USER_CONTEXT.userRef,
-      accessToken: 'tf-access-token',
     });
     expect(connection).toEqual({
       url: 'https://gateway.example/mcp-server/tfy-mcp',
-      headers: { Authorization: 'Bearer tf-access-token' },
+      headers: {},
     });
-  });
-
-  it('rejects truefoundry invoke without an access token', async () => {
-    await mcpServerStore.upsertServer({
-      tenant_id: TENANT_ID,
-      name: 'tfy-mcp-no-token',
-      manifest: {
-        type: 'truefoundry',
-        name: 'tfy-mcp-no-token',
-        url: 'https://gateway.example/mcp-server/tfy-mcp-no-token',
-        description: 'TrueFoundry-managed MCP.',
-      },
-    });
-
-    await expect(
-      getMcpConnection({
-        tenant_id: TENANT_ID,
-        name: 'tfy-mcp-no-token',
-        store: mcpServerStore,
-        tokenStore,
-        clientName: 'test-client',
-        userRef: LOCAL_USER_CONTEXT.userRef,
-      }),
-    ).rejects.toMatchObject({ status: 401 });
   });
 
   it('returns undefined when the server is not registered', async () => {

--- a/packages/trueforge/tests/unit/truefoundry/mapSfyMcpServers.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/mapSfyMcpServers.test.ts
@@ -66,6 +66,16 @@ describe('parseSfyMcpServerSummary', () => {
     expect(parsed.updatedAt).toBe('2026-02-02T00:00:00.000Z');
   });
 
+  it('throws ZodError when required timestamps are missing', () => {
+    expect(() =>
+      parseSfyMcpServerSummary({
+        id: 'mcp-1',
+        name: 'github',
+        proxyUrl: `${MCP_PROXY_BASE_URL_TEMPLATE}/mcp-server/github`,
+      }),
+    ).toThrow(ZodError);
+  });
+
   it('throws ZodError on contract drift', () => {
     expect(() => parseSfyMcpServerSummary({ id: 'mcp-1', name: 'github' })).toThrow(ZodError);
   });


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP authentication paths for TrueFoundry gateway invoke and tightens upstream SFY list contract; mistakes could break MCP access or fail listing if timestamps are missing.
> 
> **Overview**
> TrueFoundry-managed MCP **tools/list** and turn invokes now send the caller’s access token as `Authorization: Bearer` through the gateway, without threading tokens through turn/tools APIs.
> 
> **`IMcpServerStore.resolveInvokeHeaders`** centralizes static invoke headers: DB-backed stores still use configured header/no-auth manifests; **`TrueFoundryMcpServerStore`** returns Bearer from the request-scoped access token already used to construct that store. **`getMcpConnection`** calls the store for headers and **does not run local DCR** when `manifest.type === 'truefoundry'` (wire `dcr` stays Connect UX only).
> 
> Auth middleware adds **`readAccessToken`** (shared by **`requireAccessToken`**) and broadens the 401 message to cover MCP servers. ServiceFoundry MCP list parsing now **requires** `createdAt`/`updatedAt` instead of defaulting to “now”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b4fd50cafe60161e0fb80e80a521948365c09d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->