### PR TITLE
feat: add persistent session repository checkouts

### DIFF
--- a/.changeset/session-repository-checkouts.md
+++ b/.changeset/session-repository-checkouts.md
@@ -1,0 +1,6 @@
+---
+'@truefoundry/trueforge-core': minor
+'@truefoundry/trueforge': minor
+---
+
+Add persistent session repository checkouts with per-turn credential resolution and read-only or read-write access controls.

--- a/packages/trueforge-core/src/agent-session/Sessions.ts
+++ b/packages/trueforge-core/src/agent-session/Sessions.ts
@@ -14,10 +14,11 @@ import { SessionExternalIdConflictError } from './store/SessionStoreErrors';
 
 export type SessionsCreateInput<TSessionCustom extends object> = Omit<
   CreateSessionInput<TSessionCustom>,
-  'custom' | 'metadata'
+  'custom' | 'metadata' | 'repository'
 > & {
   custom?: TSessionCustom | undefined;
   metadata?: CreateSessionInput<TSessionCustom>['metadata'] | undefined;
+  repository?: CreateSessionInput<TSessionCustom>['repository'] | undefined;
 };
 
 export class Sessions<
@@ -38,6 +39,7 @@ export class Sessions<
       ...input,
       custom: input.custom ?? null,
       metadata: input.metadata ?? {},
+      repository: input.repository ?? null,
     });
     const record = await this.store.getSession({
       tenant_id: input.tenant_id,

--- a/packages/trueforge-core/src/agent-session/TurnResourceResolver.ts
+++ b/packages/trueforge-core/src/agent-session/TurnResourceResolver.ts
@@ -74,6 +74,8 @@ export class TurnResourceResolver<
       mcpConnectTimeoutMs: number;
       /** One sandbox type per runtime. Omit = no sandbox support. */
       sandboxProvider?: TurnSandboxFactory | undefined;
+      /** Force sandbox provisioning for session-owned resources such as a repository checkout. */
+      sandboxRequired?: boolean | undefined;
       /**
        * Named-agent lookup (registry id → live AgentSpec). Required when a
        * session is bound by reference; omit only if all sessions use inline agents.
@@ -118,7 +120,7 @@ export class TurnResourceResolver<
     signal: AbortSignal;
     tracing: AgentTracing;
   }): Promise<Sandbox | undefined> {
-    if (!this.deps.sandboxProvider || !specWantsSandbox(input.spec)) {
+    if (!this.deps.sandboxProvider || (!specWantsSandbox(input.spec) && this.deps.sandboxRequired !== true)) {
       return undefined;
     }
     this.#sandbox = await this.deps.sandboxProvider({

--- a/packages/trueforge-core/src/agent-session/index.ts
+++ b/packages/trueforge-core/src/agent-session/index.ts
@@ -21,8 +21,8 @@ export {
 } from './schemas/turn';
 export type { TerminalTurnState, Turn, TurnInputItem, TurnMetrics, TurnState } from './schemas/turn';
 
-export { SessionMetadataSchema, SessionMetricsSchema, SessionSchema } from './schemas/session';
-export type { Session, SessionAgent, SessionMetadata, SessionMetrics } from './schemas/session';
+export { SessionMetadataSchema, SessionMetricsSchema, SessionRepositorySchema, SessionSchema } from './schemas/session';
+export type { Session, SessionAgent, SessionMetadata, SessionMetrics, SessionRepository } from './schemas/session';
 
 export {
   EventType,

--- a/packages/trueforge-core/src/agent-session/models/SessionRecord.ts
+++ b/packages/trueforge-core/src/agent-session/models/SessionRecord.ts
@@ -1,4 +1,4 @@
-import type { SessionAgent, SessionMetadata, SessionMetrics } from '../schemas/session';
+import type { SessionAgent, SessionMetadata, SessionMetrics, SessionRepository } from '../schemas/session';
 
 /**
  * Session persistence record. Agent binding is a single discriminated `agent`
@@ -37,5 +37,7 @@ export interface SessionRecord<TCustom extends object = Record<string, never>> {
   last_activity_timestamp_ms: number;
   metrics: SessionMetrics;
   metadata: SessionMetadata;
+  /** Immutable sandbox checkout configuration; credentials are resolved per turn and never persisted. */
+  repository: SessionRepository | null;
   custom: TCustom | null;
 }

--- a/packages/trueforge-core/src/agent-session/schemas/session.ts
+++ b/packages/trueforge-core/src/agent-session/schemas/session.ts
@@ -3,6 +3,7 @@
  * field (`reference` | `inline`). DB stores agent_id / agent_name / agent_spec columns.
  */
 import { z } from '@hono/zod-openapi';
+import { SessionRepositorySchema, type SessionRepository } from '../../core/sandbox/RepositoryCheckout';
 import { AgentSpecSchema } from './agentSpec';
 
 /** Max key length for session metadata (aligned with LLM gateway HeaderMetadata). */
@@ -31,6 +32,9 @@ export const SessionMetadataSchema = z
   .openapi('SessionMetadata');
 
 export type SessionMetadata = z.infer<typeof SessionMetadataSchema>;
+
+export { SessionRepositorySchema };
+export type { SessionRepository };
 
 export const SessionMetricsSchema = z
   .object({
@@ -79,6 +83,7 @@ export const SessionSchema = z
     updated_at: z.string().describe('ISO 8601 last-update timestamp.'),
     metrics: SessionMetricsSchema,
     metadata: SessionMetadataSchema,
+    repository: SessionRepositorySchema.nullable(),
   })
   .openapi('Session');
 

--- a/packages/trueforge-core/src/agent-session/store/ISessionStore.ts
+++ b/packages/trueforge-core/src/agent-session/store/ISessionStore.ts
@@ -19,7 +19,7 @@ import type { CancellationReason, TerminalTurnState } from '../schemas/turn';
  */
 export type CreateSessionInput<TSessionCustom extends object = Record<string, never>> = Pick<
   SessionRecord<TSessionCustom>,
-  'tenant_id' | 'session_id' | 'agent' | 'created_by' | 'external_id' | 'metadata'
+  'tenant_id' | 'session_id' | 'agent' | 'created_by' | 'external_id' | 'metadata' | 'repository'
 > & {
   custom: TSessionCustom | null;
 };

--- a/packages/trueforge-core/src/agent-session/store/InMemorySessionStore.ts
+++ b/packages/trueforge-core/src/agent-session/store/InMemorySessionStore.ts
@@ -201,6 +201,7 @@ export class InMemorySessionStore<
         total_turns: 0,
       },
       metadata: deepCopy(input.metadata),
+      repository: input.repository !== null ? deepCopy(input.repository) : null,
       custom: input.custom !== null ? deepCopy(input.custom) : null,
     };
     this.sessions.set(key, { record, turnIds: [] });

--- a/packages/trueforge-core/src/core/index.ts
+++ b/packages/trueforge-core/src/core/index.ts
@@ -22,6 +22,9 @@ export type { CreateDynamicSubAgentThread } from './runtime/CreateDynamicSubAgen
 export { isAgentInputUserMessage, isEmptyMessageContent, isFileContentPart } from './runtime/UserInputMessage';
 export type { AgentInputUserMessage } from './runtime/UserInputMessage';
 
+export { SessionRepositorySchema } from './sandbox/RepositoryCheckout';
+export type { SessionRepository } from './sandbox/RepositoryCheckout';
+
 // Capability contracts
 export type { AgentCapability, CapabilityState, JsonValue } from './capabilities/AgentCapability';
 export type {

--- a/packages/trueforge-core/src/core/sandbox/RepositoryCheckout.ts
+++ b/packages/trueforge-core/src/core/sandbox/RepositoryCheckout.ts
@@ -1,0 +1,32 @@
+import { z } from '@hono/zod-openapi';
+
+export const SessionRepositorySchema = z
+  .object({
+    url: z.url().refine(value => {
+      const parsed = new URL(value);
+      return parsed.protocol === 'https:' && parsed.username === '' && parsed.password === '';
+    }, 'Repository URL must use HTTPS and must not contain credentials.'),
+    ref: z
+      .string()
+      .min(1)
+      .max(255)
+      .regex(/^[A-Za-z0-9][A-Za-z0-9._/-]*$/, 'Ref contains unsupported characters.')
+      .refine(value => !value.includes('..') && !value.includes('@{') && !value.endsWith('.lock'), 'Invalid Git ref.')
+      .describe('Branch, tag, or commit to check out.'),
+    path: z
+      .string()
+      .min(1)
+      .max(255)
+      .regex(
+        /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))(?!.*\/\/)[A-Za-z0-9._/-]+$/,
+        'Path must be relative, portable, and may not traverse.',
+      )
+      .refine(value => value !== '.', 'Path must use a dedicated sandbox subdirectory.'),
+    access: z.enum(['read_only', 'read_write']),
+    credential_provider_ref: z.string().min(1).max(255).nullable().default(null),
+  })
+  .strict()
+  .describe('A persistent Git checkout provisioned in the session sandbox.')
+  .openapi('SessionRepository');
+
+export type SessionRepository = z.infer<typeof SessionRepositorySchema>;

