### PR TITLE
feat: Add GitHub Actions workflow to sync commit SHA to trueforge-dev…

### DIFF
--- a/.github/workflows/sync-devtest-commit.yml
+++ b/.github/workflows/sync-devtest-commit.yml
@@ -1,0 +1,52 @@
+name: Sync commit to trueforge-devtest-deployment
+
+# Writes github.sha into trueforge-devtest-deployment/test.txt on main.
+# For pre-main testing: add your branch under push.branches (or use workflow_dispatch
+# once this file is on the default branch).
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, test-sujai]
+
+concurrency:
+  group: sync-devtest-commit
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Update test.txt with trueforge SHA
+    runs-on: ubuntu-latest
+    steps:
+      - id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.TRUEFORGE_GENERATE_SDK_APP_ID }}
+          private-key: ${{ secrets.TRUEFORGE_GENERATE_SDK_APP_PRIVATE_KEY }}
+          owner: truefoundry
+          repositories: trueforge-devtest-deployment
+
+      - uses: actions/checkout@v7
+        with:
+          repository: truefoundry/trueforge-devtest-deployment
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Write commit SHA and push
+        env:
+          SHA: ${{ github.sha }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          echo "$SHA" > test.txt
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+          git add test.txt
+          if git diff --cached --quiet; then
+            echo "test.txt already at $SHA"
+            exit 0
+          fi
+          git commit -m "chore: pin trueforge@${SHA}"
+          git push
+          echo "Updated test.txt → \`$SHA\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
…test-deployment

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New automation only; it reuses existing GitHub App credentials and writes a single pin file in a devtest deployment repo, with no application runtime changes.
> 
> **Overview**
> Adds a **GitHub Actions workflow** that keeps `trueforge-devtest-deployment` in sync with commits from this repo by writing the triggering commit’s SHA into `test.txt` and pushing when it changes.
> 
> The job runs on **push** to `main` and `test-sujai` (or **manual** `workflow_dispatch`), mints a token via the existing Trueforge GitHub App secrets, checks out `truefoundry/trueforge-devtest-deployment`, updates `test.txt`, and commits with `chore: pin trueforge@<sha>` only if the file actually changed. A **concurrency** group serializes runs without canceling in-flight jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19712f010a7e741c574273ca9087ce8824b0c671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->