### PR TITLE
updated agent config alignment and ux

### DIFF
--- a/.changeset/agent-config-chrome.md
+++ b/.changeset/agent-config-chrome.md
@@ -2,4 +2,4 @@
 "@truefoundry/trueforge-ui": minor
 ---
 
-Keep agent configuration visible on the left in full-width builder layouts, align its header with chat chrome, place the primary save action after Clear Chat, and preserve open widgets across chat runtime changes.
+Keep agent configuration visible on the left in full-width builder layouts, make mobile config overlays closable, save the current instruction draft, align builder chrome, and preserve open widgets across chat runtime changes.

--- a/.changeset/agent-config-chrome.md
+++ b/.changeset/agent-config-chrome.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge-ui": minor
+---
+
+Keep agent configuration visible on the left in full-width builder layouts, align its header with chat chrome, place the primary save action after Clear Chat, and preserve open widgets across chat runtime changes.

--- a/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
+++ b/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
@@ -14,8 +14,8 @@ import { useOptionalShellMode } from '../server/ShellModeContext.js';
 import type { AgentSpec, McpToolSelection } from '../server/types.js';
 import { useSlot } from '../theme/SlotsProvider.js';
 import { getErrorMessage } from '../utils/getErrorMessage.js';
-import { useOptionalAgentConfigInstructions } from './draft/AgentConfigInstructionsContext.js';
 import type { AgentConfigEditor } from './draft/AgentConfigEditors.js';
+import { useOptionalAgentConfigInstructions } from './draft/AgentConfigInstructionsContext.js';
 import { DraftCatalogProvider, useDraftCatalog } from './draft/DraftCatalogProvider.js';
 import { editableMountsFromSpec, withPreload } from './draft/agentConfigMounts.js';
 import { auiButtonClass } from './lib/buttonClasses.js';
