### PR TITLE
Add agent_id to schedule table with index

### DIFF
--- a/.changeset/schedule-agent-id.md
+++ b/.changeset/schedule-agent-id.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": patch
+---
+
+Add NOT NULL `agent_id` on `schedule` (backfilled from `agent`), FK to `agent(id)`, and `(tenant_id, agent_id)` index for per-agent listing.

--- a/.changeset/schedule-agent-id.md
+++ b/.changeset/schedule-agent-id.md
@@ -2,4 +2,4 @@
 "@truefoundry/trueforge": patch
 ---
 
-Add NOT NULL `agent_id` on `schedule` (backfilled from `agent`), FK to `agent(id)`, and `(tenant_id, agent_id)` index for per-agent listing.
+Add NOT NULL `agent_id` on `schedule` (backfilled from `agent`), FK to `agent(id)` ON DELETE CASCADE (replacing the `(tenant_id, agent_name)` FK), and `(tenant_id, agent_id)` index for per-agent listing.

--- a/packages/trueforge/src/apis/schedules.ts
+++ b/packages/trueforge/src/apis/schedules.ts
@@ -250,6 +250,7 @@ export function createSchedulesRouter<TTransaction>(deps: SchedulesRouterDeps<TT
         const { schedule } = await deps.scheduleStore.createScheduleAndRun(
           {
             tenant_id: requestContext.tenant_id,
+            agent_id: agent.id,
             agent_name: agent.name,
             name: body.name,
             manifest: body.manifest,

--- a/packages/trueforge/src/db/indexes.ts
+++ b/packages/trueforge/src/db/indexes.ts
@@ -13,5 +13,8 @@ export const SESSION_CREATED_BY_SUBJECT_ID_IDX = 'session_created_by_subject_id_
 /** `(tenant_id, created_by_subject.subject_id)` on schedule. */
 export const SCHEDULE_CREATED_BY_SUBJECT_ID_IDX = 'schedule_created_by_subject_id_idx';
 
+/** `(tenant_id, agent_id)` on schedule — list schedules for one agent by id. */
+export const SCHEDULE_AGENT_ID_IDX = 'schedule_agent_id_idx';
+
 /** `(tenant_id, created_by_subject.subject_id)` on schedule_run. */
 export const SCHEDULE_RUN_CREATED_BY_SUBJECT_ID_IDX = 'schedule_run_created_by_subject_id_idx';

--- a/packages/trueforge/src/db/postgres/migrations/20260904_000001_schedule_agent_id.ts
+++ b/packages/trueforge/src/db/postgres/migrations/20260904_000001_schedule_agent_id.ts
@@ -1,36 +1,46 @@
 import { sql, type Kysely } from 'kysely';
 import { SCHEDULE_AGENT_ID_IDX } from '../../indexes';
 
+/**
+ * Add `agent_id` on schedule (stable ULID binding). Backfills from `agent` via
+ * `(tenant_id, agent_name)`, then drops the name FK in favor of `agent(id)`.
+ * Index mirrors `session_agent_id_idx` for per-agent schedule lists.
+ * Runs inside the Migrator's transaction — do not nest `db.transaction()`.
+ */
 export async function up(db: Kysely<unknown>): Promise<void> {
-  await sql`SET LOCAL lock_timeout = '5s'`.execute(db);
-
-  await db.schema.alterTable('schedule').addColumn('agent_id', 'text').execute();
-
   await sql`
+    SET LOCAL lock_timeout = '5s';
+
+    ALTER TABLE schedule
+      ADD COLUMN agent_id text;
     UPDATE schedule AS s
     SET agent_id = a.id
     FROM agent AS a
     WHERE s.tenant_id = a.tenant_id
-      AND s.agent_name = a.name
-  `.execute(db);
-
-  await sql`ALTER TABLE schedule ALTER COLUMN agent_id SET NOT NULL`.execute(db);
-
-  await sql`
+      AND s.agent_name = a.name;
+    ALTER TABLE schedule
+      ALTER COLUMN agent_id SET NOT NULL;
+    ALTER TABLE schedule
+      DROP CONSTRAINT schedule_agent_name_fk;
     ALTER TABLE schedule
       ADD CONSTRAINT schedule_agent_id_fk
-      FOREIGN KEY (agent_id) REFERENCES agent (id) ON DELETE CASCADE
-  `.execute(db);
-
-  await sql`
+      FOREIGN KEY (agent_id) REFERENCES agent (id) ON DELETE CASCADE;
     CREATE INDEX ${sql.raw(SCHEDULE_AGENT_ID_IDX)}
-      ON schedule (tenant_id, agent_id)
+      ON schedule (tenant_id, agent_id);
   `.execute(db);
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-  await sql`SET LOCAL lock_timeout = '5s'`.execute(db);
-  await sql`DROP INDEX IF EXISTS ${sql.raw(SCHEDULE_AGENT_ID_IDX)}`.execute(db);
-  await sql`ALTER TABLE schedule DROP CONSTRAINT IF EXISTS schedule_agent_id_fk`.execute(db);
-  await db.schema.alterTable('schedule').dropColumn('agent_id').execute();
+  await sql`
+    SET LOCAL lock_timeout = '5s';
+
+    DROP INDEX IF EXISTS ${sql.raw(SCHEDULE_AGENT_ID_IDX)};
+    ALTER TABLE schedule
+      DROP CONSTRAINT IF EXISTS schedule_agent_id_fk;
+    ALTER TABLE schedule
+      ADD CONSTRAINT schedule_agent_name_fk
+      FOREIGN KEY (tenant_id, agent_name) REFERENCES agent (tenant_id, name) ON DELETE CASCADE;
+    ALTER TABLE schedule
+      DROP COLUMN agent_id;
+  `.execute(db);
 }

--- a/packages/trueforge/src/db/postgres/migrations/20260904_000001_schedule_agent_id.ts
+++ b/packages/trueforge/src/db/postgres/migrations/20260904_000001_schedule_agent_id.ts
@@ -1,0 +1,36 @@
+import { sql, type Kysely } from 'kysely';
+import { SCHEDULE_AGENT_ID_IDX } from '../../indexes';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`SET LOCAL lock_timeout = '5s'`.execute(db);
+
+  await db.schema.alterTable('schedule').addColumn('agent_id', 'text').execute();
+
+  await sql`
+    UPDATE schedule AS s
+    SET agent_id = a.id
+    FROM agent AS a
+    WHERE s.tenant_id = a.tenant_id
+      AND s.agent_name = a.name
+  `.execute(db);
+
+  await sql`ALTER TABLE schedule ALTER COLUMN agent_id SET NOT NULL`.execute(db);
+
+  await sql`
+    ALTER TABLE schedule
+      ADD CONSTRAINT schedule_agent_id_fk
+      FOREIGN KEY (agent_id) REFERENCES agent (id) ON DELETE CASCADE
+  `.execute(db);
+
+  await sql`
+    CREATE INDEX ${sql.raw(SCHEDULE_AGENT_ID_IDX)}
+      ON schedule (tenant_id, agent_id)
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`SET LOCAL lock_timeout = '5s'`.execute(db);
+  await sql`DROP INDEX IF EXISTS ${sql.raw(SCHEDULE_AGENT_ID_IDX)}`.execute(db);
+  await sql`ALTER TABLE schedule DROP CONSTRAINT IF EXISTS schedule_agent_id_fk`.execute(db);
+  await db.schema.alterTable('schedule').dropColumn('agent_id').execute();
+}

--- a/packages/trueforge/src/db/postgres/schedule-store/PostgresScheduleStore.ts
+++ b/packages/trueforge/src/db/postgres/schedule-store/PostgresScheduleStore.ts
@@ -37,6 +37,7 @@ function toScheduleRecord(row: Selectable<ScheduleTable>): ScheduleRecord {
   return {
     id: row.id,
     tenant_id: row.tenant_id,
+    agent_id: row.agent_id,
     agent_name: row.agent_name,
     name: row.name,
     manifest: parseStoredScheduleManifest(row.manifest),
@@ -140,6 +141,7 @@ export class PostgresScheduleStore implements IScheduleStore<Transaction<Databas
         .values({
           id: newId(),
           tenant_id: input.tenant_id,
+          agent_id: input.agent_id,
           agent_name: input.agent_name,
           name: input.name,
           manifest: json(input.manifest),

--- a/packages/trueforge/src/db/postgres/types.ts
+++ b/packages/trueforge/src/db/postgres/types.ts
@@ -386,12 +386,15 @@ export interface AgentTable {
  * Configured schedules — immutable ULID `id` PK.
  * PRIMARY KEY (id)
  * CREATE INDEX schedule_agent_idx ON schedule (tenant_id, agent_name)
+ * CREATE INDEX schedule_agent_id_idx ON schedule (tenant_id, agent_id)
  * FK (tenant_id, agent_name) → agent(tenant_id, name) ON DELETE CASCADE
+ * FK (agent_id) → agent(id) ON DELETE CASCADE
  */
 export interface ScheduleTable {
   /** application-generated (ulid); FK target for schedule_run */
   id: string;
   tenant_id: string;
+  agent_id: string;
   /** FK with tenant_id → agent(tenant_id, name). Immutable; agent version resolves at run time. */
   agent_name: string;
   /** Display label; not unique. */

--- a/packages/trueforge/src/db/postgres/types.ts
+++ b/packages/trueforge/src/db/postgres/types.ts
@@ -387,15 +387,15 @@ export interface AgentTable {
  * PRIMARY KEY (id)
  * CREATE INDEX schedule_agent_idx ON schedule (tenant_id, agent_name)
  * CREATE INDEX schedule_agent_id_idx ON schedule (tenant_id, agent_id)
- * FK (tenant_id, agent_name) → agent(tenant_id, name) ON DELETE CASCADE
  * FK (agent_id) → agent(id) ON DELETE CASCADE
  */
 export interface ScheduleTable {
   /** application-generated (ulid); FK target for schedule_run */
   id: string;
   tenant_id: string;
+  /** FK → agent(id). Immutable. */
   agent_id: string;
-  /** FK with tenant_id → agent(tenant_id, name). Immutable; agent version resolves at run time. */
+  /** Create-time snapshot of registry agent name. */
   agent_name: string;
   /** Display label; not unique. */
   name: string;

--- a/packages/trueforge/src/db/scheduleStore.ts
+++ b/packages/trueforge/src/db/scheduleStore.ts
@@ -38,6 +38,7 @@ export function manualRunName(): string {
 export interface ScheduleRecord {
   id: string;
   tenant_id: string;
+  agent_id: string;
   /** Immutable FK to `agent.name` (with tenant); agent version resolves at run time. */
   agent_name: string;
   /** Slug-shaped label, unique per agent (`schedule_name_uq`). */
@@ -108,6 +109,7 @@ export interface GetScheduleInput {
 
 export interface CreateScheduleInput {
   tenant_id: string;
+  agent_id: string;
   agent_name: string;
   name: string;
   manifest: ScheduleManifest;

--- a/packages/trueforge/src/db/scheduleStore.ts
+++ b/packages/trueforge/src/db/scheduleStore.ts
@@ -38,8 +38,9 @@ export function manualRunName(): string {
 export interface ScheduleRecord {
   id: string;
   tenant_id: string;
+  /** Immutable FK to `agent.id`. */
   agent_id: string;
-  /** Immutable FK to `agent.name` (with tenant); agent version resolves at run time. */
+  /** Create-time snapshot of registry agent name. */
   agent_name: string;
   /** Slug-shaped label, unique per agent (`schedule_name_uq`). */
   name: string;

--- a/packages/trueforge/src/db/sqlite/migrations/20260904_000001_schedule_agent_id.ts
+++ b/packages/trueforge/src/db/sqlite/migrations/20260904_000001_schedule_agent_id.ts
@@ -1,0 +1,139 @@
+import { sql, type Kysely } from 'kysely';
+import {
+  SCHEDULE_AGENT_ID_IDX,
+  SCHEDULE_CREATED_BY_SUBJECT_ID_IDX,
+} from '../../indexes';
+
+/**
+ * Add NOT NULL `agent_id` on schedule — mirrors
+ * db/postgres/migrations/20260904_000001_schedule_agent_id.ts.
+ *
+ * SQLite STRICT cannot ADD a NOT NULL column without a DEFAULT, so rebuild
+ * `schedule` (FKs off so `schedule_run` rows survive the drop/rename).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`PRAGMA foreign_keys = OFF`.execute(db);
+  try {
+    await db.transaction().execute(async trx => {
+      await sql`
+        CREATE TABLE schedule_new (
+          id TEXT NOT NULL,
+          tenant_id TEXT NOT NULL,
+          agent_id TEXT NOT NULL,
+          agent_name TEXT NOT NULL,
+          name TEXT NOT NULL,
+          manifest BLOB NOT NULL,
+          status TEXT NOT NULL CHECK (length(status) <= 16),
+          created_by_subject BLOB NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (id),
+          FOREIGN KEY (tenant_id, agent_name) REFERENCES agent (tenant_id, name) ON DELETE CASCADE,
+          FOREIGN KEY (agent_id) REFERENCES agent (id) ON DELETE CASCADE
+        ) STRICT
+      `.execute(trx);
+
+      await sql`
+        INSERT INTO schedule_new (
+          id,
+          tenant_id,
+          agent_id,
+          agent_name,
+          name,
+          manifest,
+          status,
+          created_by_subject,
+          created_at,
+          updated_at
+        )
+        SELECT
+          s.id,
+          s.tenant_id,
+          a.id,
+          s.agent_name,
+          s.name,
+          s.manifest,
+          s.status,
+          s.created_by_subject,
+          s.created_at,
+          s.updated_at
+        FROM schedule AS s
+        INNER JOIN agent AS a
+          ON a.tenant_id = s.tenant_id
+         AND a.name = s.agent_name
+      `.execute(trx);
+
+      await sql`DROP TABLE schedule`.execute(trx);
+      await sql`ALTER TABLE schedule_new RENAME TO schedule`.execute(trx);
+
+      await sql`
+        CREATE INDEX schedule_agent_idx
+          ON schedule (tenant_id, agent_name)
+      `.execute(trx);
+      await sql`
+        CREATE UNIQUE INDEX schedule_name_uq
+          ON schedule (tenant_id, agent_name, name)
+      `.execute(trx);
+      await sql`
+        CREATE INDEX ${sql.raw(SCHEDULE_CREATED_BY_SUBJECT_ID_IDX)}
+          ON schedule (tenant_id, json_extract(created_by_subject, '$.subject_id'))
+      `.execute(trx);
+      await sql`
+        CREATE INDEX ${sql.raw(SCHEDULE_AGENT_ID_IDX)}
+          ON schedule (tenant_id, agent_id)
+      `.execute(trx);
+    });
+  } finally {
+    await sql`PRAGMA foreign_keys = ON`.execute(db);
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`PRAGMA foreign_keys = OFF`.execute(db);
+  try {
+    await db.transaction().execute(async trx => {
+      await sql`
+        CREATE TABLE schedule_old (
+          id TEXT NOT NULL,
+          tenant_id TEXT NOT NULL,
+          agent_name TEXT NOT NULL,
+          name TEXT NOT NULL,
+          manifest BLOB NOT NULL,
+          status TEXT NOT NULL CHECK (length(status) <= 16),
+          created_by_subject BLOB NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (id),
+          FOREIGN KEY (tenant_id, agent_name) REFERENCES agent (tenant_id, name) ON DELETE CASCADE
+        ) STRICT
+      `.execute(trx);
+
+      await sql`
+        INSERT INTO schedule_old (
+          id, tenant_id, agent_name, name, manifest, status, created_by_subject, created_at, updated_at
+        )
+        SELECT
+          id, tenant_id, agent_name, name, manifest, status, created_by_subject, created_at, updated_at
+        FROM schedule
+      `.execute(trx);
+
+      await sql`DROP TABLE schedule`.execute(trx);
+      await sql`ALTER TABLE schedule_old RENAME TO schedule`.execute(trx);
+
+      await sql`
+        CREATE INDEX schedule_agent_idx
+          ON schedule (tenant_id, agent_name)
+      `.execute(trx);
+      await sql`
+        CREATE UNIQUE INDEX schedule_name_uq
+          ON schedule (tenant_id, agent_name, name)
+      `.execute(trx);
+      await sql`
+        CREATE INDEX ${sql.raw(SCHEDULE_CREATED_BY_SUBJECT_ID_IDX)}
+          ON schedule (tenant_id, json_extract(created_by_subject, '$.subject_id'))
+      `.execute(trx);
+    });
+  } finally {
+    await sql`PRAGMA foreign_keys = ON`.execute(db);
+  }
+}

--- a/packages/trueforge/src/db/sqlite/migrations/20260904_000001_schedule_agent_id.ts
+++ b/packages/trueforge/src/db/sqlite/migrations/20260904_000001_schedule_agent_id.ts
@@ -1,15 +1,14 @@
 import { sql, type Kysely } from 'kysely';
-import {
-  SCHEDULE_AGENT_ID_IDX,
-  SCHEDULE_CREATED_BY_SUBJECT_ID_IDX,
-} from '../../indexes';
+import { SCHEDULE_AGENT_ID_IDX, SCHEDULE_CREATED_BY_SUBJECT_ID_IDX } from '../../indexes';
 
 /**
  * Add NOT NULL `agent_id` on schedule — mirrors
  * db/postgres/migrations/20260904_000001_schedule_agent_id.ts.
+ * Drops the `(tenant_id, agent_name)` FK; binding is `agent(id)` only.
  *
  * SQLite STRICT cannot ADD a NOT NULL column without a DEFAULT, so rebuild
  * `schedule` (FKs off so `schedule_run` rows survive the drop/rename).
+ * better-sqlite3 prepares one statement per call — keep statements separate.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`PRAGMA foreign_keys = OFF`.execute(db);
@@ -28,7 +27,6 @@ export async function up(db: Kysely<unknown>): Promise<void> {
           created_at TEXT NOT NULL,
           updated_at TEXT NOT NULL,
           PRIMARY KEY (id),
-          FOREIGN KEY (tenant_id, agent_name) REFERENCES agent (tenant_id, name) ON DELETE CASCADE,
           FOREIGN KEY (agent_id) REFERENCES agent (id) ON DELETE CASCADE
         ) STRICT
       `.execute(trx);

--- a/packages/trueforge/src/db/sqlite/schedule-store/SqliteScheduleStore.ts
+++ b/packages/trueforge/src/db/sqlite/schedule-store/SqliteScheduleStore.ts
@@ -39,6 +39,7 @@ function scheduleColumns(eb: ExpressionBuilder<Database, 'schedule'>) {
   return [
     'id' as const,
     'tenant_id' as const,
+    'agent_id' as const,
     'agent_name' as const,
     'name' as const,
     jsonText<ScheduleManifest>(eb.ref('manifest')).as('manifest'),
@@ -67,6 +68,7 @@ function runColumns(eb: ExpressionBuilder<Database, 'schedule_run'>) {
 interface ScheduleRow {
   id: string;
   tenant_id: string;
+  agent_id: string;
   agent_name: string;
   name: string;
   manifest: ScheduleManifest;
@@ -146,6 +148,7 @@ export class SqliteScheduleStore implements IScheduleStore<Transaction<Database>
         .values({
           id: newId(),
           tenant_id: input.tenant_id,
+          agent_id: input.agent_id,
           agent_name: input.agent_name,
           name: input.name,
           manifest: jsonbBind(input.manifest),

--- a/packages/trueforge/src/db/sqlite/types.ts
+++ b/packages/trueforge/src/db/sqlite/types.ts
@@ -232,11 +232,14 @@ export interface AgentTable {
  * Configured schedules.
  * PRIMARY KEY (id).
  * FK (tenant_id, agent_name) → agent(tenant_id, name) ON DELETE CASCADE.
+ * FK (agent_id) → agent(id) ON DELETE CASCADE.
  */
 export interface ScheduleTable {
   /** application-generated (ulid); FK target for schedule_run */
   id: string;
   tenant_id: string;
+  /** FK → agent(id). Immutable; pairs with agent_name snapshot. */
+  agent_id: string;
   /** FK with tenant_id → agent(tenant_id, name). Immutable; agent version resolves at run time. */
   agent_name: string;
   /** Display label; not unique. */

--- a/packages/trueforge/src/db/sqlite/types.ts
+++ b/packages/trueforge/src/db/sqlite/types.ts
@@ -231,16 +231,15 @@ export interface AgentTable {
 /**
  * Configured schedules.
  * PRIMARY KEY (id).
- * FK (tenant_id, agent_name) → agent(tenant_id, name) ON DELETE CASCADE.
  * FK (agent_id) → agent(id) ON DELETE CASCADE.
  */
 export interface ScheduleTable {
   /** application-generated (ulid); FK target for schedule_run */
   id: string;
   tenant_id: string;
-  /** FK → agent(id). Immutable; pairs with agent_name snapshot. */
+  /** FK → agent(id). Immutable. */
   agent_id: string;
-  /** FK with tenant_id → agent(tenant_id, name). Immutable; agent version resolves at run time. */
+  /** Create-time snapshot of registry agent name. */
   agent_name: string;
   /** Display label; not unique. */
   name: string;

--- a/packages/trueforge/tests/db/scheduleDispatchContractSuite.ts
+++ b/packages/trueforge/tests/db/scheduleDispatchContractSuite.ts
@@ -65,7 +65,7 @@ export function runScheduleDispatchContractSuite<TTransaction>(deps: {
   const logger = createLogger({ silent: true });
   let seq = 0;
 
-  async function seedAgent(): Promise<string> {
+  async function seedAgent(): Promise<{ id: string; name: string }> {
     seq += 1;
     const agent = await deps.getAgentStore().createAgent({
       tenant_id: TENANT,
@@ -77,7 +77,7 @@ export function runScheduleDispatchContractSuite<TTransaction>(deps: {
       }),
       external_id: null,
     });
-    return agent.name;
+    return { id: agent.id, name: agent.name };
   }
 
   async function scheduledRunsFor(scheduleId: string): Promise<ScheduleRunRecord[]> {
@@ -104,12 +104,13 @@ export function runScheduleDispatchContractSuite<TTransaction>(deps: {
     createdBySubject?: CreatedBySubject;
   }): Promise<{ schedule: ScheduleRecord; run: ScheduleRunRecord }> {
     const store = deps.getScheduleStore();
-    const agentName = await seedAgent();
+    const agent = await seedAgent();
     const status = params.status ?? 'active';
     const cron = params.cron ?? CRON;
     const { schedule, pendingRun } = await store.createScheduleAndRun({
       tenant_id: TENANT,
-      agent_name: agentName,
+      agent_id: agent.id,
+      agent_name: agent.name,
       name: `sched-${String(Date.now())}-${String(seq)}`,
       manifest: manifest({ status, cron }),
       created_by_subject: USER_SUBJECT,

--- a/packages/trueforge/tests/db/scheduleStoreContractSuite.ts
+++ b/packages/trueforge/tests/db/scheduleStoreContractSuite.ts
@@ -48,6 +48,7 @@ export function runScheduleStoreContractSuite(deps: {
 
     const { schedule, pendingRun } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'daily',
       manifest: m,
@@ -71,6 +72,7 @@ export function runScheduleStoreContractSuite(deps: {
     const agent = await seedAgent();
     const { schedule, pendingRun } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'paused-at-create',
       manifest: manifest({ status: 'paused' }),
@@ -87,6 +89,7 @@ export function runScheduleStoreContractSuite(deps: {
     const agent = await seedAgent();
     const { schedule } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'toggle',
       manifest: manifest({ cron: '0 * * * *', timezone: 'UTC' }),
@@ -125,6 +128,7 @@ export function runScheduleStoreContractSuite(deps: {
     const runFrom = new Date('2026-08-27T08:00:00.000Z');
     const { schedule, pendingRun: first } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'reclock',
       manifest: manifest({ cron: '0 9 * * *', timezone: 'UTC' }),
@@ -157,6 +161,7 @@ export function runScheduleStoreContractSuite(deps: {
     const runFrom = new Date('2026-08-27T08:00:00.000Z');
     const { schedule, pendingRun: first } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'label-only',
       manifest: manifest({ cron: '0 9 * * *', timezone: 'UTC', task: 'old task' }),
@@ -186,6 +191,7 @@ export function runScheduleStoreContractSuite(deps: {
     const create = (name: string) =>
       store.createScheduleAndRun({
         tenant_id: TENANT,
+        agent_id: agent.id,
         agent_name: agent.name,
         name,
         manifest: manifest({ status: 'paused' }),
@@ -200,18 +206,19 @@ export function runScheduleStoreContractSuite(deps: {
   it('allows the same schedule name under different agents', async () => {
     const store = deps.getScheduleStore();
     const [first, second] = [await seedAgent(), await seedAgent()];
-    const create = (agentName: string) =>
+    const create = (agent: { id: string; name: string }) =>
       store.createScheduleAndRun({
         tenant_id: TENANT,
-        agent_name: agentName,
+        agent_id: agent.id,
+        agent_name: agent.name,
         name: 'daily-report',
         manifest: manifest({ status: 'paused' }),
         created_by_subject: USER_SUBJECT,
         runFrom: new Date(),
       });
 
-    await create(first.name);
-    await expect(create(second.name)).resolves.toBeDefined();
+    await create(first);
+    await expect(create(second)).resolves.toBeDefined();
   });
 
   it('rejects renaming a schedule onto a name already taken for the agent', async () => {
@@ -219,6 +226,7 @@ export function runScheduleStoreContractSuite(deps: {
     const agent = await seedAgent();
     await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'taken',
       manifest: manifest({ status: 'paused' }),
@@ -227,6 +235,7 @@ export function runScheduleStoreContractSuite(deps: {
     });
     const { schedule: other } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'free',
       manifest: manifest({ status: 'paused' }),
@@ -250,6 +259,7 @@ export function runScheduleStoreContractSuite(deps: {
     const agent = await seedAgent();
     const { schedule } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'paused-edit',
       manifest: manifest({ status: 'paused', cron: '0 9 * * *' }),
@@ -277,6 +287,7 @@ export function runScheduleStoreContractSuite(deps: {
     async function pausedSchedule(name: string) {
       const { schedule } = await store.createScheduleAndRun({
         tenant_id: TENANT,
+        agent_id: agent.id,
         agent_name: agent.name,
         name,
         manifest: manifest({ status: 'paused' }),
@@ -338,6 +349,7 @@ export function runScheduleStoreContractSuite(deps: {
 
     const { schedule } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'to-delete',
       manifest: manifest({ status: 'paused' }),
@@ -381,6 +393,7 @@ export function runScheduleStoreContractSuite(deps: {
     await expect(
       store.createScheduleAndRun({
         tenant_id: TENANT,
+        agent_id: 'no-such-id',
         agent_name: 'no-such-agent',
         name: 'orphan',
         manifest: manifest(),
@@ -395,6 +408,7 @@ export function runScheduleStoreContractSuite(deps: {
     const agent = await seedAgent();
     const { schedule, pendingRun } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'bound-to-agent',
       manifest: manifest({ cron: '0 * * * *', timezone: 'UTC' }),
@@ -418,6 +432,7 @@ export function runScheduleStoreContractSuite(deps: {
     const agent = await seedAgent();
     const { schedule } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'name-unique',
       manifest: manifest({ status: 'paused' }),
@@ -453,6 +468,7 @@ export function runScheduleStoreContractSuite(deps: {
     const agent = await seedAgent();
     const { schedule } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'one-pending',
       manifest: manifest({ status: 'paused' }),
@@ -490,6 +506,7 @@ export function runScheduleStoreContractSuite(deps: {
 
     const older = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agentA.id,
       agent_name: agentA.name,
       name: 'list-older',
       manifest: manifest({ status: 'paused' }),
@@ -500,6 +517,7 @@ export function runScheduleStoreContractSuite(deps: {
     await new Promise(resolve => setTimeout(resolve, 5));
     const newer = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agentA.id,
       agent_name: agentA.name,
       name: 'list-newer',
       manifest: manifest({ status: 'paused' }),
@@ -509,6 +527,7 @@ export function runScheduleStoreContractSuite(deps: {
     await new Promise(resolve => setTimeout(resolve, 5));
     const otherAgent = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agentB.id,
       agent_name: agentB.name,
       name: 'list-other-agent',
       manifest: manifest({ status: 'paused' }),
@@ -588,6 +607,7 @@ export function runScheduleStoreContractSuite(deps: {
 
     const { schedule: scheduleA } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agentA.id,
       agent_name: agentA.name,
       name: 'runs-a',
       manifest: manifest({ status: 'paused' }),
@@ -613,6 +633,7 @@ export function runScheduleStoreContractSuite(deps: {
 
     const { schedule: scheduleB } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agentB.id,
       agent_name: agentB.name,
       name: 'runs-b',
       manifest: manifest({ status: 'paused' }),
@@ -641,6 +662,7 @@ export function runScheduleStoreContractSuite(deps: {
     const agent = await seedAgent();
     const { schedule } = await store.createScheduleAndRun({
       tenant_id: TENANT,
+      agent_id: agent.id,
       agent_name: agent.name,
       name: 'run-status',
       manifest: manifest({ status: 'paused' }),

--- a/packages/trueforge/tests/unit/controller/scheduleDispatch.test.ts
+++ b/packages/trueforge/tests/unit/controller/scheduleDispatch.test.ts
@@ -23,6 +23,7 @@ function item(): ScheduleDispatchItem {
     schedule: {
       id: 'sched-1',
       tenant_id: 'default',
+      agent_id: 'agent-1',
       agent_name: 'reporter',
       name: 'daily',
       manifest: ScheduleManifestSchema.parse({


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->
Add agent_id to schedule table with index
Closes AGE-2097

## Changes

Add agent_id to schedule table with index

## How was this tested?

NA

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema migration alters FK semantics and requires successful backfill for every schedule row; failed joins would block NOT NULL, and deploys must run migrations before code that inserts agent_id.
> 
> **Overview**
> Schedules are now tied to agents by stable **`agent_id`** (ULID) instead of only **`(tenant_id, agent_name)`**. Postgres and SQLite migrations add a NOT NULL column, backfill from the existing agent join, drop the composite name FK, and add **`agent(id)` ON DELETE CASCADE** plus **`(tenant_id, agent_id)`** index (`schedule_agent_id_idx`) for per-agent listing.
> 
> Application code persists and returns **`agent_id`** on create (`schedules` API passes resolved agent id into **`createScheduleAndRun`**), and both schedule stores map the new column. **`agent_name`** remains as a create-time snapshot; uniqueness rules on **`(tenant_id, agent_name, name)`** are unchanged. Contract and dispatch tests were updated to supply **`agent_id`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9371063c4e8f43213a6767303a9668eb67fc449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->