### PR TITLE
[AuthZ: 1/N] Remove TrueFoundry global admin

### DIFF
--- a/.changeset/truefoundry-no-global-admin.md
+++ b/.changeset/truefoundry-no-global-admin.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge': minor
+---
+
+Stop treating TrueFoundry control-plane roles as tenant-wide TrueForge administrator access.

--- a/.changeset/truefoundry-no-global-admin.md
+++ b/.changeset/truefoundry-no-global-admin.md
@@ -1,5 +1,0 @@
----
-'@truefoundry/trueforge': minor
----
-
-Stop treating TrueFoundry control-plane roles as tenant-wide TrueForge administrator access.

--- a/packages/trueforge/src/auth/identity.ts
+++ b/packages/trueforge/src/auth/identity.ts
@@ -3,9 +3,6 @@ import type { Context } from 'hono';
 
 import configuration, { getTrueForgeMode, isOidcConfigured, TrueForgeMode } from '../config';
 
-/** TrueFoundry Control Plane role treated as admin until mapping is settled. */
-export const TRUEFOUNDRY_ADMIN_ROLE = 'tenant-admin';
-
 /** Standalone / default TrueForge admin role string. */
 export const STANDALONE_ADMIN_ROLE = 'admin';
 
@@ -55,13 +52,12 @@ export function resolveRequestContext(c: Context): RequestContext {
  * Mode and OIDC admin claim value come from process config ({@link getTrueForgeMode}).
  * - Standalone: `roles` includes `admin`
  * - OIDC: `roles` includes configured `OIDC_ADMIN_ROLE_VALUE`
- * - TrueFoundry: `roles` includes `tenant-admin` (temporary; revisit mapping later)
+ * - TrueFoundry: no tenant-wide TrueForge admin
  */
 export function hasAdminRole(requestContext: Pick<RequestContext, 'roles'>): boolean {
   switch (getTrueForgeMode()) {
     case TrueForgeMode.TrueFoundry:
-      // TODO: stop treating `tenant-admin` as TrueForge admin once TFY role mapping is settled.
-      return requestContext.roles.includes(TRUEFOUNDRY_ADMIN_ROLE);
+      return false;
     case TrueForgeMode.Oidc: {
       const adminValue = isOidcConfigured(configuration)
         ? configuration.OIDC.OIDC_ADMIN_ROLE_VALUE

--- a/packages/trueforge/src/auth/identity.ts
+++ b/packages/trueforge/src/auth/identity.ts
@@ -54,15 +54,17 @@ export function resolveRequestContext(c: Context): RequestContext {
  * - OIDC: `roles` includes configured `OIDC_ADMIN_ROLE_VALUE`
  * - TrueFoundry: no tenant-wide TrueForge admin
  */
+// TODO (chiragjn): hasAdminRole will be renamed to canAccessSettings once all authorizer changes are done
 export function hasAdminRole(requestContext: Pick<RequestContext, 'roles'>): boolean {
   switch (getTrueForgeMode()) {
     case TrueForgeMode.TrueFoundry:
       return false;
     case TrueForgeMode.Oidc: {
-      const adminValue = isOidcConfigured(configuration)
-        ? configuration.OIDC.OIDC_ADMIN_ROLE_VALUE
-        : STANDALONE_ADMIN_ROLE;
-      return requestContext.roles.includes(adminValue);
+      if (!isOidcConfigured(configuration)) {
+        // this is technically unreachable since case TrueForgeMode.Oidc already ensures OIDC is configured
+        return false;
+      }
+      return requestContext.roles.includes(configuration.OIDC.OIDC_ADMIN_ROLE_VALUE);
     }
     case TrueForgeMode.Standalone:
       return requestContext.roles.includes(STANDALONE_ADMIN_ROLE);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes who counts as admin in TrueFoundry mode (settings/capabilities and schedule admin visibility), with no replacement tenant-wide admin in this PR.
> 
> **Overview**
> **Removes the temporary `tenant-admin` → TrueForge admin mapping** in TrueFoundry mode as the first step in a broader AuthZ rollout.
> 
> `hasAdminRole` now always returns **false** when `getTrueForgeMode()` is TrueFoundry, and the `TRUEFOUNDRY_ADMIN_ROLE` constant is deleted. Docs and a rename TODO note that this gate is still used for settings, capabilities, and schedule bypass until `canAccessSettings` lands.
> 
> **OIDC admin checks are tightened:** instead of falling back to the standalone `admin` role when OIDC config is missing, the OIDC branch returns false unless OIDC is configured and `OIDC_ADMIN_ROLE_VALUE` is present in `roles`. Standalone behavior is unchanged (`admin` role).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e4ed3042ae277d331f825bc423c7c49e17599a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->