@@ -116,9 +116,7 @@ function SaveAgentButtonContent({
     if (flushedAgentSpec === null) return;
     const instructionsDraft = instructionsOverride ?? configInstructions?.draft;
     const latestAgentSpec =
-      instructionsDraft === undefined
-        ? flushedAgentSpec
-        : { ...flushedAgentSpec, instructions: instructionsDraft };
+      instructionsDraft === undefined ? flushedAgentSpec : { ...flushedAgentSpec, instructions: instructionsDraft };
     const currentName = shell?.mode.status === 'active' ? (shell.mode.agentName ?? shell.mode.agentId ?? '') : '';
     setIntent(currentName ? 'update' : 'create');
     setName(currentName);

--- a/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
+++ b/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
@@ -18,7 +18,6 @@ import type { AgentConfigEditor } from './draft/AgentConfigEditors.js';
 import { DraftCatalogProvider, useDraftCatalog } from './draft/DraftCatalogProvider.js';
 import { editableMountsFromSpec, withPreload } from './draft/agentConfigMounts.js';
 import { auiButtonClass } from './lib/buttonClasses.js';
-import { cn } from './lib/cn.js';
 import { CenteredModal } from './primitives/CenteredModal.js';
 
 type SaveIntent = 'create' | 'update';
@@ -191,12 +190,9 @@ function SaveAgentButtonContent({
         type="button"
         disabled={disabled || builder === null || agentSpec === null}
         className={auiButtonClass({
-          variant: 'outline',
+          variant: 'default',
           size: 'sm',
-          // Chrome-action triggers use the squared-off header treatment: tight corners,
-          // roomier horizontal padding, and a card-surface fill rather than the grey
-          // secondary fill, so they read as controls layered on the topbar.
-          className: cn('gap-2 rounded-[0.125rem] bg-card-bg px-[0.625rem]', className),
+          className,
         })}
         onClick={() => void show()}
       >

--- a/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
+++ b/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
@@ -14,6 +14,7 @@ import { useOptionalShellMode } from '../server/ShellModeContext.js';
 import type { AgentSpec, McpToolSelection } from '../server/types.js';
 import { useSlot } from '../theme/SlotsProvider.js';
 import { getErrorMessage } from '../utils/getErrorMessage.js';
+import { useOptionalAgentConfigInstructions } from './draft/AgentConfigInstructionsContext.js';
 import type { AgentConfigEditor } from './draft/AgentConfigEditors.js';
 import { DraftCatalogProvider, useDraftCatalog } from './draft/DraftCatalogProvider.js';
 import { editableMountsFromSpec, withPreload } from './draft/agentConfigMounts.js';
@@ -76,6 +77,7 @@ function SaveAgentButtonContent({
   const adoptAgentSpec = useTrueFoundryAdoptAgentSpec();
   const builder = useOptionalServer();
   const shell = useOptionalShellMode();
+  const configInstructions = useOptionalAgentConfigInstructions();
   const catalog = useDraftCatalog();
   const serverCapabilities = useServerCapabilities();
   const AgentConfigEditors = useSlot('AgentConfigEditors');
@@ -108,13 +110,15 @@ function SaveAgentButtonContent({
     if (agentSpecRef.current === null || builder === null) return;
     setError(null);
     catalog.ensureLoaded();
+    configInstructions?.flush();
     await flushAgentSpec();
     const flushedAgentSpec = agentSpecRef.current;
     if (flushedAgentSpec === null) return;
+    const instructionsDraft = instructionsOverride ?? configInstructions?.draft;
     const latestAgentSpec =
-      instructionsOverride === undefined
+      instructionsDraft === undefined
         ? flushedAgentSpec
-        : { ...flushedAgentSpec, instructions: instructionsOverride };
+        : { ...flushedAgentSpec, instructions: instructionsDraft };
     const currentName = shell?.mode.status === 'active' ? (shell.mode.agentName ?? shell.mode.agentId ?? '') : '';
     setIntent(currentName ? 'update' : 'create');
     setName(currentName);

--- a/packages/trueforge-ui/src/atoms/draft/AgentConfigInstructionsContext.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentConfigInstructionsContext.tsx
@@ -16,10 +16,7 @@ const AgentConfigInstructionsContext = createContext<AgentConfigInstructionsCont
 export function AgentConfigInstructionsProvider({ children }: { children: ReactNode }) {
   const { agentSpec } = useTrueFoundryAgentSpec();
   const updateAgentSpec = useTrueFoundryUpdateAgentSpec();
-  const commit = useCallback(
-    (instructions: string) => updateAgentSpec?.({ instructions }),
-    [updateAgentSpec],
-  );
+  const commit = useCallback((instructions: string) => updateAgentSpec?.({ instructions }), [updateAgentSpec]);
   const { draft, onChange, flush } = useDebouncedAgentInstructions({
     value: agentSpec?.instructions ?? '',
     onCommit: commit,

--- a/packages/trueforge-ui/src/atoms/draft/AgentConfigInstructionsContext.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentConfigInstructionsContext.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useTrueFoundryAgentSpec, useTrueFoundryUpdateAgentSpec } from '@truefoundry/assistant-ui-runtime';
+import { createContext, useCallback, useContext, useMemo, type ReactNode } from 'react';
+
+import { useDebouncedAgentInstructions } from '../../hooks/useDebouncedAgentInstructions.js';
+
+type AgentConfigInstructionsContextValue = {
+  draft: string;
+  onChange: (value: string) => void;
+  flush: () => void;
+};
+
+const AgentConfigInstructionsContext = createContext<AgentConfigInstructionsContextValue | null>(null);
+
+export function AgentConfigInstructionsProvider({ children }: { children: ReactNode }) {
+  const { agentSpec } = useTrueFoundryAgentSpec();
+  const updateAgentSpec = useTrueFoundryUpdateAgentSpec();
+  const commit = useCallback(
+    (instructions: string) => updateAgentSpec?.({ instructions }),
+    [updateAgentSpec],
+  );
+  const { draft, onChange, flush } = useDebouncedAgentInstructions({
+    value: agentSpec?.instructions ?? '',
+    onCommit: commit,
+  });
+  const value = useMemo(() => ({ draft, onChange, flush }), [draft, flush, onChange]);
+
+  return <AgentConfigInstructionsContext.Provider value={value}>{children}</AgentConfigInstructionsContext.Provider>;
+}
+
+export function useAgentConfigInstructions(): AgentConfigInstructionsContextValue {
+  const value = useContext(AgentConfigInstructionsContext);
+  if (value === null) {
+    throw new Error('useAgentConfigInstructions must be used within AgentConfigInstructionsProvider');
+  }
+  return value;
+}
+
+export function useOptionalAgentConfigInstructions(): AgentConfigInstructionsContextValue | null {
+  return useContext(AgentConfigInstructionsContext);
+}

--- a/packages/trueforge-ui/src/atoms/draft/AgentConfigPanel.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentConfigPanel.tsx
@@ -16,7 +16,6 @@ import { runtimeConfigSummary } from './runtimeConfigSummary.js';
 export type AgentConfigPanelProps = {
   spec: AgentSpec;
   model?: ModelSelection;
-  saveAction?: ReactNode;
   skillsAvailable: boolean;
   instructions: string;
   onInstructionsChange: (value: string) => void;
@@ -67,7 +66,6 @@ export function AgentConfigSection({
 export function AgentConfigPanel({
   spec,
   model,
-  saveAction,
   skillsAvailable,
   instructions,
   onInstructionsChange,
@@ -98,11 +96,10 @@ export function AgentConfigPanel({
 
   return (
     <div className="bg-card-bg text-text-primary flex h-full min-h-0 flex-col">
-      <header className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-3">
+      <header className="flex h-11 shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5">
         <Icon name="sliders" className="size-4" />
         <h2 className="text-sm font-semibold">Agent Config</h2>
         <span className="min-w-0 flex-1" />
-        {saveAction}
         {onClose ? (
           <button
             type="button"

--- a/packages/trueforge-ui/src/atoms/draft/DraftComposerSections.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/DraftComposerSections.tsx
@@ -5,6 +5,7 @@ import { shellIsCreateAgent, useOptionalShellMode } from '../../server/ShellMode
 import { useSlot } from '../../theme/SlotsProvider.js';
 import type { ComposerLeftSectionProps, ComposerRightSectionProps } from '../ComposerSections.js';
 import { auiButtonClass } from '../lib/buttonClasses.js';
+import { useCompactLayout } from '../lib/CompactLayoutContext.js';
 import { Tooltip } from '../primitives/Tooltip.js';
 import { DraftReasoningEffortSelector } from './DraftReasoningEffortSelector.js';
 
@@ -12,12 +13,13 @@ export function DraftComposerLeftSection({ disabled, isRunning, onAttach }: Comp
   const shell = useOptionalShellMode();
   const DraftCompositeSelector = useSlot('DraftCompositeSelector');
   const DraftAgentConfigTrigger = useSlot('DraftAgentConfigTrigger');
+  const compact = useCompactLayout();
   const isBuilder = shell != null && shellIsCreateAgent(shell.mode);
 
   return (
     <div className="flex min-w-0 flex-wrap items-center gap-1.5">
       {!isBuilder ? <DraftCompositeSelector disabled={disabled} isRunning={isRunning} onAttach={onAttach} /> : null}
-      {isBuilder ? <DraftAgentConfigTrigger disabled={disabled} isRunning={isRunning} /> : null}
+      {isBuilder && compact ? <DraftAgentConfigTrigger disabled={disabled} isRunning={isRunning} /> : null}
       {isBuilder && onAttach != null ? (
         <Tooltip content="Attach a file">
           <button

--- a/packages/trueforge-ui/src/atoms/draft/DraftComposerSections.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/DraftComposerSections.tsx
@@ -6,6 +6,7 @@ import { useSlot } from '../../theme/SlotsProvider.js';
 import type { ComposerLeftSectionProps, ComposerRightSectionProps } from '../ComposerSections.js';
 import { auiButtonClass } from '../lib/buttonClasses.js';
 import { useCompactLayout } from '../lib/CompactLayoutContext.js';
+import { useIsMobile } from '../lib/useIsMobile.js';
 import { Tooltip } from '../primitives/Tooltip.js';
 import { DraftReasoningEffortSelector } from './DraftReasoningEffortSelector.js';
 
@@ -14,12 +15,15 @@ export function DraftComposerLeftSection({ disabled, isRunning, onAttach }: Comp
   const DraftCompositeSelector = useSlot('DraftCompositeSelector');
   const DraftAgentConfigTrigger = useSlot('DraftAgentConfigTrigger');
   const compact = useCompactLayout();
+  const isMobile = useIsMobile();
   const isBuilder = shell != null && shellIsCreateAgent(shell.mode);
 
   return (
     <div className="flex min-w-0 flex-wrap items-center gap-1.5">
       {!isBuilder ? <DraftCompositeSelector disabled={disabled} isRunning={isRunning} onAttach={onAttach} /> : null}
-      {isBuilder && compact ? <DraftAgentConfigTrigger disabled={disabled} isRunning={isRunning} /> : null}
+      {isBuilder && (compact || isMobile) ? (
+        <DraftAgentConfigTrigger disabled={disabled} isRunning={isRunning} />
+      ) : null}
       {isBuilder && onAttach != null ? (
         <Tooltip content="Attach a file">
           <button

--- a/packages/trueforge-ui/src/containers/AgentConfigDrawerContainer.tsx
+++ b/packages/trueforge-ui/src/containers/AgentConfigDrawerContainer.tsx
@@ -11,7 +11,7 @@ import type { AgentConfigEditor } from '../atoms/draft/AgentConfigEditors.js';
 import { useDraftCatalog } from '../atoms/draft/DraftCatalogProvider.js';
 import { useDebouncedAgentInstructions } from '../hooks/useDebouncedAgentInstructions.js';
 import { useOptionalServer, useServerCapabilities } from '../server/ServerContext.js';
-import { useShellMode } from '../server/ShellModeContext.js';
+import { shellIsCreateAgent, useShellMode } from '../server/ShellModeContext.js';
 import type { AgentSpec, McpToolSelection } from '../server/types.js';
 import { useSlot } from '../theme/SlotsProvider.js';
 
@@ -25,8 +25,8 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
   const catalog = useDraftCatalog();
   const AgentConfigPanel = useSlot('AgentConfigPanel');
   const AgentConfigEditors = useSlot('AgentConfigEditors');
-  const SaveAgentButton = useSlot('SaveAgentButton');
   const [editor, setEditor] = useState<AgentConfigEditor | null>(null);
+  const isBuilder = shellIsCreateAgent(shell.mode);
   const commitInstructions = useCallback(
     (instructions: string) => updateAgentSpec?.({ instructions }),
     [updateAgentSpec],
@@ -46,11 +46,11 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
   }, [flushAgentSpec, flushInstructions, shell]);
 
   useEffect(() => {
-    if (shell.agentConfigOpen) catalog.ensureLoaded();
-  }, [catalog, shell.agentConfigOpen]);
+    if (isBuilder) catalog.ensureLoaded();
+  }, [catalog, isBuilder]);
 
   useEffect(() => {
-    if (!shell.agentConfigOpen) return;
+    if (!showClose || !shell.agentConfigOpen) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && editor === null && document.querySelector('dialog[open]') === null) {
         closeDrawer();
@@ -58,7 +58,7 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [closeDrawer, editor, shell.agentConfigOpen]);
+  }, [closeDrawer, editor, shell.agentConfigOpen, showClose]);
 
   // Flush pending edits on unmount. ChatProvider remount (runtimeKey) tears the
   // runtime down first — flush then throws; ignore so the new draft can mount.
@@ -100,7 +100,7 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
     [server],
   );
 
-  if (!shell.agentConfigOpen || agentSpec === null || shell.mode.status !== 'active' || !shell.mode.isMutable) {
+  if (!isBuilder || agentSpec === null || (showClose && !shell.agentConfigOpen)) {
     return null;
   }
 
@@ -111,7 +111,6 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
       <AgentConfigPanel
         spec={agentSpec}
         model={model}
-        saveAction={<SaveAgentButton instructionsOverride={instructionDraft} />}
         skillsAvailable={capabilities?.skill.enabled === true}
         instructions={instructionDraft}
         onInstructionsChange={onInstructionChange}

--- a/packages/trueforge-ui/src/containers/AgentConfigDrawerContainer.tsx
+++ b/packages/trueforge-ui/src/containers/AgentConfigDrawerContainer.tsx
@@ -7,9 +7,9 @@ import {
 } from '@truefoundry/assistant-ui-runtime';
 import { useCallback, useEffect, useState } from 'react';
 
+import { useAgentConfigInstructions } from '../atoms/draft/AgentConfigInstructionsContext.js';
 import type { AgentConfigEditor } from '../atoms/draft/AgentConfigEditors.js';
 import { useDraftCatalog } from '../atoms/draft/DraftCatalogProvider.js';
-import { useDebouncedAgentInstructions } from '../hooks/useDebouncedAgentInstructions.js';
 import { useOptionalServer, useServerCapabilities } from '../server/ServerContext.js';
 import { shellIsCreateAgent, useShellMode } from '../server/ShellModeContext.js';
 import type { AgentSpec, McpToolSelection } from '../server/types.js';
@@ -27,18 +27,11 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
   const AgentConfigEditors = useSlot('AgentConfigEditors');
   const [editor, setEditor] = useState<AgentConfigEditor | null>(null);
   const isBuilder = shellIsCreateAgent(shell.mode);
-  const commitInstructions = useCallback(
-    (instructions: string) => updateAgentSpec?.({ instructions }),
-    [updateAgentSpec],
-  );
   const {
     draft: instructionDraft,
     onChange: onInstructionChange,
     flush: flushInstructions,
-  } = useDebouncedAgentInstructions({
-    value: agentSpec?.instructions ?? '',
-    onCommit: commitInstructions,
-  });
+  } = useAgentConfigInstructions();
   const closeDrawer = useCallback(() => {
     flushInstructions();
     void flushAgentSpec();

--- a/packages/trueforge-ui/src/containers/AgentConfigDrawerContainer.tsx
+++ b/packages/trueforge-ui/src/containers/AgentConfigDrawerContainer.tsx
@@ -7,8 +7,8 @@ import {
 } from '@truefoundry/assistant-ui-runtime';
 import { useCallback, useEffect, useState } from 'react';
 
-import { useAgentConfigInstructions } from '../atoms/draft/AgentConfigInstructionsContext.js';
 import type { AgentConfigEditor } from '../atoms/draft/AgentConfigEditors.js';
+import { useAgentConfigInstructions } from '../atoms/draft/AgentConfigInstructionsContext.js';
 import { useDraftCatalog } from '../atoms/draft/DraftCatalogProvider.js';
 import { useOptionalServer, useServerCapabilities } from '../server/ServerContext.js';
 import { shellIsCreateAgent, useShellMode } from '../server/ShellModeContext.js';

--- a/packages/trueforge-ui/src/containers/TrueForgeUIShell.tsx
+++ b/packages/trueforge-ui/src/containers/TrueForgeUIShell.tsx
@@ -8,6 +8,7 @@ import { DraftSpecPreferenceBridge } from '../atoms/draft/DraftSpecPreferenceBri
 import { cn } from '../atoms/lib/cn.js';
 import { IS_CREATE_AGENT_METADATA_KEY, isCreateAgentMetadataValue } from '../atoms/lib/sessionCreateAgent.js';
 import { Spinner } from '../atoms/primitives/Spinner.js';
+import { WidgetVisibilityProvider } from '../layouts/WidgetVisibilityContext.js';
 import { LibrarySessionShareBoot } from '../routing/LibrarySessionShareBoot.js';
 import { RemoteIdRouteBridge } from '../routing/RemoteIdRouteBridge.js';
 import { ResolvedRoutesProvider } from '../routing/ResolvedRoutesContext.js';
@@ -297,15 +298,18 @@ export function TrueForgeUIShell(props: TrueForgeUIShellProps) {
       </ChatProviderFromShell>
     </ShellModeProvider>
   );
+  // Widget visibility provider is used to control the visibility of the widget with isolated state
+  const visibilityTree =
+    layout === 'widget' ? <WidgetVisibilityProvider>{shellTree}</WidgetVisibilityProvider> : shellTree;
 
   return (
     <SlotsProvider overrides={overrides} theme={theme}>
       <CustomActionRenderersProvider renderers={customActionRenderers}>
         <ServerProvider server={server}>
           {resolvedRoutes != null ? (
-            <ResolvedRoutesProvider routes={resolvedRoutes}>{shellTree}</ResolvedRoutesProvider>
+            <ResolvedRoutesProvider routes={resolvedRoutes}>{visibilityTree}</ResolvedRoutesProvider>
           ) : (
-            shellTree
+            visibilityTree
           )}
         </ServerProvider>
       </CustomActionRenderersProvider>

--- a/packages/trueforge-ui/src/containers/TrueForgeUIShell.tsx
+++ b/packages/trueforge-ui/src/containers/TrueForgeUIShell.tsx
@@ -3,6 +3,7 @@
 import type { TrueFoundryAgentConfig, UseTrueFoundryAgentRuntimeOptions } from '@truefoundry/assistant-ui-runtime';
 import { lazy, Suspense, useCallback, useMemo, useState, type ReactNode } from 'react';
 
+import { AgentConfigInstructionsProvider } from '../atoms/draft/AgentConfigInstructionsContext.js';
 import { DraftCatalogProvider } from '../atoms/draft/DraftCatalogProvider.js';
 import { DraftSpecPreferenceBridge } from '../atoms/draft/DraftSpecPreferenceBridge.js';
 import { cn } from '../atoms/lib/cn.js';
@@ -228,9 +229,11 @@ function ChatProviderFromShell({
       initialSessionId={pendingSessionId ?? hostInitialSessionId}
     >
       <DraftCatalogProvider>
-        <DraftSpecPreferenceBridge />
-        {onRemoteIdChange != null ? <RemoteIdRouteBridge onRemoteIdChange={onRemoteIdChange} /> : null}
-        {children}
+        <AgentConfigInstructionsProvider>
+          <DraftSpecPreferenceBridge />
+          {onRemoteIdChange != null ? <RemoteIdRouteBridge onRemoteIdChange={onRemoteIdChange} /> : null}
+          {children}
+        </AgentConfigInstructionsProvider>
       </DraftCatalogProvider>
     </TrueFoundryChatProvider>
   );

--- a/packages/trueforge-ui/src/layouts/DrawerLayout.tsx
+++ b/packages/trueforge-ui/src/layouts/DrawerLayout.tsx
@@ -7,6 +7,7 @@ import { NamedAgentHeaderLabel } from '../atoms/NamedAgentHeaderLabel.js';
 import { ShellActions } from '../atoms/ShellActions.js';
 import { auiButtonClass } from '../atoms/lib/buttonClasses.js';
 import { cn } from '../atoms/lib/cn.js';
+import { useIsMobile } from '../atoms/lib/useIsMobile.js';
 import { Spinner } from '../atoms/primitives/Spinner.js';
 import { AgentConfigDrawerContainer } from '../containers/AgentConfigDrawerContainer.js';
 import { Thread } from '../containers/Thread.js';
@@ -22,6 +23,7 @@ const SchedulesPage = lazy(() =>
 export function DrawerLayout({ className }: { className?: string }) {
   const aui = useAui();
   const shell = useOptionalShellMode();
+  const isMobile = useIsMobile();
   const ClearChatButton = useSlot('ClearChatButton');
   const AgentDetailsPage = useSlot('AgentDetailsPage');
   const AgentsLibrary = useSlot('AgentsLibrary');
@@ -35,7 +37,8 @@ export function DrawerLayout({ className }: { className?: string }) {
   const sessionsOpen = shell?.sessionsOpen === true;
   const schedulesOpen = shell?.schedulesOpen === true;
   const overlayOpen = settingsOpen || libraryOpen || sessionsOpen || schedulesOpen;
-  const showAgentConfig = shell != null && shellIsCreateAgent(shell.mode) && !overlayOpen;
+  const showAgentConfig =
+    shell != null && shellIsCreateAgent(shell.mode) && !overlayOpen && (!isMobile || shell.agentConfigOpen);
   const showNewActions = shell?.isNewChatEnabled !== false;
 
   const handleNewChat = () => {
@@ -66,7 +69,7 @@ export function DrawerLayout({ className }: { className?: string }) {
           aria-label="Agent Config"
           className="absolute inset-y-0 left-0 z-20 w-full max-w-sm border-r border-border shadow-xl md:static md:z-auto md:w-88 md:max-w-none md:shrink-0 md:shadow-none"
         >
-          <AgentConfigDrawerContainer />
+          <AgentConfigDrawerContainer showClose={isMobile} />
         </aside>
       ) : null}
 

--- a/packages/trueforge-ui/src/layouts/DrawerLayout.tsx
+++ b/packages/trueforge-ui/src/layouts/DrawerLayout.tsx
@@ -11,7 +11,7 @@ import { Spinner } from '../atoms/primitives/Spinner.js';
 import { AgentConfigDrawerContainer } from '../containers/AgentConfigDrawerContainer.js';
 import { Thread } from '../containers/Thread.js';
 import { Icon } from '../icons/Icon.js';
-import { useOptionalShellMode } from '../server/ShellModeContext.js';
+import { shellIsCreateAgent, useOptionalShellMode } from '../server/ShellModeContext.js';
 import { useSlot } from '../theme/SlotsProvider.js';
 
 const TruefoundrySettingsBuilder = lazy(() => import('../containers/SettingsBuilder/index.js'));
@@ -35,6 +35,7 @@ export function DrawerLayout({ className }: { className?: string }) {
   const sessionsOpen = shell?.sessionsOpen === true;
   const schedulesOpen = shell?.schedulesOpen === true;
   const overlayOpen = settingsOpen || libraryOpen || sessionsOpen || schedulesOpen;
+  const showAgentConfig = shell != null && shellIsCreateAgent(shell.mode) && !overlayOpen;
   const showNewActions = shell?.isNewChatEnabled !== false;
 
   const handleNewChat = () => {
@@ -58,18 +59,47 @@ export function DrawerLayout({ className }: { className?: string }) {
   };
 
   return (
-    <div className={cn('relative flex h-full min-h-0 w-full flex-col bg-primary-bg', className)}>
-      {/* Keep ShellActions mounted across Settings open/close so host action-slot state persists. */}
-      <header className="flex shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5">
-        {!overlayOpen ? (
-          <>
-            <NamedAgentHeaderLabel />
-            <span className="min-w-0 flex-1" />
-            <ClearChatButton />
-            {!shell?.agentConfigOpen ? <SaveAgentButton /> : null}
-          </>
-        ) : libraryOpen || schedulesOpen ? (
-          <>
+    <div className={cn('relative flex h-full min-h-0 w-full bg-primary-bg', className)}>
+      {showAgentConfig ? (
+        <aside
+          role="dialog"
+          aria-label="Agent Config"
+          className="absolute inset-y-0 left-0 z-20 w-full max-w-sm border-r border-border shadow-xl md:static md:z-auto md:w-88 md:max-w-none md:shrink-0 md:shadow-none"
+        >
+          <AgentConfigDrawerContainer />
+        </aside>
+      ) : null}
+
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        {/* Keep ShellActions mounted across Settings open/close so host action-slot state persists. */}
+        <header className="flex h-11 shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5">
+          {!overlayOpen ? (
+            <>
+              <NamedAgentHeaderLabel />
+              {showNewActions ? (
+                <button
+                  type="button"
+                  aria-label="New Chat"
+                  title="New Chat"
+                  className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
+                  onClick={handleNewChat}
+                >
+                  <Icon name="square-pen" />
+                </button>
+              ) : null}
+              {showNewActions && shell?.isComposerEnabled ? (
+                <button
+                  type="button"
+                  aria-label="New Agent"
+                  title="New Agent"
+                  className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
+                  onClick={handleNewAgent}
+                >
+                  <Icon name="agent-2" />
+                </button>
+              ) : null}
+            </>
+          ) : libraryOpen || schedulesOpen ? (
             <button
               type="button"
               className={auiButtonClass({ variant: 'ghost', size: 'sm' })}
@@ -81,40 +111,18 @@ export function DrawerLayout({ className }: { className?: string }) {
               <Icon name="arrow-left" />
               Back to chat
             </button>
-            <span className="min-w-0 flex-1" />
-          </>
-        ) : (
+          ) : (
+            <span />
+          )}
+          <ShellActions key="shell-actions" />
           <span className="min-w-0 flex-1" />
-        )}
-        <ShellActions key="shell-actions" />
-        {!overlayOpen ? (
-          <>
-            {showNewActions ? (
-              <button
-                type="button"
-                aria-label="New Chat"
-                title="New Chat"
-                className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
-                onClick={handleNewChat}
-              >
-                <Icon name="square-pen" />
-              </button>
-            ) : null}
-            {showNewActions && shell?.isComposerEnabled ? (
-              <button
-                type="button"
-                aria-label="New Agent"
-                title="New Agent"
-                className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
-                onClick={handleNewAgent}
-              >
-                <Icon name="agent-2" />
-              </button>
-            ) : null}
-          </>
-        ) : null}
-      </header>
-      <div className="flex min-h-0 min-w-0 flex-1">
+          {!overlayOpen ? (
+            <>
+              <ClearChatButton />
+              <SaveAgentButton />
+            </>
+          ) : null}
+        </header>
         <div ref={mainRef} className="min-h-0 min-w-0 flex-1">
           {settingsOpen ? (
             <Suspense
@@ -160,15 +168,6 @@ export function DrawerLayout({ className }: { className?: string }) {
             <Thread />
           )}
         </div>
-        {shell?.agentConfigOpen ? (
-          <aside
-            role="dialog"
-            aria-label="Agent Config"
-            className="absolute inset-y-0 right-0 z-20 w-full max-w-sm border-l border-border shadow-xl md:static md:z-auto md:w-[22rem] md:max-w-none md:shrink-0 md:shadow-none"
-          >
-            <AgentConfigDrawerContainer />
-          </aside>
-        ) : null}
       </div>
     </div>
   );

--- a/packages/trueforge-ui/src/layouts/SidebarLayout.tsx
+++ b/packages/trueforge-ui/src/layouts/SidebarLayout.tsx
@@ -178,6 +178,7 @@ export function SidebarLayout({ className }: { className?: string }) {
   const sessionsOpen = shell?.sessionsOpen === true;
   const schedulesOpen = shell?.schedulesOpen === true;
   const overlayOpen = settingsOpen || libraryOpen || sessionsOpen || schedulesOpen;
+  const showAgentConfig = shell != null && shellIsCreateAgent(shell.mode) && !overlayOpen;
   const hasChatHeaderContent = useChatHeaderContentVisible();
 
   useEffect(() => {
@@ -208,17 +209,26 @@ export function SidebarLayout({ className }: { className?: string }) {
     <div className={cn('relative flex h-full min-h-0 w-full min-w-0', className)}>
       <SidebarRail className="hidden md:flex" />
 
+      {showAgentConfig ? (
+        <aside
+          role="dialog"
+          aria-label="Agent Config"
+          className="absolute inset-y-0 left-0 z-20 w-full max-w-sm border-r border-border shadow-xl md:static md:z-auto md:w-88 md:max-w-none md:shrink-0 md:shadow-none"
+        >
+          <AgentConfigDrawerContainer />
+        </aside>
+      ) : null}
+
       <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-primary-bg">
         {/* Desktop keeps shell chrome in the rail footer (always mounted, including
             when visually hidden on small screens so host action-slot state persists).
             Mobile reaches theme/settings via the nav drawer rail. */}
         <header
           className={cn(
-            'flex shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5',
+            'flex h-11 shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5',
             // Desktop: hide when settings/idle or the thread header has nothing to show
             // (empty untitled draft). Mobile still needs the menu button.
-            // Keep visible while Agent Config is open so New Agent / title stay in chrome;
-            // SaveAgentButton is omitted below to avoid duplicating the drawer's save control.
+            // Builder mode keeps New Agent and its actions beside the persistent config.
             (overlayOpen || isIdle || !hasChatHeaderContent) && 'md:hidden',
           )}
         >
@@ -237,7 +247,7 @@ export function SidebarLayout({ className }: { className?: string }) {
               <NamedAgentHeaderLabel />
               <span className="min-w-0 flex-1" />
               <ClearChatButton />
-              {!shell?.agentConfigOpen ? <SaveAgentButton /> : null}
+              <SaveAgentButton />
             </>
           ) : (
             <span className="min-w-0 flex-1" />
@@ -290,16 +300,6 @@ export function SidebarLayout({ className }: { className?: string }) {
           )}
         </div>
       </div>
-
-      {shell?.agentConfigOpen ? (
-        <aside
-          role="dialog"
-          aria-label="Agent Config"
-          className="absolute inset-y-0 right-0 z-20 w-full max-w-sm border-l border-border shadow-xl md:static md:z-auto md:w-[22rem] md:max-w-none md:shrink-0 md:shadow-none"
-        >
-          <AgentConfigDrawerContainer />
-        </aside>
-      ) : null}
 
       {/* Mobile: same narrow rail as desktop */}
       {mobileNavOpen ? (

--- a/packages/trueforge-ui/src/layouts/SidebarLayout.tsx
+++ b/packages/trueforge-ui/src/layouts/SidebarLayout.tsx
@@ -14,6 +14,7 @@ import {
 import { useAui } from '../assistant-ui.js';
 import { auiButtonClass } from '../atoms/lib/buttonClasses.js';
 import { cn } from '../atoms/lib/cn.js';
+import { useIsMobile } from '../atoms/lib/useIsMobile.js';
 import { NamedAgentHeaderLabel } from '../atoms/NamedAgentHeaderLabel.js';
 import { Spinner } from '../atoms/primitives/Spinner.js';
 import { ShellActions } from '../atoms/ShellActions.js';
@@ -161,6 +162,7 @@ function SidebarRail({
 
 export function SidebarLayout({ className }: { className?: string }) {
   const shell = useOptionalShellMode();
+  const isMobile = useIsMobile();
   const AgentDetailsPage = useSlot('AgentDetailsPage');
   const AgentsLibrary = useSlot('AgentsLibrary');
   const SessionsPage = useSlot('SessionsPage');
@@ -178,7 +180,8 @@ export function SidebarLayout({ className }: { className?: string }) {
   const sessionsOpen = shell?.sessionsOpen === true;
   const schedulesOpen = shell?.schedulesOpen === true;
   const overlayOpen = settingsOpen || libraryOpen || sessionsOpen || schedulesOpen;
-  const showAgentConfig = shell != null && shellIsCreateAgent(shell.mode) && !overlayOpen;
+  const showAgentConfig =
+    shell != null && shellIsCreateAgent(shell.mode) && !overlayOpen && (!isMobile || shell.agentConfigOpen);
   const hasChatHeaderContent = useChatHeaderContentVisible();
 
   useEffect(() => {
@@ -215,7 +218,7 @@ export function SidebarLayout({ className }: { className?: string }) {
           aria-label="Agent Config"
           className="absolute inset-y-0 left-0 z-20 w-full max-w-sm border-r border-border shadow-xl md:static md:z-auto md:w-88 md:max-w-none md:shrink-0 md:shadow-none"
         >
-          <AgentConfigDrawerContainer />
+          <AgentConfigDrawerContainer showClose={isMobile} />
         </aside>
       ) : null}
 

--- a/packages/trueforge-ui/src/layouts/StackChatPanel.tsx
+++ b/packages/trueforge-ui/src/layouts/StackChatPanel.tsx
@@ -122,7 +122,7 @@ export function StackChatPanel({ className, threadHeaderEnd }: StackChatPanelPro
         </div>
       ) : (
         <>
-          <header className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5">
+          <header className="flex h-11 shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5">
             {showNewActions ? (
               <button
                 type="button"
@@ -146,10 +146,10 @@ export function StackChatPanel({ className, threadHeaderEnd }: StackChatPanelPro
               </button>
             ) : null}
             <NamedAgentHeaderLabel />
+            {threadHeaderEnd}
             <span className="min-w-0 flex-1" />
             <ClearChatButton />
             <SaveAgentButton />
-            {threadHeaderEnd}
           </header>
           <div className="min-h-0 flex-1">{isIdle ? <SelectAgentEmptyState /> : <Thread />}</div>
         </>

--- a/packages/trueforge-ui/src/layouts/WidgetLayout.tsx
+++ b/packages/trueforge-ui/src/layouts/WidgetLayout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { auiButtonClass } from '../atoms/lib/buttonClasses.js';
 import { cn } from '../atoms/lib/cn.js';
@@ -8,11 +8,12 @@ import { CompactLayoutProvider } from '../atoms/lib/CompactLayoutContext.js';
 import { Icon } from '../icons/Icon.js';
 import { useSlot } from '../theme/SlotsProvider.js';
 import { StackChatPanel } from './StackChatPanel.js';
+import { useWidgetVisibility } from './WidgetVisibilityContext.js';
 
 /** FAB-anchored panel with the same list ↔ thread stack as `dock`. */
 export function WidgetLayout({ className }: { className?: string }) {
   const BrandLogo = useSlot('BrandLogo');
-  const [open, setOpen] = useState(false);
+  const { open, setOpen } = useWidgetVisibility();
   const fabRef = useRef<HTMLButtonElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
   const wasOpen = useRef(false);
@@ -26,7 +27,7 @@ export function WidgetLayout({ className }: { className?: string }) {
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [open]);
+  }, [open, setOpen]);
 
   useEffect(() => {
     if (open) {

--- a/packages/trueforge-ui/src/layouts/WidgetVisibilityContext.tsx
+++ b/packages/trueforge-ui/src/layouts/WidgetVisibilityContext.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from 'react';
+
+type WidgetVisibilityContextValue = {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+const WidgetVisibilityContext = createContext<WidgetVisibilityContextValue | null>(null);
+
+export function WidgetVisibilityProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const value = useMemo(() => ({ open, setOpen }), [open]);
+
+  return <WidgetVisibilityContext.Provider value={value}>{children}</WidgetVisibilityContext.Provider>;
+}
+
+export function useWidgetVisibility(): WidgetVisibilityContextValue {
+  const value = useContext(WidgetVisibilityContext);
+  if (value === null) {
+    throw new Error('useWidgetVisibility must be used within WidgetVisibilityProvider');
+  }
+  return value;
+}

--- a/packages/trueforge-ui/test/atoms/SaveAgentButton.test.tsx
+++ b/packages/trueforge-ui/test/atoms/SaveAgentButton.test.tsx
@@ -4,6 +4,10 @@ import { cloneElement, isValidElement, useEffect, useLayoutEffect, type ReactNod
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SaveAgentButton } from '@/atoms/SaveAgentButton.js';
+import {
+  AgentConfigInstructionsProvider,
+  useAgentConfigInstructions,
+} from '@/atoms/draft/AgentConfigInstructionsContext.js';
 import { ServerProvider } from '@/server/ServerContext.js';
 import { ShellModeProvider, useShellMode, type AgentConfig } from '@/server/ShellModeContext.js';
 import type { AgentSpec, AgentUIServer, SaveAgentRequest, SaveAgentResult } from '@/server/types.js';
@@ -13,11 +17,13 @@ import { createMockAgentUIServer } from '../server/mockServer.js';
 let agentSpec: AgentSpec;
 const flushAgentSpec = vi.fn(async () => undefined);
 const adoptAgentSpec = vi.fn();
+const updateAgentSpec = vi.fn();
 
 vi.mock('@truefoundry/assistant-ui-runtime', () => ({
   useTrueFoundryAgentSpec: () => ({ agentSpec, draftSessionId: 'draft-1' }),
   useTrueFoundryFlushAgentSpec: () => flushAgentSpec,
   useTrueFoundryAdoptAgentSpec: () => adoptAgentSpec,
+  useTrueFoundryUpdateAgentSpec: () => updateAgentSpec,
 }));
 
 beforeAll(() => {
@@ -110,6 +116,18 @@ function BoundMutableSaveButton({ agentId, agentName }: { agentId: string; agent
   return <SaveAgentButton />;
 }
 
+function SaveWithInstructionDraft() {
+  const { onChange } = useAgentConfigInstructions();
+  return (
+    <>
+      <button type="button" onClick={() => onChange('Instructions currently visible in the drawer.')}>
+        Edit instructions
+      </button>
+      <SaveAgentButton />
+    </>
+  );
+}
+
 function deferred<T>() {
   let resolvePromise: ((value: T) => void) | undefined;
   const promise = new Promise<T>(resolve => {
@@ -142,6 +160,7 @@ describe('SaveAgentButton', () => {
     flushAgentSpec.mockReset();
     flushAgentSpec.mockResolvedValue(undefined);
     adoptAgentSpec.mockClear();
+    updateAgentSpec.mockClear();
   });
 
   it('is hidden when the shell is locked to a named agent', () => {
@@ -260,6 +279,27 @@ describe('SaveAgentButton', () => {
 
     expect(within(dialog).getByLabelText('Instructions')).toHaveValue('Instructions currently visible in the drawer.');
     expect(within(dialog).getByText('gpt-4.1')).toBeInTheDocument();
+  });
+
+  it('flushes the shared instruction draft when opening Save Agent', async () => {
+    renderButton({
+      children: (
+        <AgentConfigInstructionsProvider>
+          <SaveWithInstructionDraft />
+        </AgentConfigInstructionsProvider>
+      ),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit instructions' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save Agent' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Save agent' });
+
+    expect(updateAgentSpec).toHaveBeenCalledWith({
+      instructions: 'Instructions currently visible in the drawer.',
+    });
+    expect(within(dialog).getByLabelText('Instructions')).toHaveValue(
+      'Instructions currently visible in the drawer.',
+    );
   });
 
   it('labels an existing mutable binding as Update Agent and submits an update', async () => {

--- a/packages/trueforge-ui/test/atoms/SaveAgentButton.test.tsx
+++ b/packages/trueforge-ui/test/atoms/SaveAgentButton.test.tsx
@@ -151,7 +151,10 @@ describe('SaveAgentButton', () => {
 
   it('shows on an empty new chat when a model is selected', () => {
     renderButton();
-    expect(screen.getByRole('button', { name: 'Save Agent' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save Agent' })).toHaveClass(
+      'bg-primary-button-bg',
+      'text-primary-button-text',
+    );
   });
 
   it('is hidden when the draft has no model', () => {

--- a/packages/trueforge-ui/test/atoms/SaveAgentButton.test.tsx
+++ b/packages/trueforge-ui/test/atoms/SaveAgentButton.test.tsx
@@ -297,9 +297,7 @@ describe('SaveAgentButton', () => {
     expect(updateAgentSpec).toHaveBeenCalledWith({
       instructions: 'Instructions currently visible in the drawer.',
     });
-    expect(within(dialog).getByLabelText('Instructions')).toHaveValue(
-      'Instructions currently visible in the drawer.',
-    );
+    expect(within(dialog).getByLabelText('Instructions')).toHaveValue('Instructions currently visible in the drawer.');
   });
 
   it('labels an existing mutable binding as Update Agent and submits an update', async () => {

--- a/packages/trueforge-ui/test/atoms/draft/AgentConfigPanel.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/AgentConfigPanel.test.tsx
@@ -69,6 +69,13 @@ describe('AgentConfigPanel', () => {
     expect(screen.queryByText('Variables')).not.toBeInTheDocument();
     expect(screen.queryByText('Initial messages')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Close agent config' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Agent Config' }).parentElement).toHaveClass(
+      'h-11',
+      'border-b',
+      'bg-topbar-bg',
+      'px-2',
+      'py-1.5',
+    );
   });
 
   it('routes editor actions and live instruction changes', () => {

--- a/packages/trueforge-ui/test/atoms/draft/DraftComposerSections.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/DraftComposerSections.test.tsx
@@ -1,10 +1,13 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen } from '@testing-library/react';
+import { useLayoutEffect, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DraftCatalogProvider } from '@/atoms/draft/DraftCatalogProvider.js';
 import { DraftComposerLeftSection, DraftComposerRightSection } from '@/atoms/draft/DraftComposerSections.js';
+import { CompactLayoutProvider } from '@/atoms/lib/CompactLayoutContext.js';
 import { ServerProvider } from '@/server/ServerContext.js';
+import { ShellModeProvider, useShellMode } from '@/server/ShellModeContext.js';
 import type { AgentSpec } from '@/server/types.js';
 import { createMockAgentUIServer } from '../../server/mockServer.js';
 
@@ -46,6 +49,14 @@ function DraftSections({
   );
 }
 
+function BuilderMode({ children }: { children: ReactNode }) {
+  const { openAgentBuilder } = useShellMode();
+  useLayoutEffect(() => {
+    openAgentBuilder();
+  }, [openAgentBuilder]);
+  return children;
+}
+
 describe('draft composer sections', () => {
   beforeEach(() => {
     agentSpec = {
@@ -76,6 +87,30 @@ describe('draft composer sections', () => {
     expect(await screen.findByTitle('Select reasoning effort')).toHaveTextContent('high');
     // Without shell builder mode, left chrome is Tools — not Agent config.
     expect(screen.queryByRole('button', { name: 'Agent config' })).not.toBeInTheDocument();
+  });
+
+  it('shows the Agent config trigger only in compact builder layouts', () => {
+    const { rerender } = render(
+      <ShellModeProvider agentConfig={{ mode: 'AgentComposer' }}>
+        <BuilderMode>
+          <DraftSections />
+        </BuilderMode>
+      </ShellModeProvider>,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Agent config' })).not.toBeInTheDocument();
+
+    rerender(
+      <ShellModeProvider agentConfig={{ mode: 'AgentComposer' }}>
+        <BuilderMode>
+          <CompactLayoutProvider>
+            <DraftSections />
+          </CompactLayoutProvider>
+        </BuilderMode>
+      </ShellModeProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Agent config' })).toBeInTheDocument();
   });
 
   it('propagates disabled and running state to composed controls', async () => {

--- a/packages/trueforge-ui/test/containers/AgentConfigDrawerContainer.test.tsx
+++ b/packages/trueforge-ui/test/containers/AgentConfigDrawerContainer.test.tsx
@@ -2,6 +2,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
+import { SaveAgentButton } from '@/atoms/SaveAgentButton.js';
 import { AgentConfigDrawerContainer } from '@/containers/AgentConfigDrawerContainer.js';
 import { ServerProvider } from '@/server/ServerContext.js';
 import { ShellModeProvider, useShellMode } from '@/server/ShellModeContext.js';
@@ -30,7 +31,7 @@ beforeAll(() => {
   };
 });
 
-function TestView() {
+function TestView({ compact = true }: { compact?: boolean }) {
   const shell = useShellMode();
   return (
     <>
@@ -43,8 +44,9 @@ function TestView() {
       >
         Open config
       </button>
+      <SaveAgentButton />
       <output data-testid="config-open">{String(shell.agentConfigOpen)}</output>
-      {shell.agentConfigOpen ? <AgentConfigDrawerContainer showClose /> : null}
+      {shell.agentConfigOpen ? <AgentConfigDrawerContainer showClose={compact} /> : null}
     </>
   );
 }
@@ -71,5 +73,23 @@ describe('AgentConfigDrawerContainer', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(screen.getByTestId('config-open')).toHaveTextContent('false');
+  });
+
+  it('does not close the persistent sidebar panel on Escape', () => {
+    render(
+      <SlotsProvider>
+        <ServerProvider server={createMockAgentUIServer()}>
+          <ShellModeProvider agentConfig={{ mode: 'AgentComposer' }}>
+            <TestView compact={false} />
+          </ShellModeProvider>
+        </ServerProvider>
+      </SlotsProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open config' }));
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(screen.getByTestId('config-open')).toHaveTextContent('true');
+    expect(screen.queryByRole('button', { name: 'Close agent config' })).not.toBeInTheDocument();
   });
 });

--- a/packages/trueforge-ui/test/containers/AgentConfigDrawerContainer.test.tsx
+++ b/packages/trueforge-ui/test/containers/AgentConfigDrawerContainer.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { SaveAgentButton } from '@/atoms/SaveAgentButton.js';
+import { AgentConfigInstructionsProvider } from '@/atoms/draft/AgentConfigInstructionsContext.js';
 import { AgentConfigDrawerContainer } from '@/containers/AgentConfigDrawerContainer.js';
 import { ServerProvider } from '@/server/ServerContext.js';
 import { ShellModeProvider, useShellMode } from '@/server/ShellModeContext.js';
@@ -57,7 +58,9 @@ describe('AgentConfigDrawerContainer', () => {
       <SlotsProvider>
         <ServerProvider server={createMockAgentUIServer()}>
           <ShellModeProvider agentConfig={{ mode: 'AgentComposer' }}>
-            <TestView />
+            <AgentConfigInstructionsProvider>
+              <TestView />
+            </AgentConfigInstructionsProvider>
           </ShellModeProvider>
         </ServerProvider>
       </SlotsProvider>,
@@ -80,7 +83,9 @@ describe('AgentConfigDrawerContainer', () => {
       <SlotsProvider>
         <ServerProvider server={createMockAgentUIServer()}>
           <ShellModeProvider agentConfig={{ mode: 'AgentComposer' }}>
-            <TestView compact={false} />
+            <AgentConfigInstructionsProvider>
+              <TestView compact={false} />
+            </AgentConfigInstructionsProvider>
           </ShellModeProvider>
         </ServerProvider>
       </SlotsProvider>,

--- a/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
+++ b/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
@@ -539,13 +539,11 @@ describe('SidebarLayout', () => {
     expect(selectedNewAgent).toHaveAttribute('aria-current', 'page');
     expect(deselectedNewChat).not.toHaveAttribute('aria-current');
     const config = await screen.findByRole('dialog', { name: 'Agent Config' });
-    const clearChat = await screen.findByRole('button', { name: 'Clear chat' });
-    const saveAgent = await screen.findByRole('button', { name: 'Save Agent' });
+    const chatColumn = config.nextElementSibling;
     expect(config).toHaveClass('border-r');
-    expect(config.nextElementSibling).toContainElement(saveAgent);
-    expect(clearChat.nextElementSibling).toBe(saveAgent);
+    expect(chatColumn).not.toBeNull();
     expect(config.querySelector('header')).toHaveClass('h-11');
-    expect(saveAgent.closest('header')).toHaveClass('h-11');
+    expect(chatColumn?.querySelector('header')).toHaveClass('h-11');
     expect(screen.queryByRole('button', { name: 'Agent config' })).not.toBeInTheDocument();
 
     const [settingsButton] = screen.getAllByRole('button', { name: 'Settings' });
@@ -679,6 +677,10 @@ describe('layout slot overrides', () => {
     return <button type="button">custom clear</button>;
   }
 
+  function CustomSaveAgent() {
+    return <button type="button">custom save</button>;
+  }
+
   function CustomActionSlot() {
     return <button type="button">custom action</button>;
   }
@@ -705,6 +707,24 @@ describe('layout slot overrides', () => {
 
     expect(screen.getByRole('button', { name: 'custom clear' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Clear chat' })).not.toBeInTheDocument();
+  });
+
+  it.each(hosts)('%s places Clear Chat immediately before Save Agent', (_name, Layout) => {
+    render(
+      <SlotsProvider overrides={{ ClearChatButton: CustomClearChat, SaveAgentButton: CustomSaveAgent }}>
+        <ShellModeProvider agentConfig={{ mode: 'SingleAgent', name: 'a' }}>
+          <RuntimeHarness messages={[]}>
+            <div className="h-96">
+              <Layout />
+            </div>
+          </RuntimeHarness>
+        </ShellModeProvider>
+      </SlotsProvider>,
+    );
+
+    const clearChat = screen.getByRole('button', { name: 'custom clear' });
+    const saveAgent = screen.getByRole('button', { name: 'custom save' });
+    expect(clearChat.nextElementSibling).toBe(saveAgent);
   });
 
   it.each(hosts)('%s honors overrides.ShellActionsActionSlot to the right of shell actions', (_name, Layout) => {

--- a/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
+++ b/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
@@ -136,12 +136,7 @@ describe('TrueForgeUI', () => {
 
   it('keeps the widget open across mutable runtime remounts', async () => {
     render(
-      <TrueForgeUI
-        server={mockServer()}
-        agentConfig={{ mode: 'AgentComposer' }}
-        layout="widget"
-        className="h-96"
-      />,
+      <TrueForgeUI server={mockServer()} agentConfig={{ mode: 'AgentComposer' }} layout="widget" className="h-96" />,
     );
 
     fireEvent.click(await screen.findByRole('button', { name: 'Open chat' }));

--- a/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
+++ b/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
@@ -59,6 +59,7 @@ import { DrawerLayout } from '@/layouts/DrawerLayout.js';
 import { SidebarLayout } from '@/layouts/SidebarLayout.js';
 import { StackChatPanel } from '@/layouts/StackChatPanel.js';
 import { WidgetLayout } from '@/layouts/WidgetLayout.js';
+import { WidgetVisibilityProvider } from '@/layouts/WidgetVisibilityContext.js';
 import { ServerProvider } from '@/server/ServerContext.js';
 import { ShellModeProvider, useShellMode } from '@/server/ShellModeContext.js';
 import { SlotsProvider } from '@/theme/SlotsProvider.js';
@@ -117,6 +118,29 @@ describe('TrueForgeUI', () => {
       }
     });
     expect(container.querySelector('.h-96')).toBeInTheDocument();
+  });
+
+  it('keeps the widget open across mutable runtime remounts', async () => {
+    render(
+      <TrueForgeUI
+        server={mockServer()}
+        agentConfig={{ mode: 'AgentComposer' }}
+        layout="widget"
+        className="h-96"
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open chat' }));
+    expect(screen.getByRole('dialog', { name: 'Chat' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Chat' }));
+    await waitFor(() => expect(screen.getByRole('dialog', { name: 'Chat' })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Agent' }));
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: 'Chat' })).toBeInTheDocument();
+      expect(screen.getByRole('dialog', { name: 'Agent Config' })).toBeInTheDocument();
+    });
   });
 
   it('mounts a custom layout component inside providers', async () => {
@@ -467,6 +491,15 @@ describe('SidebarLayout', () => {
     fireEvent.click(newAgent);
     expect(newAgent).toHaveAttribute('aria-current', 'page');
     expect(newChat).not.toHaveAttribute('aria-current');
+    const config = screen.getByRole('dialog', { name: 'Agent Config' });
+    const clearChat = screen.getByRole('button', { name: 'Clear chat' });
+    const saveAgent = screen.getByRole('button', { name: 'Save Agent' });
+    expect(config).toHaveClass('border-r');
+    expect(config.nextElementSibling).toContainElement(saveAgent);
+    expect(clearChat.nextElementSibling).toBe(saveAgent);
+    expect(config.querySelector('header')).toHaveClass('h-11');
+    expect(saveAgent.closest('header')).toHaveClass('h-11');
+    expect(screen.queryByRole('button', { name: 'Agent config' })).not.toBeInTheDocument();
 
     const [settingsButton] = screen.getAllByRole('button', { name: 'Settings' });
     if (settingsButton === undefined) {
@@ -699,11 +732,13 @@ describe('WidgetLayout a11y', () => {
   it('opens chat dialog, focuses it, and restores FAB focus on Escape', async () => {
     render(
       <SlotsProvider>
-        <RuntimeHarness messages={[]}>
-          <div className="h-96">
-            <WidgetLayout />
-          </div>
-        </RuntimeHarness>
+        <WidgetVisibilityProvider>
+          <RuntimeHarness messages={[]}>
+            <div className="h-96">
+              <WidgetLayout />
+            </div>
+          </RuntimeHarness>
+        </WidgetVisibilityProvider>
       </SlotsProvider>,
     );
 

--- a/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
+++ b/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
@@ -54,6 +54,7 @@ vi.mock('@/plugins/trueforge-agent-server-adapter/index.js', () => ({
   ),
 }));
 
+import { AgentConfigInstructionsProvider } from '@/atoms/draft/AgentConfigInstructionsContext.js';
 import { TrueForgeUI, type ChatLayout } from '@/containers/TrueForgeUI.js';
 import { DrawerLayout } from '@/layouts/DrawerLayout.js';
 import { SidebarLayout } from '@/layouts/SidebarLayout.js';
@@ -81,6 +82,19 @@ beforeAll(() => {
     this.dispatchEvent(new Event('close'));
   };
 });
+
+function mobileMatchMedia(query: string): MediaQueryList {
+  return {
+    matches: query === '(max-width: 767px)',
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(() => true),
+  };
+}
 
 describe('TrueForgeUI', () => {
   const server = mockServer();
@@ -376,6 +390,40 @@ describe('StackChatPanel', () => {
 });
 
 describe('SidebarLayout', () => {
+  it('lets mobile builders close and reopen Agent Config', () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'matchMedia', { configurable: true, value: mobileMatchMedia });
+
+    try {
+      render(
+        <SlotsProvider>
+          <ServerProvider server={mockServer(stubCatalog)}>
+            <ShellModeProvider>
+              <AgentConfigInstructionsProvider>
+                <RuntimeHarness messages={[]}>
+                  <div className="h-96">
+                    <SidebarLayout />
+                  </div>
+                </RuntimeHarness>
+              </AgentConfigInstructionsProvider>
+            </ShellModeProvider>
+          </ServerProvider>
+        </SlotsProvider>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Start new agent' }));
+      expect(screen.getByRole('dialog', { name: 'Agent Config' })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Close agent config' }));
+      expect(screen.queryByRole('dialog', { name: 'Agent Config' })).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Agent config' }));
+      expect(screen.getByRole('dialog', { name: 'Agent Config' })).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, 'matchMedia', { configurable: true, value: originalMatchMedia });
+    }
+  });
+
   it('shows the app brand in the mobile navigation drawer', () => {
     render(
       <SlotsProvider theme={{ brand: { mode: 'icon-title', name: 'Acme', icon: { src: '/acme.svg' } } }}>
@@ -473,11 +521,13 @@ describe('SidebarLayout', () => {
       <SlotsProvider theme={{ brand: { mode: 'icon-title', name: 'Acme' } }}>
         <ServerProvider server={mockServer(stubCatalog)}>
           <ShellModeProvider>
-            <RuntimeHarness messages={[]}>
-              <div className="h-96">
-                <SidebarLayout />
-              </div>
-            </RuntimeHarness>
+            <AgentConfigInstructionsProvider>
+              <RuntimeHarness messages={[]}>
+                <div className="h-96">
+                  <SidebarLayout />
+                </div>
+              </RuntimeHarness>
+            </AgentConfigInstructionsProvider>
           </ShellModeProvider>
         </ServerProvider>
       </SlotsProvider>,

--- a/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
+++ b/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
@@ -534,11 +534,13 @@ describe('SidebarLayout', () => {
     expect(newAgent).not.toHaveAttribute('aria-current');
 
     fireEvent.click(newAgent);
-    expect(newAgent).toHaveAttribute('aria-current', 'page');
-    expect(newChat).not.toHaveAttribute('aria-current');
-    const config = screen.getByRole('dialog', { name: 'Agent Config' });
-    const clearChat = screen.getByRole('button', { name: 'Clear chat' });
-    const saveAgent = screen.getByRole('button', { name: 'Save Agent' });
+    const selectedNewAgent = await screen.findByRole('button', { name: 'Start new agent' });
+    const deselectedNewChat = screen.getByRole('button', { name: 'Start new chat' });
+    expect(selectedNewAgent).toHaveAttribute('aria-current', 'page');
+    expect(deselectedNewChat).not.toHaveAttribute('aria-current');
+    const config = await screen.findByRole('dialog', { name: 'Agent Config' });
+    const clearChat = await screen.findByRole('button', { name: 'Clear chat' });
+    const saveAgent = await screen.findByRole('button', { name: 'Save Agent' });
     expect(config).toHaveClass('border-r');
     expect(config.nextElementSibling).toContainElement(saveAgent);
     expect(clearChat.nextElementSibling).toBe(saveAgent);
@@ -554,8 +556,8 @@ describe('SidebarLayout', () => {
     fireEvent.click(settingsButton);
     expect(await screen.findByRole('heading', { name: 'Settings' })).toBeInTheDocument();
     expect(settingsButton).toHaveAttribute('aria-current', 'page');
-    expect(newChat).not.toHaveAttribute('aria-current');
-    expect(newAgent).not.toHaveAttribute('aria-current');
+    expect(deselectedNewChat).not.toHaveAttribute('aria-current');
+    expect(selectedNewAgent).not.toHaveAttribute('aria-current');
   });
 
   it('toggles theme from the footer and shows settings only when catalog is provided', async () => {

--- a/packages/trueforge-ui/test/tsconfig.json
+++ b/packages/trueforge-ui/test/tsconfig.json
@@ -5,6 +5,7 @@
     "declarationMap": false,
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "customConditions": ["trueforge-dev"],
     "rootDir": "..",
     "types": ["node", "vitest/globals"]
   },

--- a/packages/trueforge-ui/tsconfig.json
+++ b/packages/trueforge-ui/tsconfig.json
@@ -19,7 +19,8 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "noUncheckedIndexedAccess": true,
-    "types": ["node"]
+    "types": ["node"],
+    "customConditions": ["trueforge-dev"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

https://linear.app/truefoundry/issue/FRONTEN-2449/agent-builder-page-issues


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/layout and draft-sync behavior in the agent composer; no auth or API contract changes, with broad test coverage for layouts and save flow.
> 
> **Overview**
> Reworks **agent builder** chrome so **Agent Config** is a **persistent left column** on desktop (sidebar/drawer) while in create-agent mode, instead of a right drawer toggled by `agentConfigOpen`. On **mobile**, config stays an overlay with a **Close** control and can be reopened via the composer **Agent config** trigger; desktop hides that trigger because the panel is always shown.
> 
> Introduces **`AgentConfigInstructionsProvider`** so debounced instruction edits are shared between the config panel and **`SaveAgentButton`**, which **flushes** the draft (and agent spec) before opening the save modal so the saved spec matches what the user typed. Save moves out of the panel header into the main top bar (always beside Clear Chat); panel header styling aligns with other **`h-11` / `bg-topbar-bg`** chrome.
> 
> **Widget** layout lifts open/closed state into **`WidgetVisibilityProvider`** above the chat runtime so the FAB panel **stays open** across `runtimeKey` remounts (e.g. New Chat / New Agent). **`DraftComposerLeftSection`** only shows the config trigger in **compact or mobile** builder layouts.
> 
> Minor: Save Agent uses the default button variant; tsconfig adds **`customConditions: ["trueforge-dev"]`** for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e5aee664aac29288c8754921a3b1692f957217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->