### PR TITLE
Feat/update commit

### DIFF
--- a/.github/workflows/sync-devtest-commit.yml
+++ b/.github/workflows/sync-devtest-commit.yml
@@ -1,8 +1,9 @@
 name: Sync commit to trueforge-devtest-deployment
 
-# Writes github.sha into trueforge-devtest-deployment/test.txt on main.
-# For pre-main testing: add your branch under push.branches (or use workflow_dispatch
-# once this file is on the default branch).
+# Pins github.sha into trueforge-devtest-deployment/truefoundry.yaml (both
+# components' image.build_source.ref) and pushes to main. That merge triggers
+# tfy-deploy in the deployment repo.
+# For pre-main testing: add your branch under push.branches.
 on:
   workflow_dispatch:
   push:
@@ -17,7 +18,7 @@ permissions:
 
 jobs:
   sync:
-    name: Update test.txt with trueforge SHA
+    name: Pin SHA and push
     runs-on: ubuntu-latest
     steps:
       - id: app-token
@@ -33,20 +34,33 @@ jobs:
           repository: truefoundry/trueforge-devtest-deployment
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Write commit SHA and push
+      - name: Install yq
+        run: |
+          sudo wget -q https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
+
+      - name: Pin trueforge SHA and push
         env:
           SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -euo pipefail
+          yq -i '
+            (.components[] | select(.image.build_source.repo_url == "https://github.com/truefoundry/trueforge") |
+              .image.build_source.ref) = strenv(SHA) |
+            (.components[] | select(.image.build_source.repo_url == "https://github.com/truefoundry/trueforge") |
+              .image.build_source.branch_name) = strenv(BRANCH)
+          ' truefoundry.yaml
           echo "$SHA" > test.txt
+
           git config user.name "${APP_SLUG}[bot]"
           git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
-          git add test.txt
+          git add truefoundry.yaml test.txt
           if git diff --cached --quiet; then
-            echo "test.txt already at $SHA"
+            echo "Already pinned at $SHA"
             exit 0
           fi
           git commit -m "chore: pin trueforge@${SHA}"
           git push
-          echo "Updated test.txt → \`$SHA\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Pinned trueforge@\`$SHA\` on main" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
…ndry.yaml and push changes

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to an external deployment sync workflow; no application runtime or auth logic is modified.
> 
> **Overview**
> The **sync-devtest-commit** workflow no longer only records the commit in `test.txt`; it now **pins** the triggering `github.sha` and branch into `truefoundry.yaml` in `trueforge-devtest-deployment` for every component whose `image.build_source` points at the trueforge repo (`ref` and `branch_name`), then commits and pushes so deployment can run via **tfy-deploy**.
> 
> A new step installs **yq** and applies those YAML updates alongside the existing `test.txt` write. Job naming, comments, and step summaries were updated to match the pin-and-push behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f696b13e2a0d80a87c649e0281baff220c6ea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->