### PR TITLE
feat: per-MCP-server request headers via x-tfg-mcp-headers

### DIFF
--- a/.changeset/tfg-per-server-mcp-headers.md
+++ b/.changeset/tfg-per-server-mcp-headers.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": patch
+---
+
+Per-MCP-server request headers via `x-tfg-mcp-headers`, merged into the invoke headers for the named server. Lets a caller that authenticates as one identity give each MCP server the identity it should actually see.

--- a/packages/trueforge/src/main.ts
+++ b/packages/trueforge/src/main.ts
@@ -83,6 +83,7 @@ import { PACKAGE_VERSION } from './packageVersion';
 import { ActiveTurnRegistry } from './runtime/activeTurns';
 import { EventSubscriptionRegistry } from './runtime/event-subscription';
 import { printStandaloneStartupBanner } from './startupBanner';
+import { parsePerServerMcpHeaders, X_TFG_MCP_HEADERS } from './truefoundry/perServerMcpHeaders';
 import { TrueFoundryMcpServerStore } from './truefoundry/TrueFoundryMcpServerStore';
 import { TrueFoundryModelProviderStore } from './truefoundry/TrueFoundryModelProviderStore';
 import { TrueFoundryServiceFoundryServerClient } from './truefoundry/TrueFoundryServiceFoundryServerClient';
@@ -163,7 +164,11 @@ function buildResolveMcpServerStore<TTransaction>(options: {
   });
   return c =>
     c
-      ? new TrueFoundryMcpServerStore<TTransaction>({ client, accessToken: requireRequestCredentialToken(c) })
+      ? new TrueFoundryMcpServerStore<TTransaction>({
+          client,
+          accessToken: requireRequestCredentialToken(c),
+          perServerHeaders: parsePerServerMcpHeaders(c.req.header(X_TFG_MCP_HEADERS)),
+        })
       : withAuthPersistence;
 }
 

--- a/packages/trueforge/src/main.ts
+++ b/packages/trueforge/src/main.ts
@@ -162,14 +162,17 @@ function buildResolveMcpServerStore<TTransaction>(options: {
     logger: options.logger,
     tls: { enabled: configuration.TRUEFOUNDRY_MTLS_ENABLED, dir: configuration.TRUEFOUNDRY_MTLS_CERTS_DIR },
   });
-  return c =>
-    c
-      ? new TrueFoundryMcpServerStore<TTransaction>({
-          client,
-          accessToken: requireRequestCredentialToken(c),
-          perServerHeaders: parsePerServerMcpHeaders(c.req.header(X_TFG_MCP_HEADERS)),
-        })
-      : withAuthPersistence;
+  return c => {
+    if (!c) {
+      return withAuthPersistence;
+    }
+    const rawPerServerHeaders = c.req.header(X_TFG_MCP_HEADERS);
+    return new TrueFoundryMcpServerStore<TTransaction>({
+      client,
+      accessToken: requireRequestCredentialToken(c),
+      perServerHeaders: rawPerServerHeaders ? parsePerServerMcpHeaders(rawPerServerHeaders) : {},
+    });
+  };
 }
 
 /** SQLite stores; Redis unused (executor peering disabled). */

--- a/packages/trueforge/src/truefoundry/TrueFoundryMcpServerStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryMcpServerStore.ts
@@ -28,6 +28,13 @@ function managed(): never {
   throw new HTTPException(TRUEFOUNDRY_MANAGED_STATUS, { message: TRUEFOUNDRY_MANAGED_MESSAGE });
 }
 