--- a/packages/trueforge-core/src/core/sandbox/Sandbox.ts
+++ b/packages/trueforge-core/src/core/sandbox/Sandbox.ts
@@ -22,6 +22,7 @@ import { SandboxNotAvailableError, validateNoPathTraversal } from './SandboxErro
 import { formatSandboxId, rawSandboxId } from './sandboxRef';
 // Import submodules, not the ./skills barrel, to avoid a cycle (the mounters import from Sandbox).
 import { dirname, join, relative } from 'node:path';
+import { SessionRepositorySchema, type SessionRepository } from './RepositoryCheckout';
 import type { ISkillMounter } from './skills/ISkillMounter';
 
 /** Layout derived from install remotePath (always `…/mcp_client.py`). */
@@ -79,6 +80,27 @@ function buildGitCredentialHelperEnv(credentialsPath: string): Record<string, st
   };
 }
 
+/** Idempotently provision a repository without resetting a resumed sandbox's working tree. */
+export function buildRepositoryCheckoutCommand(repository: SessionRepository): string {
+  const path = shellEscape(repository.path);
+  const url = shellEscape(repository.url);
+  const fetchRef = shellEscape(`+${repository.ref}:refs/trueforge/session-source`);
+  const pushPolicy =
+    repository.access === 'read_only'
+      ? ` && git -C ${path} remote set-url --push origin disabled://read-only`
+      : ` && git -C ${path} config remote.origin.push ${shellEscape(`HEAD:${repository.ref}`)}`;
+  return (
+    `if [ -d ${path}/.git ]; then ` +
+    `(git -C ${path} remote get-url origin >/dev/null 2>&1 && git -C ${path} remote set-url origin ${url} || ` +
+    `git -C ${path} remote add origin ${url}) && git -C ${path} fetch origin ${fetchRef}; ` +
+    `elif [ -e ${path} ] && [ ! -d ${path} ]; then echo "Repository path already exists and is not a directory" >&2; exit 1; ` +
+    `else mkdir -p ${path} && git init -- ${path} && git -C ${path} remote add origin ${url} && ` +
+    `git -C ${path} fetch --depth=1 origin ${fetchRef}; fi && ` +
+    `(git -C ${path} rev-parse --verify HEAD >/dev/null 2>&1 || git -C ${path} checkout -B trueforge-session FETCH_HEAD)` +
+    pushPolicy
+  );
+}
+
 export interface SandboxStoredFile {
   filePath: string;
   sandboxCreated?: SandboxInfo | undefined;
@@ -91,6 +113,8 @@ export interface SandboxOptions {
   fileDownloadEnabled?: boolean | undefined;
   /** Pre-resolved credential-store file content (null = clear / no git auth). */
   resolvedGitCredentialsContent?: string | null | undefined;
+  /** Immutable repository checkout metadata. */
+  repository?: SessionRepository | null | undefined;
   /**
    * Blocks destructive tools in code mode so they go through the approval flow
    * instead. Must be `true` — approvals are always enabled (the kill switch is gone).
@@ -210,6 +234,7 @@ export class Sandbox extends LocalToolMCP {
   private readonly logger: Logger;
   // Pre-resolved credential-store file content (null = clear / no git auth).
   private readonly resolvedGitCredentialsContent: string | null;
+  private readonly repository: SessionRepository | null;
   private codeModeDispatcher: CodeModeDispatcher | undefined;
   private codeModeTransport: CodeModeTransport | undefined;
   /** Cached from transport.getClientInstall after sandbox init (when Code Mode is configured). */
@@ -234,6 +259,10 @@ export class Sandbox extends LocalToolMCP {
     this.requestTimeoutSeconds = Math.ceil(mcpBoundTimeoutMs / 1000) + NATS_REQUEST_TIMEOUT_BUFFER_SECONDS;
     this.logger = options.logger.child({ module: 'Sandbox' });
     this.resolvedGitCredentialsContent = options.resolvedGitCredentialsContent ?? null;
+    this.repository =
+      options.repository === null || options.repository === undefined
+        ? null
+        : SessionRepositorySchema.parse(options.repository);
 
     if (this.existingSandboxId) {
       this.existingSandboxInfo = { sandbox_id: this.existingSandboxId };
@@ -295,6 +324,9 @@ export class Sandbox extends LocalToolMCP {
     const sandboxInstructions = builder.beginSection('sandbox');
     sandboxInstructions.addContent('The Agent has access to a persistent sandbox environment for executing code.');
     sandboxInstructions.addContent('The Agent must NOT read or modify any git credential files.');
+    if (this.repository !== null) {
+      sandboxInstructions.addContent(`The session repository is checked out at ${this.repository.path}.`);
+    }
 
     this.buildSchemaSection(sandboxInstructions);
     this.buildSkillsSection(sandboxInstructions);
@@ -684,13 +716,31 @@ export class Sandbox extends LocalToolMCP {
     ensureExecSuccess(result);
   }
 
+  private async prepareRepository(): Promise<void> {
+    if (this.repository === null) {
+      return;
+    }
+    const sandboxId = this.providerSandboxId(this.requiredSandboxInfo.sandbox_id);
+    const credentialsPath = this.provider.getGitCredentialsPath(sandboxId);
+    const result = await this.provider.exec({
+      sandboxId,
+      command: buildRepositoryCheckoutCommand(this.repository),
+      env: buildGitCredentialHelperEnv(credentialsPath),
+      timeoutSeconds: SKILL_DOWNLOAD_TIMEOUT_SECONDS,
+    });
+    ensureExecSuccess(result);
+  }
+
   private async initSandboxEnvironment(): Promise<void> {
     const sandboxId = this.providerSandboxId(this.requiredSandboxInfo.sandbox_id);
     const fileUploadsDir = this.provider.getFileUploadsDir(sandboxId);
     const skillsDir = this.provider.getSkillsDir(sandboxId);
     const toolResultDumpDir = this.provider.getToolResultDumpDir(sandboxId);
 
-    this.logger.info('Uploading MCP client script and preparing skills directory in sandbox');
+    this.logger.info('Uploading MCP client script and preparing sandbox resources');
+
+    await this.writeGitCredentials();
+    await this.prepareRepository();
 
     this.mcpClientInstall = this.codeModeTransport?.getClientInstall({ sandboxId });
     const install = this.mcpClientInstall;
@@ -750,8 +800,6 @@ export class Sandbox extends LocalToolMCP {
         ? `Sandbox initialized: skills dir ${skillsDir}`
         : `Sandbox initialized: MCP client at ${install.remotePath}; skills dir ${skillsDir}`,
     );
-
-    await this.writeGitCredentials();
   }
 
   /**

--- a/packages/trueforge-core/tests/agent-session/sessionRepository.test.ts
+++ b/packages/trueforge-core/tests/agent-session/sessionRepository.test.ts
@@ -1,0 +1,35 @@
+import { SessionRepositorySchema } from '../../src/agent-session/schemas/session';
+
+describe('SessionRepositorySchema', () => {
+  const repository = {
+    url: 'https://github.com/example/repository.git',
+    ref: 'feature/work',
+    path: 'workspace/repository',
+    access: 'read_write',
+    credential_provider_ref: 'github-app:installation-123',
+  };
+
+  it('accepts a scoped HTTPS checkout', () => {
+    expect(SessionRepositorySchema.parse(repository)).toEqual(repository);
+  });
+
+  it('defaults to anonymous credentials for public repositories', () => {
+    const { credential_provider_ref: _credentialProviderRef, ...publicRepository } = repository;
+    expect(SessionRepositorySchema.parse(publicRepository).credential_provider_ref).toBeNull();
+    expect(
+      SessionRepositorySchema.parse({ ...repository, credential_provider_ref: null }).credential_provider_ref,
+    ).toBeNull();
+  });
+
+  it.each([
+    ['non-HTTPS URL', { ...repository, url: 'ssh://git@github.com/example/repository.git' }],
+    ['URL credentials', { ...repository, url: 'https://token@github.com/example/repository.git' }],
+    ['absolute path', { ...repository, path: '/workspace/repository' }],
+    ['sandbox root path', { ...repository, path: '.' }],
+    ['traversing path', { ...repository, path: '../repository' }],
+    ['empty credential provider reference', { ...repository, credential_provider_ref: '' }],
+    ['option-like ref', { ...repository, ref: '--upload-pack=malicious' }],
+  ])('rejects %s', (_label, candidate) => {
+    expect(SessionRepositorySchema.safeParse(candidate).success).toBe(false);
+  });
+});

--- a/packages/trueforge-core/tests/agent-session/store/storeContractSuite.ts
+++ b/packages/trueforge-core/tests/agent-session/store/storeContractSuite.ts
@@ -2,8 +2,9 @@ import { z } from 'zod';
 import { MAIN_THREAD_ID } from '../../../src/agent-session/models/TurnRecord';
 import type { PersistedTurnEvent } from '../../../src/agent-session/schemas/events';
 import { EventType } from '../../../src/agent-session/schemas/events';
+import type { SessionRepository } from '../../../src/agent-session/schemas/session';
 import { CancellationReason } from '../../../src/agent-session/schemas/turn';
-import type { ISessionStore } from '../../../src/agent-session/store/ISessionStore';
+import type { CreateSessionInput, ISessionStore } from '../../../src/agent-session/store/ISessionStore';
 import { decodeSessionEventPageToken } from '../../../src/agent-session/store/SessionEventPageToken';
 import {
   PreviousTurnRunningError,
@@ -69,6 +70,13 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
   const missingSessionId = 'missing-session';
   const missingTurnId = 'missing-turn';
 
+  async function createSession(
+    store: ISessionStore,
+    input: Omit<CreateSessionInput, 'repository'> & { repository?: CreateSessionInput['repository'] | undefined },
+  ): Promise<void> {
+    await store.createSession({ ...input, repository: input.repository ?? null });
+  }
+
   async function finishTurn(store: ISessionStore, turnId: string) {
     const state = makeDoneTurnState();
     await store.updateTurnState({
@@ -80,13 +88,14 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
   }
 
   async function seedSession(store: ISessionStore, agentSpec = makeAgentSpec()) {
-    await store.createSession({
+    await createSession(store, {
       tenant_id: tenant,
       session_id: sessionId,
       created_by: 'user-1',
       agent: { type: 'inline', spec: agentSpec },
       custom: null,
       metadata: {},
+      repository: null,
       external_id: null,
     });
   }
@@ -187,13 +196,14 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
     it('createSession persists created_by', async () => {
       const store = createStore();
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: 'created-by-session',
         created_by: 'alice@example.com',
         agent: { type: 'inline', spec: makeAgentSpec() },
         custom: null,
         metadata: {},
+        repository: null,
         external_id: null,
       });
       const session = mustGet(await store.getSession({ tenant_id: tenant, session_id: 'created-by-session' }));
@@ -213,9 +223,34 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       expect(listed.data.find(s => s.session_id === 'created-by-session')?.created_by).toBe('alice@example.com');
     });
 
+    it('persists repository metadata without credential material', async () => {
+      const store = createStore();
+      const repository: SessionRepository = {
+        url: 'https://github.com/example/repository.git',
+        ref: 'feature/work',
+        path: 'workspace/repository',
+        access: 'read_write',
+        credential_provider_ref: 'github-app:installation-123',
+      };
+      await createSession(store, {
+        tenant_id: tenant,
+        session_id: 'repository-session',
+        created_by: 'user-1',
+        agent: { type: 'inline', spec: makeAgentSpec() },
+        custom: null,
+        metadata: {},
+        external_id: null,
+        repository,
+      });
+
+      const session = mustGet(await store.getSession({ tenant_id: tenant, session_id: 'repository-session' }));
+      expect(session.repository).toEqual(repository);
+      expect(JSON.stringify(session)).not.toContain('credential-store-content');
+    });
+
     it('persists reference agents and listSessions filters by agent_id', async () => {
       const store = createStore();
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: 'named-1',
         created_by: 'user-1',
@@ -244,7 +279,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
     it('rejects agent updates on sessions bound by agent_id', async () => {
       const store = createStore();
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: 'named-1',
         created_by: 'user-1',
@@ -299,7 +334,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
     it('createSession persists metadata for getSession', async () => {
       const store = createStore();
       const metadata = { env: 'prod', ticket: 'T-1' };
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: sessionId,
         created_by: 'user-1',
@@ -314,7 +349,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
     it('updateSession replaces metadata when set and leaves it when omitted', async () => {
       const store = createStore();
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: sessionId,
         created_by: 'user-1',
@@ -366,13 +401,14 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       const store = createStore();
       await seedSession(store);
       await expect(
-        store.createSession({
+        createSession(store, {
           tenant_id: 'other',
           session_id: sessionId,
           created_by: 'user-1',
           agent: { type: 'inline', spec: makeAgentSpec() },
           custom: null,
           metadata: {},
+          repository: null,
           external_id: null,
         }),
       ).rejects.toBeInstanceOf(SessionStoreConflictError);
@@ -387,7 +423,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
     it('createSession persists external_id and getSessionByExternalId finds it', async () => {
       const store = createStore();
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: sessionId,
         created_by: 'user-1',
@@ -406,7 +442,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
     it('createSession unique external_id within a tenant; nulls and other tenants do not collide', async () => {
       const store = createStore();
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: 's-a',
         created_by: 'user-1',
@@ -418,7 +454,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       // Specifically the external-id arm, not just any conflict: get-or-create
       // treats this rejection as its normal repeat-call path.
       await expect(
-        store.createSession({
+        createSession(store, {
           tenant_id: tenant,
           session_id: 's-b',
           created_by: 'user-1',
@@ -429,7 +465,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
         }),
       ).rejects.toBeInstanceOf(SessionExternalIdConflictError);
 
-      await store.createSession({
+      await createSession(store, {
         tenant_id: 'other',
         session_id: 's-c',
         created_by: 'user-1',
@@ -438,7 +474,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
         metadata: {},
         external_id: 'shared-key',
       });
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: 's-d',
         created_by: 'user-1',
@@ -447,7 +483,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
         metadata: {},
         external_id: null,
       });
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: 's-e',
         created_by: 'user-1',
@@ -460,7 +496,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
     it('getSessionByExternalId does not bump last_activity_timestamp_ms', async () => {
       const store = createStore();
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: sessionId,
         created_by: 'user-1',
@@ -480,7 +516,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
     it('removes all session data, is idempotent, and is a no-op when tenant_id does not match', async () => {
       const store = createStore();
       await seedSession(store);
-      await store.createSession({
+      await createSession(store, {
         tenant_id: 'other',
         session_id: 'other-session',
         created_by: 'user-1',
@@ -665,7 +701,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       const store = createStore();
       const nested = `${sessionId}:nested`;
       await seedSession(store);
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: nested,
         created_by: 'user-1',
@@ -796,7 +832,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
   describe('listSessions', () => {
     async function seedThreeSessions(store: ISessionStore) {
       for (const id of ['sa', 'sb', 'sc']) {
-        await store.createSession({
+        await createSession(store, {
           tenant_id: tenant,
           session_id: id,
           created_by: 'user-1',
@@ -812,7 +848,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
     it('lists newest-first by default, asc on request, scoped to tenant', async () => {
       const store = createStore();
       await seedThreeSessions(store);
-      await store.createSession({
+      await createSession(store, {
         tenant_id: 'other',
         session_id: 'sx',
         created_by: 'user-1',
@@ -967,7 +1003,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
     it('filters by created_by', async () => {
       const store = createStore();
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: 'alice-session',
         created_by: 'alice',
@@ -976,7 +1012,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
         metadata: {},
         external_id: null,
       });
-      await store.createSession({
+      await createSession(store, {
         tenant_id: tenant,
         session_id: 'bob-session',
         created_by: 'bob',

--- a/packages/trueforge-core/tests/agent-session/turnStream.test.ts
+++ b/packages/trueforge-core/tests/agent-session/turnStream.test.ts
@@ -509,4 +509,28 @@ describe('TurnResourceResolver caches', () => {
     }
     expect(sandboxCreates).toBe(1);
   });
+
+  it('resolves a required session sandbox when the agent sandbox flag is disabled', async () => {
+    const sandbox = makeStubPublicSandbox();
+    const sandboxProvider = jest.fn().mockResolvedValue(sandbox);
+    const resolver = new TurnResourceResolver({
+      llm: () => Promise.resolve({ modelClient: makeMockILLM(), defaultModelParams: {} }),
+      mcp: () => Promise.resolve({ url: 'http://localhost' }),
+      mcpRequestTimeoutMs: 60_000,
+      mcpConnectTimeoutMs: 5_000,
+      sandboxProvider,
+      sandboxRequired: true,
+      logger: makeSilentLogger(),
+    });
+    const spec = makeAgentSpec({ config: { sandbox: { enabled: false, file_downloads: false } } });
+
+    await expect(
+      resolver.resolveSandbox({
+        spec,
+        signal: new AbortController().signal,
+        tracing: resolver.createTracing(),
+      }),
+    ).resolves.toBe(sandbox);
+    expect(sandboxProvider).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/trueforge-core/tests/core/sandbox/Sandbox.paths.test.ts
+++ b/packages/trueforge-core/tests/core/sandbox/Sandbox.paths.test.ts
@@ -1,7 +1,7 @@
 import { InstructionBuilder } from '../../../src/core/InstructionBuilder';
 import type { CodeModeTransport } from '../../../src/core/sandbox/codeMode/CodeModeTransport';
 import type { ExecResult, SandboxExecParams, SandboxProvider } from '../../../src/core/sandbox/provider/Provider';
-import { SANDBOX_EXEC_TOOL_NAME, Sandbox } from '../../../src/core/sandbox/Sandbox';
+import { buildRepositoryCheckoutCommand, Sandbox, SANDBOX_EXEC_TOOL_NAME } from '../../../src/core/sandbox/Sandbox';
 import { NOOP_AGENT_TRACING } from '../../../src/core/tracing/NoopAgentTracing';
 import { makeMockIMCPServer, makeSilentLogger } from '../harnessMocks';
 
@@ -42,6 +42,67 @@ function makeSandbox(provider: SandboxProvider, options: { existingSandboxId?: s
 }
 
 describe('Sandbox provider-owned paths', () => {
+  it('builds an idempotent checkout that fetches without resetting resumed work', () => {
+    const command = buildRepositoryCheckoutCommand({
+      url: 'https://github.com/example/repository.git',
+      ref: 'feature/work',
+      path: 'workspace/repository',
+      access: 'read_write',
+      credential_provider_ref: 'github-app:installation-123',
+    });
+
+    expect(command).toContain('remote get-url origin');
+    expect(command).toContain("remote set-url origin 'https://github.com/example/repository.git'");
+    expect(command).toContain("remote add origin 'https://github.com/example/repository.git'");
+    expect(command).toContain("elif [ -e 'workspace/repository' ] && [ ! -d 'workspace/repository' ]");
+    expect(command).toContain("else mkdir -p 'workspace/repository' && git init -- 'workspace/repository'");
+    expect(command).toContain("fetch origin '+feature/work:refs/trueforge/session-source'");
+    expect(command).not.toContain('fetch --prune');
+    expect(command).toContain("config remote.origin.push 'HEAD:feature/work'");
+    expect(command).not.toContain('reset');
+    expect(command).not.toContain('credential_provider_ref');
+  });
+
+  it('prepares credentials and a read-only repository before agent commands', async () => {
+    const execCalls: SandboxExecParams[] = [];
+    const provider = makeProvider({
+      exec: params => {
+        execCalls.push(params);
+        return readyExec();
+      },
+    });
+    const sandbox = new Sandbox({
+      provider,
+      repository: {
+        url: 'https://github.com/example/repository.git',
+        ref: 'main',
+        path: 'workspace/repository',
+        access: 'read_only',
+        credential_provider_ref: 'github-app:installation-123',
+      },
+      resolvedGitCredentialsContent: 'https://token@example.test',
+      blockDestructiveToolsInCodeMode: true,
+      mcpRequestTimeoutMs: 60_000,
+      mcpConnectTimeoutMs: 5_000,
+      logger: makeSilentLogger(),
+      tracing: NOOP_AGENT_TRACING,
+    });
+
+    await sandbox.callTool({
+      name: SANDBOX_EXEC_TOOL_NAME,
+      arguments: { intent: 'Inspect repository', command: 'git status' },
+    });
+
+    expect(execCalls[0]?.command).toContain('base64 -d');
+    expect(execCalls[1]?.command).toContain('remote set-url --push origin disabled://read-only');
+    expect(execCalls[1]?.env).toEqual({
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'credential.helper',
+      GIT_CONFIG_VALUE_0: 'store --file /prov/.git-credentials',
+    });
+    expect(execCalls.at(-1)?.command).toBe('git status');
+  });
+
   it('puts the provider uploads dir in the system prompt, not /tmp/uploads', () => {
     const sandbox = makeSandbox(makeProvider());
     const builder = new InstructionBuilder('root');

--- a/packages/trueforge/src/apis/sessions.ts
+++ b/packages/trueforge/src/apis/sessions.ts
@@ -40,7 +40,7 @@ import {
 } from '../routes/sessionRoutes';
 import type { ActiveTurnRegistry } from '../runtime/activeTurns';
 import { executorFromTurnId } from '../runtime/peeringIds';
-import { validateAgentSpec } from '../runtime/sessionResources';
+import { validateAgentSpec, validateRepositorySandbox } from '../runtime/sessionResources';
 import { isSessionAgentNameRef, type Session } from '../schemas/session';
 import { newId } from '../utils/id';
 
@@ -68,6 +68,7 @@ export function toWireSession(record: SessionRecord): Session {
     updated_at: record.updated_at.toISOString(),
     metrics: record.metrics,
     metadata: record.metadata,
+    repository: record.repository,
   };
 }
 
@@ -269,11 +270,18 @@ function createGetOrCreateSessionByExternalIdHandler(
       agent = { type: 'inline', spec: body.agent.spec };
     }
 
+    await validateRepositorySandbox({
+      repository: body.repository ?? null,
+      tenant_id: TENANT_ID,
+      sandboxProviderStore: deps.sandboxProviderStore,
+    });
+
     const { session, created } = await deps.sessions.getOrCreateByExternalId({
       tenant_id: TENANT_ID,
       external_id: body.external_id,
       created_by: user.userRef,
       agent,
+      repository: body.repository ?? null,
     });
     if (!created && !checkSessionAccess({ userRef: user.userRef, createdBy: session.record.created_by })) {
       return c.json({ error: { message: FORBIDDEN_SESSION_ACCESS } }, 403);
@@ -300,6 +308,11 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
       if (agent === undefined) {
         return c.json({ error: { message: `Agent not found: ${body.agent.name}` } }, 404);
       }
+      await validateRepositorySandbox({
+        repository: body.repository ?? null,
+        tenant_id: TENANT_ID,
+        sandboxProviderStore: deps.sandboxProviderStore,
+      });
       const user = deps.resolveUserContext(c);
       const session = await deps.sessions.create({
         tenant_id: TENANT_ID,
@@ -307,6 +320,7 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
         created_by: user.userRef,
         agent: { type: 'reference', id: agent.id, name: agent.name },
         metadata: body.metadata,
+        repository: body.repository ?? null,
         external_id: null,
       });
       return c.json({ data: toWireSession(session.record) }, 201);
@@ -320,6 +334,11 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
       skillStore: deps.skillStore,
       sandboxProviderStore: deps.sandboxProviderStore,
     });
+    await validateRepositorySandbox({
+      repository: body.repository ?? null,
+      tenant_id: TENANT_ID,
+      sandboxProviderStore: deps.sandboxProviderStore,
+    });
     const user = deps.resolveUserContext(c);
     const session = await deps.sessions.create({
       tenant_id: TENANT_ID,
@@ -327,6 +346,7 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
       created_by: user.userRef,
       agent: { type: 'inline', spec: body.agent.spec },
       metadata: body.metadata,
+      repository: body.repository ?? null,
       external_id: null,
     });
     return c.json({ data: toWireSession(session.record) }, 201);

--- a/packages/trueforge/src/apis/turns.ts
+++ b/packages/trueforge/src/apis/turns.ts
@@ -2,7 +2,13 @@
  * DB-backed turns API (mounted at /api/v1/sessions).
  */
 import { OpenAPIHono, type RouteHandler } from '@hono/zod-openapi';
-import type { ISessionStore, Sessions, Turn, TurnStreamingEvent } from '@truefoundry/trueforge-core/agent-session';
+import type {
+  ISessionStore,
+  SessionRepository,
+  Sessions,
+  Turn,
+  TurnStreamingEvent,
+} from '@truefoundry/trueforge-core/agent-session';
 import {
   CancellationReason,
   EventType,
@@ -55,6 +61,7 @@ import {
   getModelDetails,
   resolveGitSkills,
   resolveSandboxProvider,
+  type ResolveRepositoryCredentials,
 } from '../runtime/sessionResources';
 import { checkSnapshotStatus } from '../sandbox/providerUtils';
 import { TENANT_ID } from './sessions';
@@ -115,6 +122,7 @@ export interface TurnsRouterDeps {
   sandboxProviderStore: ISandboxProviderStore;
   logger: Logger;
   resolveUserContext: ResolveUserContext;
+  resolveRepositoryCredentials: ResolveRepositoryCredentials;
 }
 
 /**
@@ -124,7 +132,14 @@ export interface TurnsRouterDeps {
  */
 export type BeginTurnExecutionDeps = Pick<
   TurnsRouterDeps,
-  'activeTurns' | 'eventSubscriptions' | 'tokenStore' | 'skillStore' | 'agentStore' | 'sandboxProviderStore' | 'logger'
+  | 'activeTurns'
+  | 'eventSubscriptions'
+  | 'tokenStore'
+  | 'skillStore'
+  | 'agentStore'
+  | 'sandboxProviderStore'
+  | 'logger'
+  | 'resolveRepositoryCredentials'
 > & {
   modelProviderStore: IModelProviderStore;
   mcpServerStore: IMcpServerStore;
@@ -145,6 +160,8 @@ function createTurnResolver(deps: {
   signal: AbortSignal;
   userRef: string;
   sessionId: string;
+  repository: SessionRepository | null;
+  resolveRepositoryCredentials: ResolveRepositoryCredentials;
 }): TurnResourceResolver {
   const {
     mcpServerStore,
@@ -157,8 +174,11 @@ function createTurnResolver(deps: {
     signal,
     userRef,
     sessionId,
+    repository,
+    resolveRepositoryCredentials,
   } = deps;
   return new TurnResourceResolver({
+    sandboxRequired: repository !== null,
     llm: async name => {
       const resolved = await getModelDetails({
         tenant_id: TENANT_ID,
@@ -228,6 +248,15 @@ function createTurnResolver(deps: {
         skills: spec.skills ?? [],
         store: skillStore,
       });
+      let resolvedGitCredentialsContent: string | null = null;
+      if (repository !== null && repository.credential_provider_ref !== null) {
+        resolvedGitCredentialsContent = await resolveRepositoryCredentials({
+          tenant_id: TENANT_ID,
+          session_id: sessionId,
+          user_ref: userRef,
+          repository,
+        });
+      }
       return buildTurnSandbox({
         provider,
         logger,
@@ -235,6 +264,8 @@ function createTurnResolver(deps: {
         fileDownloadEnabled: spec.config.sandbox.file_downloads,
         existingSandboxId: carriedSandboxId,
         tracing,
+        repository,
+        resolvedGitCredentialsContent,
       });
     },
     agent: async agentId => {
@@ -385,6 +416,8 @@ export async function beginTurnExecution(params: {
     signal: abortController.signal,
     userRef,
     sessionId,
+    repository: session.record.repository,
+    resolveRepositoryCredentials: deps.resolveRepositoryCredentials,
   });
 
   // First turn only: derive the title from the first user message. The store

--- a/packages/trueforge/src/app.ts
+++ b/packages/trueforge/src/app.ts
@@ -43,6 +43,7 @@ import { PACKAGE_VERSION } from './packageVersion';
 import { OPENAPI_DOCUMENT_TAGS } from './routes/openapiTags';
 import type { ActiveTurnRegistry } from './runtime/activeTurns';
 import type { EventSubscriptionRegistry } from './runtime/event-subscription';
+import { rejectUnconfiguredRepositoryCredentials, type ResolveRepositoryCredentials } from './runtime/sessionResources';
 import { InvalidCronError } from './schemas/schedule';
 import { zodErrorResponse, zodValidationHook } from './zodErrorResponse';
 
@@ -194,6 +195,8 @@ export interface ServerDeps<TTransaction> {
   logger: Logger;
   /** Discovered openid-client configuration; undefined when browser login is disabled. */
   oidcClient: Configuration | undefined;
+  /** Resolves short-lived Git credentials per turn; credential material is never persisted. */
+  resolveRepositoryCredentials?: ResolveRepositoryCredentials | undefined;
 }
 
 export function createServerApp<TTransaction>(deps: ServerDeps<TTransaction>) {
@@ -299,6 +302,7 @@ export function createServerApp<TTransaction>(deps: ServerDeps<TTransaction>) {
           agentStore: deps.agentStore,
           sandboxProviderStore: deps.sandboxProviderStore,
           logger: deps.logger,
+          resolveRepositoryCredentials: deps.resolveRepositoryCredentials ?? rejectUnconfiguredRepositoryCredentials,
         },
         withTransaction: deps.withTransaction,
         resolveUserContext,
@@ -378,6 +382,7 @@ export function createServerApp<TTransaction>(deps: ServerDeps<TTransaction>) {
         sandboxProviderStore: deps.sandboxProviderStore,
         logger: deps.logger,
         resolveUserContext: resolveUserContext,
+        resolveRepositoryCredentials: deps.resolveRepositoryCredentials ?? rejectUnconfiguredRepositoryCredentials,
       }),
     ),
   );

--- a/packages/trueforge/src/db/postgres/migrations/20260902_000002_session_repository.ts
+++ b/packages/trueforge/src/db/postgres/migrations/20260902_000002_session_repository.ts
@@ -1,0 +1,11 @@
+import { sql, type Kysely } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`SET LOCAL lock_timeout = '5s'`.execute(db);
+  await sql`ALTER TABLE session ADD COLUMN repository jsonb`.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`SET LOCAL lock_timeout = '5s'`.execute(db);
+  await sql`ALTER TABLE session DROP COLUMN repository`.execute(db);
+}

--- a/packages/trueforge/src/db/postgres/session-store/queries/sessions.ts
+++ b/packages/trueforge/src/db/postgres/session-store/queries/sessions.ts
@@ -1,5 +1,10 @@
-import type { AgentSpec, SessionMetadata, SessionMetrics } from '@truefoundry/trueforge-core/agent-session';
-import { SessionMetadataSchema } from '@truefoundry/trueforge-core/agent-session';
+import type {
+  AgentSpec,
+  SessionMetadata,
+  SessionMetrics,
+  SessionRepository,
+} from '@truefoundry/trueforge-core/agent-session';
+import { SessionMetadataSchema, SessionRepositorySchema } from '@truefoundry/trueforge-core/agent-session';
 import type { SessionRecord } from '@truefoundry/trueforge-core/agent-session/models/SessionRecord';
 import type {
   CreateSessionInput,
@@ -47,6 +52,10 @@ function parseSessionMetadata(value: unknown): SessionMetadata {
   return SessionMetadataSchema.parse(value);
 }
 
+function parseSessionRepository(value: unknown): SessionRepository | null {
+  return value === null ? null : SessionRepositorySchema.parse(value);
+}
+
 function mapRowToSessionRecord(row: {
   tenant_id: string;
   session_id: string;
@@ -59,6 +68,7 @@ function mapRowToSessionRecord(row: {
   external_id: string | null;
   custom: Record<string, unknown> | null;
   metadata: SessionMetadata;
+  repository: SessionRepository | null;
   metrics: SessionMetrics;
   created_at: Date;
   updated_at: Date;
@@ -79,6 +89,7 @@ function mapRowToSessionRecord(row: {
     external_id: row.external_id,
     custom: parseSessionCustom(row.custom),
     metadata: parseSessionMetadata(row.metadata),
+    repository: parseSessionRepository(row.repository),
     metrics: row.metrics,
     created_at: row.created_at,
     updated_at: row.updated_at,
@@ -103,6 +114,7 @@ export async function createSession(db: Kysely<Database>, input: CreateSessionIn
         title: null,
         custom: input.custom !== null ? json(input.custom) : null,
         metadata: json(input.metadata),
+        repository: input.repository !== null ? json(input.repository) : null,
         external_id: input.external_id,
         metrics: json({
           total_cost_in_usd: 0,

--- a/packages/trueforge/src/db/postgres/types.ts
+++ b/packages/trueforge/src/db/postgres/types.ts
@@ -7,6 +7,7 @@ import type {
   PersistedTurnEvent,
   SessionMetadata,
   SessionMetrics,
+  SessionRepository,
   TurnInputItem,
   TurnState,
 } from '@truefoundry/trueforge-core/agent-session';
@@ -90,6 +91,8 @@ export interface SessionTable {
   custom: JSONColumnType<Record<string, unknown>, Record<string, unknown>, Record<string, unknown>> | null;
   /** Caller-owned metadata; always present (DEFAULT '{}'). */
   metadata: JSONColumnType<SessionMetadata, SessionMetadata, SessionMetadata>;
+  /** Sandbox checkout metadata only; resolved credentials are never stored. */
+  repository: JSONColumnType<SessionRepository, SessionRepository, SessionRepository> | null;
   metrics: JSONColumnType<SessionMetrics, SessionMetrics, SessionMetrics>;
   /** top: list ordering (indexed below) */
   created_at: Date;

--- a/packages/trueforge/src/db/sqlite/client.ts
+++ b/packages/trueforge/src/db/sqlite/client.ts
@@ -123,6 +123,7 @@ function applyPragmas(database: Database.Database): void {
  */
 const JSON_RESULT_COLUMNS = new Set([
   'agent_spec',
+  'repository',
   'custom',
   'metadata',
   'metrics',

--- a/packages/trueforge/src/db/sqlite/migrations/20260902_000002_session_repository.ts
+++ b/packages/trueforge/src/db/sqlite/migrations/20260902_000002_session_repository.ts
@@ -1,0 +1,13 @@
+import { sql, type Kysely } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.transaction().execute(async trx => {
+    await sql`ALTER TABLE session ADD COLUMN repository BLOB`.execute(trx);
+  });
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.transaction().execute(async trx => {
+    await sql`ALTER TABLE session DROP COLUMN repository`.execute(trx);
+  });
+}

--- a/packages/trueforge/src/db/sqlite/session-store/queries/sessions.ts
+++ b/packages/trueforge/src/db/sqlite/session-store/queries/sessions.ts
@@ -1,5 +1,10 @@
-import type { AgentSpec, SessionMetadata, SessionMetrics } from '@truefoundry/trueforge-core/agent-session';
-import { SessionMetadataSchema } from '@truefoundry/trueforge-core/agent-session';
+import type {
+  AgentSpec,
+  SessionMetadata,
+  SessionMetrics,
+  SessionRepository,
+} from '@truefoundry/trueforge-core/agent-session';
+import { SessionMetadataSchema, SessionRepositorySchema } from '@truefoundry/trueforge-core/agent-session';
 import type { SessionRecord } from '@truefoundry/trueforge-core/agent-session/models/SessionRecord';
 import type {
   CreateSessionInput,
@@ -46,6 +51,10 @@ function parseSessionMetadata(value: unknown): SessionMetadata {
   return SessionMetadataSchema.parse(value);
 }
 
+function parseSessionRepository(value: unknown): SessionRepository | null {
+  return value === null ? null : SessionRepositorySchema.parse(value);
+}
+
 function mapRowToSessionRecord(row: {
   tenant_id: string;
   session_id: string;
@@ -58,6 +67,7 @@ function mapRowToSessionRecord(row: {
   external_id: string | null;
   custom: Record<string, unknown> | null;
   metadata: SessionMetadata;
+  repository: SessionRepository | null;
   metrics: SessionMetrics;
   created_at: string;
   updated_at: string;
@@ -78,6 +88,7 @@ function mapRowToSessionRecord(row: {
     external_id: row.external_id,
     custom: parseSessionCustom(row.custom),
     metadata: parseSessionMetadata(row.metadata),
+    repository: parseSessionRepository(row.repository),
     metrics: row.metrics,
     created_at: new Date(row.created_at),
     updated_at: new Date(row.updated_at),
@@ -98,6 +109,7 @@ function sessionSelectColumns() {
     'external_id' as const,
     jsonText<Record<string, unknown> | null>(sql.ref('custom')).as('custom'),
     jsonText<SessionMetadata>(sql.ref('metadata')).as('metadata'),
+    jsonText<SessionRepository | null>(sql.ref('repository')).as('repository'),
     jsonText<SessionMetrics>(sql.ref('metrics')).as('metrics'),
     'created_at' as const,
     'updated_at' as const,
@@ -122,6 +134,7 @@ export async function createSession(db: Kysely<Database>, input: CreateSessionIn
         title: null,
         custom: input.custom !== null ? jsonbBind(input.custom) : null,
         metadata: jsonbBind(input.metadata),
+        repository: input.repository !== null ? jsonbBind(input.repository) : null,
         external_id: input.external_id,
         metrics: jsonbBind({
           total_cost_in_usd: 0,

--- a/packages/trueforge/src/db/sqlite/types.ts
+++ b/packages/trueforge/src/db/sqlite/types.ts
@@ -10,6 +10,7 @@ import type {
   PersistedTurnEvent,
   SessionMetadata,
   SessionMetrics,
+  SessionRepository,
   TurnInputItem,
   TurnState,
 } from '@truefoundry/trueforge-core/agent-session';
@@ -74,6 +75,8 @@ export interface SessionTable {
   external_id: string | null;
   custom: JsonbColumn<Record<string, unknown>> | null;
   metadata: JsonbColumn<SessionMetadata>;
+  /** Sandbox checkout metadata only; resolved credentials are never stored. */
+  repository: JsonbColumn<SessionRepository> | null;
   metrics: JsonbColumn<SessionMetrics>;
   created_at: string;
   updated_at: string;

--- a/packages/trueforge/src/runtime/sessionResources.ts
+++ b/packages/trueforge/src/runtime/sessionResources.ts
@@ -1,7 +1,7 @@
 /**
  * Store-backed model/MCP/skill/sandbox resolution for session admit and turns.
  */
-import type { AgentSpec } from '@truefoundry/trueforge-core/agent-session';
+import type { AgentSpec, SessionRepository } from '@truefoundry/trueforge-core/agent-session';
 import {
   Sandbox,
   SkillMounter,
@@ -32,6 +32,20 @@ export interface McpConnection {
   url: string;
   headers: RemoteMcpHeaders;
 }
+
+export type ResolveRepositoryCredentials = (input: {
+  tenant_id: string;
+  session_id: string;
+  user_ref: string;
+  repository: SessionRepository;
+}) => Promise<string | null>;
+
+export const rejectUnconfiguredRepositoryCredentials: ResolveRepositoryCredentials = input =>
+  Promise.reject(
+    new HTTPException(422, {
+      message: `Repository credential provider "${input.repository.credential_provider_ref ?? ''}" is not configured`,
+    }),
+  );
 
 /** Split `provider/model` FQN. Returns undefined when the shape is not exactly one slash. */
 export function parseModelFqn(name: string): { providerName: string; modelName: string } | undefined {
@@ -276,6 +290,8 @@ export function buildTurnSandbox(input: {
   fileDownloadEnabled: boolean;
   existingSandboxId?: string | undefined;
   tracing: AgentTracing;
+  repository: SessionRepository | null;
+  resolvedGitCredentialsContent: string | null;
 }): Sandbox {
   const skillMounter = input.gitSkills.length > 0 ? new SkillMounter([...input.gitSkills]) : undefined;
   return new Sandbox({
@@ -288,6 +304,8 @@ export function buildTurnSandbox(input: {
     ...(skillMounter ? { skillMounter } : {}),
     tracing: input.tracing,
     logger: input.logger,
+    repository: input.repository,
+    resolvedGitCredentialsContent: input.resolvedGitCredentialsContent,
   });
 }
 
@@ -365,5 +383,25 @@ export async function validateAgentSpec({
           : 'sandbox is enabled but no sandbox provider is configured — PUT /settings/sandbox-providers',
       });
     }
+  }
+}
+
+export async function validateRepositorySandbox({
+  repository,
+  tenant_id,
+  sandboxProviderStore,
+}: {
+  repository: SessionRepository | null;
+  tenant_id: string;
+  sandboxProviderStore: ISandboxProviderStore;
+}): Promise<void> {
+  if (repository === null) {
+    return;
+  }
+  const record = await sandboxProviderStore.getSandboxProvider(tenant_id);
+  if (record === undefined && !isLocalSandboxFallbackEnabled()) {
+    throw new HTTPException(422, {
+      message: 'repository checkouts require a sandbox provider — configure via PUT /settings/sandbox-providers',
+    });
   }
 }

--- a/packages/trueforge/src/schemas/session.ts
+++ b/packages/trueforge/src/schemas/session.ts
@@ -3,6 +3,7 @@ import { z } from '@hono/zod-openapi';
 import {
   AgentSpecSchema,
   SessionMetadataSchema,
+  SessionRepositorySchema,
   SessionSchema,
   TokenPaginationSchema,
 } from '@truefoundry/trueforge-core/agent-session';
@@ -35,6 +36,7 @@ export const CreateSessionRequestSchema = z
   .object({
     agent: CreateSessionAgentSchema,
     metadata: SessionMetadataSchema.optional(),
+    repository: SessionRepositorySchema.optional(),
   })
   .strict()
   .openapi('CreateSessionRequest');
@@ -43,6 +45,7 @@ export const GetOrCreateSessionByExternalIdRequestSchema = z
   .object({
     external_id: z.string().min(1).max(128).describe('Caller-supplied id unique within the tenant.'),
     agent: CreateSessionAgentSchema,
+    repository: SessionRepositorySchema.optional(),
   })
   .strict()
   .openapi('GetOrCreateSessionByExternalIdRequest');

--- a/packages/trueforge/tests/db/session-metrics/metricsContractSuite.ts
+++ b/packages/trueforge/tests/db/session-metrics/metricsContractSuite.ts
@@ -33,6 +33,7 @@ export function runSessionMetricsStoreContractSuite(
         agent: { type: 'reference', id: 'agent-abc', name: 'Agent ABC' },
         custom: null,
         metadata: {},
+        repository: null,
         external_id: null,
       });
       await sessionStore.createSession({
@@ -42,6 +43,7 @@ export function runSessionMetricsStoreContractSuite(
         agent: { type: 'reference', id: 'agent-abc', name: 'Agent ABC' },
         custom: null,
         metadata: {},
+        repository: null,
         external_id: null,
       });
       await sessionStore.createTurn(makeCreateTurnInput({ sessionId: 'metrics-session', turnId: 'metrics-turn' }));
@@ -122,6 +124,7 @@ export function runSessionMetricsStoreContractSuite(
           agent: { type: 'reference', id: 'agent-distributions', name: 'Agent Distributions' },
           custom: null,
           metadata: {},
+          repository: null,
           external_id: null,
         });
         for (const [index, durationMs] of definition.turnDurations.entries()) {
@@ -172,6 +175,7 @@ export function runSessionMetricsStoreContractSuite(
         agent: { type: 'reference', id: 'agent-inflight', name: 'Agent InFlight' },
         custom: null,
         metadata: {},
+        repository: null,
         external_id: null,
       });
       await sessionStore.createSession({
@@ -181,6 +185,7 @@ export function runSessionMetricsStoreContractSuite(
         agent: { type: 'reference', id: 'agent-inflight', name: 'Agent InFlight' },
         custom: null,
         metadata: {},
+        repository: null,
         external_id: null,
       });
       await sessionStore.createTurn(makeCreateTurnInput({ sessionId: 'inflight-session', turnId: 'inflight-turn' }));

--- a/packages/trueforge/tests/unit/apis/deletedSessionCrud.test.ts
+++ b/packages/trueforge/tests/unit/apis/deletedSessionCrud.test.ts
@@ -66,6 +66,7 @@ describe('public CRUD after session deletion', () => {
         sandboxProviderStore,
         logger: createLogger({ silent: true }),
         resolveUserContext: () => LOCAL_USER_CONTEXT,
+        resolveRepositoryCredentials: () => Promise.resolve(null),
       }),
     );
 
@@ -82,6 +83,7 @@ describe('public CRUD after session deletion', () => {
       },
       custom: null,
       metadata: {},
+      repository: null,
       external_id: null,
     });
     expect((await app.request('/s1', { method: 'DELETE' })).status).toBe(204);

--- a/packages/trueforge/tests/unit/apis/sandboxFileDownload.test.ts
+++ b/packages/trueforge/tests/unit/apis/sandboxFileDownload.test.ts
@@ -47,6 +47,7 @@ async function buildApp() {
       sandboxProviderStore: new SqliteSandboxProviderStore(db),
       logger: createLogger({ silent: true }),
       resolveUserContext: () => LOCAL_USER_CONTEXT,
+      resolveRepositoryCredentials: () => Promise.resolve(null),
     }),
   );
 

--- a/packages/trueforge/tests/unit/apis/schedules.test.ts
+++ b/packages/trueforge/tests/unit/apis/schedules.test.ts
@@ -63,6 +63,7 @@ async function setup() {
         skillStore: {} as never,
         agentStore,
         sandboxProviderStore: {} as never,
+        resolveRepositoryCredentials: () => Promise.resolve(null),
         logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() } as never,
       },
       withTransaction: callback => db.transaction().execute(callback),

--- a/packages/trueforge/tests/unit/apis/sessionHttp.test.ts
+++ b/packages/trueforge/tests/unit/apis/sessionHttp.test.ts
@@ -1,5 +1,5 @@
-import { OpenAPIHono } from '@hono/zod-openapi';
-import { AgentSpecSchema, Sessions } from '@truefoundry/trueforge-core/agent-session';
+import { OpenAPIHono, z } from '@hono/zod-openapi';
+import { AgentSpecSchema, Sessions, SessionSchema } from '@truefoundry/trueforge-core/agent-session';
 import { RequestReplyRouter } from '@truefoundry/trueforge-core/request-reply';
 import { createClient } from 'redis';
 import { createLogger } from 'winston';
@@ -21,6 +21,7 @@ import { SqliteSessionMetricsStore } from '../../../src/db/sqlite/session-metric
 import { SqliteSessionStore } from '../../../src/db/sqlite/session-store/SqliteSessionStore';
 import { SqliteSkillStore } from '../../../src/db/sqlite/skill-store/SqliteSkillStore';
 import { ActiveTurnRegistry } from '../../../src/runtime/activeTurns';
+import { setCachedLocalSandboxSupport } from '../../../src/sandbox/localRuntime';
 import {
   GetSessionMetricsChartDataResponseSchema,
   GetSessionMetricsChartResponseSchema,
@@ -44,6 +45,10 @@ describe('sessions HTTP agent binding', () => {
   let app: OpenAPIHono;
   let agentStore: SqliteAgentStore;
   let sessionStore: SqliteSessionStore;
+
+  afterEach(() => {
+    setCachedLocalSandboxSupport(undefined);
+  });
 
   beforeEach(async () => {
     const db = createSqliteDb(':memory:');
@@ -122,6 +127,47 @@ describe('sessions HTTP agent binding', () => {
     expect(missing.status).toBe(404);
   });
 
+  it('creates and returns a repository-backed session', async () => {
+    setCachedLocalSandboxSupport({
+      supported: true,
+      platform: 'darwin',
+      shell: '/bin/bash',
+      python: '/usr/bin/python3',
+    });
+    const repository = {
+      url: 'https://github.com/example/repository.git',
+      ref: 'main',
+      path: 'workspace/repository',
+      access: 'read_write',
+      credential_provider_ref: 'github-app:installation-123',
+    };
+    const response = await app.request('/', jsonInit('POST', { agent: { spec: inlineSpec }, repository }));
+
+    expect(response.status).toBe(201);
+    const payload = z.object({ data: SessionSchema }).parse(await response.json()).data;
+    expect(payload.repository).toEqual(repository);
+  });
+
+  it('rejects a repository-backed session when no sandbox provider is available', async () => {
+    const response = await app.request(
+      '/',
+      jsonInit('POST', {
+        agent: { spec: inlineSpec },
+        repository: {
+          url: 'https://github.com/example/repository.git',
+          ref: 'main',
+          path: 'workspace/repository',
+          access: 'read_only',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.text()).resolves.toBe(
+      'repository checkouts require a sandbox provider — configure via PUT /settings/sandbox-providers',
+    );
+  });
+
   it('creates a named session and filters list by agent_id', async () => {
     const agent = await agentStore.createAgent({
       tenant_id: TENANT_ID,
@@ -161,6 +207,7 @@ describe('sessions HTTP agent binding', () => {
       agent: { type: 'reference', id: agent.id, name: agent.name },
       custom: null,
       metadata: {},
+      repository: null,
       external_id: null,
     });
     await sessionStore.createSession({
@@ -170,6 +217,7 @@ describe('sessions HTTP agent binding', () => {
       agent: { type: 'reference', id: agent.id, name: agent.name },
       custom: null,
       metadata: {},
+      repository: null,
       external_id: null,
     });
     const start = new Date(Date.now() - 60 * 60 * 1000);
@@ -232,6 +280,7 @@ describe('sessions HTTP agent binding', () => {
       agent: { type: 'inline', spec: inlineSpec },
       custom: null,
       metadata: {},
+      repository: null,
       external_id: null,
     });
 
@@ -399,6 +448,7 @@ describe('sessions HTTP agent binding', () => {
       agent: { type: 'inline', spec: inlineSpec },
       custom: null,
       metadata: {},
+      repository: null,
       external_id: 'run-theirs',
     });
     const forbidden = await app.request(

--- a/packages/trueforge/tests/unit/apis/turnHarnessErrorStatus.test.ts
+++ b/packages/trueforge/tests/unit/apis/turnHarnessErrorStatus.test.ts
@@ -64,6 +64,7 @@ async function postTurnRejectingWith(error: AgentHarnessError): Promise<Response
       sandboxProviderStore: new SqliteSandboxProviderStore(db),
       logger: createLogger({ silent: true }),
       resolveUserContext: () => LOCAL_USER_CONTEXT,
+      resolveRepositoryCredentials: () => Promise.resolve(null),
     }),
   );
 

--- a/packages/trueforge/tests/unit/apis/turns.test.ts
+++ b/packages/trueforge/tests/unit/apis/turns.test.ts
@@ -42,6 +42,7 @@ describe('turns', () => {
         },
         custom: null,
         metadata: {},
+        repository: null,
         external_id: null,
       });
 
@@ -61,6 +62,7 @@ describe('turns', () => {
           sandboxProviderStore: new SqliteSandboxProviderStore(db),
           logger: createLogger({ silent: true }),
           resolveUserContext: () => LOCAL_USER_CONTEXT,
+          resolveRepositoryCredentials: () => Promise.resolve(null),
         }),
       );
 
@@ -180,6 +182,7 @@ describe('turns', () => {
           sandboxProviderStore: new SqliteSandboxProviderStore(db),
           logger,
           resolveUserContext: () => LOCAL_USER_CONTEXT,
+          resolveRepositoryCredentials: () => Promise.resolve(null),
         }),
       );
 
@@ -280,6 +283,7 @@ describe('turns', () => {
           sandboxProviderStore: new SqliteSandboxProviderStore(db),
           logger,
           resolveUserContext: () => LOCAL_USER_CONTEXT,
+          resolveRepositoryCredentials: () => Promise.resolve(null),
         }),
       );
 

--- a/packages/trueforge/tests/unit/runtime/sessionResources.test.ts
+++ b/packages/trueforge/tests/unit/runtime/sessionResources.test.ts
@@ -7,7 +7,12 @@ import { SqliteMcpServerStore } from '../../../src/db/sqlite/mcp-server-store/Sq
 import { SqliteModelProviderStore } from '../../../src/db/sqlite/model-provider-store/SqliteModelProviderStore';
 import { SqliteSandboxProviderStore } from '../../../src/db/sqlite/sandbox-provider-store/SqliteSandboxProviderStore';
 import { SqliteSkillStore } from '../../../src/db/sqlite/skill-store/SqliteSkillStore';
-import { getModelDetails, localSandboxSessionSegment, validateAgentSpec } from '../../../src/runtime/sessionResources';
+import {
+  getModelDetails,
+  localSandboxSessionSegment,
+  rejectUnconfiguredRepositoryCredentials,
+  validateAgentSpec,
+} from '../../../src/runtime/sessionResources';
 import { setCachedLocalSandboxSupport } from '../../../src/sandbox/localRuntime';
 import type { ReasoningEffort } from '../../../src/schemas/modelProvider';
 
@@ -19,6 +24,28 @@ describe('localSandboxSessionSegment', () => {
     expect(localSandboxSessionSegment('a/b')).toBe('_');
     expect(localSandboxSessionSegment('..')).toBe('_');
     expect(localSandboxSessionSegment('foo..bar')).toBe('_');
+  });
+});
+
+describe('rejectUnconfiguredRepositoryCredentials', () => {
+  it('identifies an unresolved opaque provider reference', async () => {
+    await expect(
+      rejectUnconfiguredRepositoryCredentials({
+        tenant_id: TENANT_ID,
+        session_id: 'session-1',
+        user_ref: 'user-1',
+        repository: {
+          url: 'https://github.com/example/repository.git',
+          ref: 'main',
+          path: 'workspace/repository',
+          access: 'read_write',
+          credential_provider_ref: 'github-app:installation-123',
+        },
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: 'Repository credential provider "github-app:installation-123" is not configured',
+    } satisfies Partial<HTTPException>);
   });
 });
 


### PR DESCRIPTION
## Summary

- add an immutable session repository resource with HTTPS URL, ref, destination path, access mode, and opaque credential-provider reference
- persist repository metadata in SQLite and PostgreSQL without storing resolved credentials
- resolve credentials per turn and initialize or refresh the checkout without resetting resumed work
- force sandbox provisioning for repository-backed sessions and restrict the configured push remote for read-only checkouts
- add schema, store-contract, API, sandbox initialization, and resolver tests

## Validation

- `pnpm format:fix`
- `pnpm lint:ci`
- `pnpm typecheck`
- `pnpm test`
- SQLite store contract suite
- PostgreSQL store suite invoked but skipped because no local test database URL was configured

Closes #556

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox git exec, per-turn credential resolution, and session persistence; mitigated by strict URL/path/ref validation and not storing secrets, but misconfigured providers or checkout bugs could affect repo access or sandbox state.
> 
> **Overview**
> Adds an optional **immutable `repository`** on sessions so agents get a **persistent Git checkout** in the session sandbox (HTTPS URL, ref, sandbox-relative path, and `read_only` or `read_write` access). Only metadata and an opaque `credential_provider_ref` are stored; **resolved Git credentials are resolved each turn** and never written to the DB.
> 
> **Create/get-or-create session APIs** accept `repository`, return it on the wire, and **reject repository-backed sessions** when no sandbox provider is configured. **Turn setup** forces sandbox provisioning when a repository is set (`sandboxRequired`), resolves credentials via an injectable `resolveRepositoryCredentials` hook (default **422** if a provider ref is set but not configured), and passes checkout config into the sandbox.
> 
> **Sandbox init** syncs git credential files, then runs an **idempotent checkout** that fetches/updates the remote without `git reset` (so resumed sandboxes keep local work). **Read-only** checkouts disable push via a disabled push URL; **read-write** configures push to the session ref. Agent instructions mention the checkout path.
> 
> Schema/store contract, HTTP, resolver, and sandbox command tests cover validation (HTTPS-only URLs, safe paths/refs) and persistence without credential leakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c78cc2ecb807163ba17f60b044caaa5f10dac5de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->