+function withoutAuthorization(headers: Record<string, string> | undefined): Record<string, string> {
+  if (headers === undefined) {
+    return {};
+  }
+  return Object.fromEntries(Object.entries(headers).filter(([name]) => name.toLowerCase() !== 'authorization'));
+}
+
 /**
  * Read-only MCP registry backed by ServiceFoundry + the tenant AI Gateway.
  * Writes and local OAuth client columns are not supported — configure servers in TrueFoundry.
@@ -49,12 +56,14 @@ export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServ
   }
 
   /**
-   * The gateway Bearer is written last so a per-server override cannot replace it: it is what the
-   * gateway authorises `USE_MCP_SERVER` on, and the overrides are cargo it forwards upstream.
+   * The gateway Bearer is what the gateway authorises `USE_MCP_SERVER` on; the overrides are cargo
+   * it forwards upstream. Writing the Bearer last is not enough on its own to protect it, because
+   * object keys are case-sensitive and header names are not: an override under another casing would
+   * survive as a separate key and reach the wire alongside it. So it is dropped, not overwritten.
    */
   resolveInvokeHeaders(record: McpServerRecord): Record<string, string> {
     return {
-      ...this.#perServerHeaders[record.name],
+      ...withoutAuthorization(this.#perServerHeaders[record.name]),
       Authorization: `Bearer ${this.#accessToken}`,
     };
   }

--- a/packages/trueforge/src/truefoundry/TrueFoundryMcpServerStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryMcpServerStore.ts
@@ -20,6 +20,7 @@ import {
   toTrueFoundryMcpManifest,
   type SfyMcpServerSummary,
 } from './mapSfyMcpServers';
+import type { PerServerMcpHeaders } from './perServerMcpHeaders';
 import { TRUEFOUNDRY_MANAGED_MESSAGE, TRUEFOUNDRY_MANAGED_STATUS } from './trueFoundryManaged';
 import type { TrueFoundryServiceFoundryServerClient } from './TrueFoundryServiceFoundryServerClient';
 
@@ -35,15 +36,27 @@ function managed(): never {
 export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServerWithAuthStore<TTransaction> {
   readonly #client: TrueFoundryServiceFoundryServerClient;
   readonly #accessToken: string;
+  readonly #perServerHeaders: PerServerMcpHeaders;
 
-  constructor(input: { client: TrueFoundryServiceFoundryServerClient; accessToken: string }) {
+  constructor(input: {
+    client: TrueFoundryServiceFoundryServerClient;
+    accessToken: string;
+    perServerHeaders?: PerServerMcpHeaders;
+  }) {
     this.#client = input.client;
     this.#accessToken = input.accessToken;
+    this.#perServerHeaders = input.perServerHeaders ?? {};
   }
 
+  /**
+   * The gateway Bearer is written last so a per-server override cannot replace it: it is what the
+   * gateway authorises `USE_MCP_SERVER` on, and the overrides are cargo it forwards upstream.
+   */
   resolveInvokeHeaders(record: McpServerRecord): Record<string, string> {
-    void record;
-    return { Authorization: `Bearer ${this.#accessToken}` };
+    return {
+      ...this.#perServerHeaders[record.name],
+      Authorization: `Bearer ${this.#accessToken}`,
+    };
   }
 
   async listServers(input: ListMcpServersInput, transaction?: TTransaction): Promise<McpServerRecord[]> {

--- a/packages/trueforge/src/truefoundry/perServerMcpHeaders.ts
+++ b/packages/trueforge/src/truefoundry/perServerMcpHeaders.ts
@@ -27,8 +27,8 @@ export function parsePerServerMcpHeaders(raw: string | undefined): PerServerMcpH
   let decoded: unknown;
   try {
     decoded = JSON.parse(raw);
-  } catch {
-    throw new HTTPException(400, { message: `${X_TFG_MCP_HEADERS} must be a JSON object` });
+  } catch (error) {
+    throw new HTTPException(400, { message: `${X_TFG_MCP_HEADERS} must be a JSON object`, cause: error });
   }
 
   const parsed = PerServerMcpHeadersSchema.safeParse(decoded);

--- a/packages/trueforge/src/truefoundry/perServerMcpHeaders.ts
+++ b/packages/trueforge/src/truefoundry/perServerMcpHeaders.ts
@@ -1,0 +1,41 @@
+import { HTTPException } from 'hono/http-exception';
+import { z } from 'zod';
+
+/**
+ * Per-MCP-server request headers, keyed by server name.
+ *
+ * TrueForge authenticates the whole turn as one caller, so every MCP connection would otherwise
+ * present that same identity. This carries the identity each individual server should see —
+ * typically the end user behind the caller, for a server that resolves its own permissions.
+ */
+export const X_TFG_MCP_HEADERS = 'x-tfg-mcp-headers';
+
+const PerServerMcpHeadersSchema = z.record(z.string().min(1), z.record(z.string().min(1), z.string()));
+
+export type PerServerMcpHeaders = z.infer<typeof PerServerMcpHeadersSchema>;
+
+/**
+ * Absent is fine and means "no overrides". Malformed is not: the alternative to failing is running
+ * a user's tool calls under the caller's own identity, which is the thing these headers exist to
+ * prevent, so a bad value is rejected rather than dropped.
+ */
+export function parsePerServerMcpHeaders(raw: string | undefined): PerServerMcpHeaders {
+  if (raw === undefined || raw.length === 0) {
+    return {};
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    throw new HTTPException(400, { message: `${X_TFG_MCP_HEADERS} must be a JSON object` });
+  }
+
+  const parsed = PerServerMcpHeadersSchema.safeParse(decoded);
+  if (!parsed.success) {
+    throw new HTTPException(400, {
+      message: `${X_TFG_MCP_HEADERS} must map each MCP server name to a header map`,
+    });
+  }
+  return parsed.data;
+}

--- a/packages/trueforge/src/truefoundry/perServerMcpHeaders.ts
+++ b/packages/trueforge/src/truefoundry/perServerMcpHeaders.ts
@@ -15,15 +15,11 @@ const PerServerMcpHeadersSchema = z.record(z.string().min(1), z.record(z.string(
 export type PerServerMcpHeaders = z.infer<typeof PerServerMcpHeadersSchema>;
 
 /**
- * Absent is fine and means "no overrides". Malformed is not: the alternative to failing is running
- * a user's tool calls under the caller's own identity, which is the thing these headers exist to
- * prevent, so a bad value is rejected rather than dropped.
+ * Rejects a malformed value rather than dropping it: the alternative to failing is running a user's
+ * tool calls under the caller's own identity, which is the thing these headers exist to prevent.
+ * An absent header is the caller's to interpret.
  */
-export function parsePerServerMcpHeaders(raw: string | undefined): PerServerMcpHeaders {
-  if (raw === undefined || raw.length === 0) {
-    return {};
-  }
-
+export function parsePerServerMcpHeaders(raw: string): PerServerMcpHeaders {
   let decoded: unknown;
   try {
     decoded = JSON.parse(raw);

--- a/packages/trueforge/tests/unit/truefoundry/perServerMcpHeaders.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/perServerMcpHeaders.test.ts
@@ -1,0 +1,73 @@
+import { HTTPException } from 'hono/http-exception';
+import type { McpServerRecord } from '../../../src/db/mcpServerStore';
+import { parsePerServerMcpHeaders } from '../../../src/truefoundry/perServerMcpHeaders';
+import { TrueFoundryMcpServerStore } from '../../../src/truefoundry/TrueFoundryMcpServerStore';
+
+const record = (name: string): McpServerRecord => ({ name }) as McpServerRecord;
+
+const storeWith = (perServerHeaders: Record<string, Record<string, string>>): TrueFoundryMcpServerStore =>
+  new TrueFoundryMcpServerStore({
+    client: {} as never,
+    accessToken: 'caller-token',
+    perServerHeaders,
+  });
+
+describe('parsePerServerMcpHeaders', () => {
+  it('treats an absent header as no overrides, which is the common case', () => {
+    expect(parsePerServerMcpHeaders(undefined)).toEqual({});
+    expect(parsePerServerMcpHeaders('')).toEqual({});
+  });
+
+  it('parses a header map per server name', () => {
+    const raw = JSON.stringify({ 'tfy-platform-mcp': { 'x-tfy-mcp-headers': '{"Authorization":"Bearer user"}' } });
+
+    expect(parsePerServerMcpHeaders(raw)).toEqual({
+      'tfy-platform-mcp': { 'x-tfy-mcp-headers': '{"Authorization":"Bearer user"}' },
+    });
+  });
+
+  it.each([
+    ['not json', 'not-json'],
+    ['an array', '[]'],
+    ['a scalar', '"nope"'],
+    ['a server mapped to a string', JSON.stringify({ 'tfy-platform-mcp': 'Bearer user' })],
+    ['a header mapped to a number', JSON.stringify({ 'tfy-platform-mcp': { 'x-h': 1 } })],
+  ])('rejects %s rather than silently dropping the identity it carries', (_case, raw) => {
+    expect(() => parsePerServerMcpHeaders(raw)).toThrow(HTTPException);
+  });
+});
+
+describe('TrueFoundryMcpServerStore.resolveInvokeHeaders', () => {
+  it('sends only the gateway Bearer when a server has no override', () => {
+    expect(storeWith({}).resolveInvokeHeaders(record('tfy-docs-mcp'))).toEqual({
+      Authorization: 'Bearer caller-token',
+    });
+  });
+
+  it("merges that server's override on top of the Bearer", () => {
+    const headers = storeWith({
+      'tfy-platform-mcp': { 'x-tfy-mcp-headers': '{"Authorization":"Bearer user"}' },
+    }).resolveInvokeHeaders(record('tfy-platform-mcp'));
+
+    expect(headers).toEqual({
+      Authorization: 'Bearer caller-token',
+      'x-tfy-mcp-headers': '{"Authorization":"Bearer user"}',
+    });
+  });
+
+  it('gives one server nothing of another, so an identity cannot reach the wrong upstream', () => {
+    const headers = storeWith({
+      'tfy-platform-mcp': { 'x-tfy-mcp-headers': '{"Authorization":"Bearer user"}' },
+    }).resolveInvokeHeaders(record('tfy-pylon-mcp'));
+
+    expect(headers).toEqual({ Authorization: 'Bearer caller-token' });
+  });
+
+  it('keeps the gateway Bearer even when an override tries to replace it', () => {
+    const headers = storeWith({
+      'tfy-platform-mcp': { Authorization: 'Bearer smuggled' },
+    }).resolveInvokeHeaders(record('tfy-platform-mcp'));
+
+    expect(headers['Authorization']).toBe('Bearer caller-token');
+  });
+});

--- a/packages/trueforge/tests/unit/truefoundry/perServerMcpHeaders.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/perServerMcpHeaders.test.ts
@@ -13,11 +13,6 @@ const storeWith = (perServerHeaders: Record<string, Record<string, string>>): Tr
   });
 
 describe('parsePerServerMcpHeaders', () => {
-  it('treats an absent header as no overrides, which is the common case', () => {
-    expect(parsePerServerMcpHeaders(undefined)).toEqual({});
-    expect(parsePerServerMcpHeaders('')).toEqual({});
-  });
-
   it('parses a header map per server name', () => {
     const raw = JSON.stringify({ 'tfy-platform-mcp': { 'x-tfy-mcp-headers': '{"Authorization":"Bearer user"}' } });
 

--- a/packages/trueforge/tests/unit/truefoundry/perServerMcpHeaders.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/perServerMcpHeaders.test.ts
@@ -35,6 +35,12 @@ describe('parsePerServerMcpHeaders', () => {
   ])('rejects %s rather than silently dropping the identity it carries', (_case, raw) => {
     expect(() => parsePerServerMcpHeaders(raw)).toThrow(HTTPException);
   });
+
+  it('keeps the parse failure as the cause, so a bad header can be debugged', () => {
+    expect(() => parsePerServerMcpHeaders('not-json')).toThrow(
+      expect.objectContaining({ cause: expect.any(SyntaxError) }),
+    );
+  });
 });
 
 describe('TrueFoundryMcpServerStore.resolveInvokeHeaders', () => {
@@ -63,11 +69,22 @@ describe('TrueFoundryMcpServerStore.resolveInvokeHeaders', () => {
     expect(headers).toEqual({ Authorization: 'Bearer caller-token' });
   });
 
-  it('keeps the gateway Bearer even when an override tries to replace it', () => {
+  it.each(['Authorization', 'authorization', 'AUTHORIZATION', 'AuThOrIzAtIoN'])(
+    'drops an override under %s, which object keys would otherwise keep beside the Bearer',
+    name => {
+      const headers = storeWith({
+        'tfy-platform-mcp': { [name]: 'Bearer smuggled' },
+      }).resolveInvokeHeaders(record('tfy-platform-mcp'));
+
+      expect(Object.values(headers)).toEqual(['Bearer caller-token']);
+    },
+  );
+
+  it('keeps the rest of an override that also carried an authorization key', () => {
     const headers = storeWith({
-      'tfy-platform-mcp': { Authorization: 'Bearer smuggled' },
+      'tfy-platform-mcp': { authorization: 'Bearer smuggled', 'x-tfy-mcp-headers': '{"a":"b"}' },
     }).resolveInvokeHeaders(record('tfy-platform-mcp'));
 
-    expect(headers['Authorization']).toBe('Bearer caller-token');
+    expect(headers).toEqual({ Authorization: 'Bearer caller-token', 'x-tfy-mcp-headers': '{"a":"b"}' });
   });
 });


### PR DESCRIPTION
## Why

A caller authenticates a whole turn as one identity, and since #555 that identity is what every MCP connection presents as its gateway Bearer. That is correct for the gateway, which authorises `USE_MCP_SERVER` on the caller — but it means a server that resolves permissions for the *end user behind* the caller has no way to learn who that is. Every user's tool calls arrive as the same account.

## What

`x-tfg-mcp-headers` maps an MCP server name to the headers that server's connection should carry:

```http
x-tfg-mcp-headers: {"tfy-platform-mcp": {"x-tfy-mcp-headers": "{\"Authorization\":\"Bearer <end user token>\"}"}}
```

`TrueFoundryMcpServerStore.resolveInvokeHeaders` merges the entry for the server it is resolving. Building on #555 means this is a small change — that PR moved invoke headers onto the store and already passes the record, so the server name needed to key the lookup was there.

## Notes for review

- **The gateway Bearer is written last**, so an override cannot replace the token authorisation depends on. Covered by a test.
- **A malformed value is a 400, not a no-op.** Ignoring it would silently run the end user's tool calls under the caller's own identity, which is the thing the header exists to prevent. Absent is still fine and means no overrides.
- **No server sees another server's entry** — the merge is keyed on `record.name`, which `toRecord` sets from the ServiceFoundry server name. Also covered by a test.
- Read where the request-scoped store is built, next to the existing `requireAccessToken(c)`. Not declared in OpenAPI, matching how `Last-Event-Id` is handled today; the changeset bumps only `@truefoundry/trueforge` for the same reason.
- Not added to `mcpServerStoreContractSuite` — that covers the DB-backed stores, and this behaviour is specific to `TrueFoundryMcpServerStore`.

## Open question

`x-tfg-` is a new prefix; nothing else in the repo uses it, and there is no `x-trueforge-` either. Happy to rename before this sets a precedent for the integration contract.

## Test plan

- [x] `tests/unit/truefoundry/perServerMcpHeaders.test.ts` — parsing, rejection cases, per-server isolation, and the non-overridable Bearer
- [x] Adjacent suites still pass: `getMcpConnection`, `mapSfyMcpServers`
- [x] `typecheck`, `eslint`, `prettier --check` clean
- [ ] Not verified: whether these headers can reach persisted turn events or logs. They carry a bearer token, so worth a second pair of eyes.

Made with [Cursor](https://cursor.com)