### PR TITLE
Unify page chrome, paginate MCP selectors, and sandbox New Chat

### DIFF
--- a/.changeset/mcp-selector-infinite-scroll.md
+++ b/.changeset/mcp-selector-infinite-scroll.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': minor
+---
+
+MCP selectors (composer + agent config) infinite-scroll through `listMcp` pages via DraftCatalogProvider.

--- a/.changeset/new-chat-capabilities-sandbox.md
+++ b/.changeset/new-chat-capabilities-sandbox.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+New Chat enables sandbox on the live draft agent config when capabilities report sandbox as available.

--- a/.changeset/unified-page-header-chrome.md
+++ b/.changeset/unified-page-header-chrome.md
@@ -2,4 +2,4 @@
 "@truefoundry/trueforge-ui": patch
 ---
 
-Share a single `PageHeader` across chat and list chrome so title size/height stay consistent, and drop decorative title icons / the Settings back button.
+Share a single `PageHeader` across chat and list chrome so title size/height stay consistent, and drop decorative title icons.

--- a/.changeset/unified-page-header-chrome.md
+++ b/.changeset/unified-page-header-chrome.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge-ui": patch
+---
+
+Share a single `PageHeader` across chat and list chrome so title size/height stay consistent, and drop decorative title icons / the Settings back button.

--- a/.cursor/rules/styles-rem-not-px.mdc
+++ b/.cursor/rules/styles-rem-not-px.mdc
@@ -1,0 +1,41 @@
+---
+description: Prefer rem over px for UI lengths (1rem = 16px)
+globs: packages/trueforge-ui/**/*.{tsx,ts,css}, packages/frontend/**/*.{tsx,ts,css}
+alwaysApply: false
+---
+
+# Styles use rem, not px
+
+Do not introduce CSS/Tailwind lengths in `px`. Use `rem` with **1rem = 16px**.
+
+## Convert
+
+| px | rem |
+|----|-----|
+| 8px | 0.5rem |
+| 10px | 0.625rem |
+| 11px | 0.6875rem |
+| 12px | 0.75rem |
+| 14px | 0.875rem |
+| 16px | 1rem |
+| 24px | 1.5rem |
+| 32px | 2rem |
+| 48px | 3rem |
+
+```tsx
+// ❌ BAD
+className="text-[10px]"
+const margin = '48px';
+
+// ✅ GOOD
+className="text-[0.625rem]"
+const margin = '3rem';
+```
+
+Prefer Tailwind spacing scale utilities (`p-2`, `gap-1.5`, `text-sm`) when they match; they already resolve to rem.
+
+## Allowed exceptions
+
+- `0px` in `calc()` / `env()` fallbacks (e.g. `env(safe-area-inset-bottom, 0px)`)
+- Media-query device breakpoints that already exist as px (e.g. `(max-width: 767px)`) — do not invent new px style lengths elsewhere to match them
+- Canvas / measurement APIs that require CSS pixels for drawing math

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
 - Zod unions MUST use `z.discriminatedUnion` whenever every member carries a shared literal discriminator field; `z.union` is only permitted when no such common discriminator exists.
 - HTTP/OpenAPI wire shapes (path params, query params, request/response JSON fields) and database identifiers (table/column names, persisted jsonb document keys) MUST use `snake_case`.
 - Server code MUST NOT read environment variables via `process.env` directly; all env reads MUST go through `packages/trueforge/src/config.ts`, unless there is a documented special requirement (for example bootstrap before config is loaded).
+- UI styles MUST use `rem` for lengths (not `px`); assume **1rem = 16px**. Prefer Tailwind spacing/type scale utilities when they fit. Exceptions: `0px` in `calc()`/`env()` fallbacks, existing media-query breakpoints, and canvas/measurement APIs that require CSS pixels.
 
 ## Code comments
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -26,7 +26,7 @@
     "@assistant-ui/core": "0.2.22",
     "@assistant-ui/react": "0.14.27",
     "@assistant-ui/store": "0.2.21",
-    "@truefoundry/assistant-ui-runtime": "0.1.26",
+    "@truefoundry/assistant-ui-runtime": "0.1.27",
     "@truefoundry/trueforge-sdk": "workspace:*",
     "@truefoundry/trueforge-ui": "workspace:*",
     "monaco-editor": "^0.52.0",

--- a/packages/trueforge-ui/package.json
+++ b/packages/trueforge-ui/package.json
@@ -95,7 +95,7 @@
     "@openuidev/react-headless": "^0.9.4",
     "@openuidev/react-lang": "^0.2.9",
     "@openuidev/react-ui": "^0.13.2",
-    "@truefoundry/assistant-ui-runtime": "0.1.26",
+    "@truefoundry/assistant-ui-runtime": "0.1.27",
     "@truefoundry/trueforge-sdk": "workspace:*",
     "chart.js": "^4.5.1",
     "clsx": "^2.1.1",

--- a/packages/trueforge-ui/src/atoms/AgentsLibrary.tsx
+++ b/packages/trueforge-ui/src/atoms/AgentsLibrary.tsx
@@ -15,6 +15,7 @@ import { auiButtonClass } from './lib/buttonClasses.js';
 import { cn } from './lib/cn.js';
 import { mountName } from './lib/mountName.js';
 import { useSearchAgentsList } from './lib/useSearchAgentsList.js';
+import { PageHeader } from './PageHeader.js';
 import SearchInput from './primitives/SearchInput.js';
 import { Skeleton } from './primitives/Skeleton.js';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './primitives/Table.js';
@@ -357,20 +358,19 @@ export function AgentsLibrary({ onSelectAgent }: AgentsLibraryProps) {
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-primary-bg">
-      <header className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 py-2.5 md:px-6">
-        <div className="flex min-w-0 items-center gap-2">
-          <Icon name="library-big" className="text-text-primary size-4" />
-          <h1 className="text-text-primary truncate text-md font-semibold">Agents</h1>
-        </div>
-        <div className="ml-auto w-56 shrink-0">
-          <SearchInput query={query} setQuery={setQuery} placeholder="Search agents" />
-          {isSearching ? (
-            <p className="sr-only" role="status">
-              Searching…
-            </p>
-          ) : null}
-        </div>
-      </header>
+      <PageHeader
+        title="Agents"
+        end={
+          <div className="w-56 shrink-0">
+            <SearchInput query={query} setQuery={setQuery} placeholder="Search agents" />
+            {isSearching ? (
+              <p className="sr-only" role="status">
+                Searching…
+              </p>
+            ) : null}
+          </div>
+        }
+      />
 
       <div className="bg-secondary-bg/40 flex min-h-0 flex-1 flex-col">
         <div ref={listRef} className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4" aria-label="Agents">

--- a/packages/trueforge-ui/src/atoms/AgentsLibraryButton.tsx
+++ b/packages/trueforge-ui/src/atoms/AgentsLibraryButton.tsx
@@ -54,7 +54,7 @@ export function AgentsLibraryButton({ className, compact = false }: AgentsLibrar
           className: cn(
             'rounded-md text-sm font-medium text-text-primary shadow-none hover:bg-secondary-button-hover hover:text-ghost-button-text',
             compact
-              ? 'h-auto w-full flex-col gap-0.5 whitespace-normal px-1 py-3 text-[0.625rem] leading-tight !justify-center'
+              ? 'h-auto w-full flex-col gap-1.5 whitespace-normal px-1 py-3 text-[0.625rem] leading-tight !justify-center'
               : 'h-8 w-full !justify-start px-2.5',
             libraryOpen &&
               'bg-primary-button-bg text-primary-button-text hover:bg-primary-button-hover hover:text-primary-button-text',

--- a/packages/trueforge-ui/src/atoms/NamedAgentHeaderLabel.tsx
+++ b/packages/trueforge-ui/src/atoms/NamedAgentHeaderLabel.tsx
@@ -4,9 +4,10 @@ import { useAuiState } from '../assistant-ui.js';
 import { useNamedAgentHeaderState } from '../hooks/useChatChromeActionsVisible.js';
 import { Icon } from '../icons/Icon.js';
 import { cn } from './lib/cn.js';
+import { pageHeaderTitleClassName } from './PageHeader.js';
 import { Tooltip } from './primitives/Tooltip.js';
 
-/** Left-of-header title for named agents and New Chat / New Agent drafts. */
+/** Dynamic chat title for named agents and New Chat / New Agent drafts. */
 export function NamedAgentHeaderLabel({ className }: { className?: string }) {
   const state = useNamedAgentHeaderState();
   const threadTitle = useAuiState(s => s.threadListItem.title);
@@ -16,14 +17,7 @@ export function NamedAgentHeaderLabel({ className }: { className?: string }) {
   const displayName = state.allowThreadTitle && syncedTitle.length > 0 ? syncedTitle : state.name;
 
   return (
-    <h1
-      className={cn(
-        // Match sm/icon chrome buttons so header height doesn't collapse when Clear/Save hide.
-        'flex min-h-8 min-w-0 items-center gap-1.5 px-1 text-sm font-medium text-text-primary',
-        className,
-      )}
-    >
-      <Icon name={state.icon} className="size-3.5 shrink-0" />
+    <h1 className={cn('flex min-w-0 items-center gap-1.5', pageHeaderTitleClassName, className)}>
       <span className="truncate" title={displayName}>
         {displayName}
       </span>

--- a/packages/trueforge-ui/src/atoms/PageHeader.tsx
+++ b/packages/trueforge-ui/src/atoms/PageHeader.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { cn } from './lib/cn.js';
+
+/** Shared title styles for page / chat chrome headers. */
+export const pageHeaderTitleClassName = 'text-text-primary min-w-0 truncate text-md font-semibold';
+
+export type PageHeaderProps = {
+  /** Page name, or a custom title node (e.g. `NamedAgentHeaderLabel`). Strings use the shared h1 styles. */
+  title?: ReactNode;
+  /** Leading chrome (back / menu). */
+  start?: ReactNode;
+  /** Trailing actions; pushed to the end. */
+  end?: ReactNode;
+  /** Extra content between title and end (prefer `start` / `end` when possible). */
+  children?: ReactNode;
+  className?: string;
+};
+
+/** Fixed-height shell/page header bar used by chat chrome and list pages. */
+export function PageHeader({ title, start, end, children, className }: PageHeaderProps) {
+  return (
+    <header
+      className={cn('flex h-14 shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 md:px-6', className)}
+    >
+      {start}
+      {typeof title === 'string' ? <h1 className={pageHeaderTitleClassName}>{title}</h1> : title}
+      {children}
+      {end != null ? <div className="ml-auto flex min-w-0 flex-wrap items-center gap-2">{end}</div> : null}
+    </header>
+  );
+}

--- a/packages/trueforge-ui/src/atoms/PageHeader.tsx
+++ b/packages/trueforge-ui/src/atoms/PageHeader.tsx
@@ -19,11 +19,16 @@ export type PageHeaderProps = {
   className?: string;
 };
 
-/** Fixed-height shell/page header bar used by chat chrome and list pages. */
+/** Shared shell/page header bar used by chat chrome and list pages.
+ * `min-h-14` keeps a single-row bar aligned with Agent Config; wrapping end actions can grow the bar.
+ */
 export function PageHeader({ title, start, end, children, className }: PageHeaderProps) {
   return (
     <header
-      className={cn('flex h-14 shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 md:px-6', className)}
+      className={cn(
+        'flex min-h-14 shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 md:px-6',
+        className,
+      )}
     >
       {start}
       {typeof title === 'string' ? <h1 className={pageHeaderTitleClassName}>{title}</h1> : title}

--- a/packages/trueforge-ui/src/atoms/SchedulesButton.tsx
+++ b/packages/trueforge-ui/src/atoms/SchedulesButton.tsx
@@ -32,7 +32,7 @@ export function SchedulesButton({ className, compact = false }: SchedulesButtonP
           className: cn(
             'rounded-md text-sm font-medium text-text-primary shadow-none hover:bg-secondary-button-hover hover:text-ghost-button-text',
             compact
-              ? 'h-auto w-full flex-col gap-0.5 whitespace-normal px-1 py-3 text-[0.625rem] leading-tight !justify-center'
+              ? 'h-auto w-full flex-col gap-1.5 whitespace-normal px-1 py-3 text-[0.625rem] leading-tight !justify-center'
               : 'h-8 w-full !justify-start px-2.5',
             open &&
               'bg-primary-button-bg text-primary-button-text hover:bg-primary-button-hover hover:text-primary-button-text',

--- a/packages/trueforge-ui/src/atoms/SessionsBrowserButton.tsx
+++ b/packages/trueforge-ui/src/atoms/SessionsBrowserButton.tsx
@@ -33,7 +33,7 @@ export function SessionsBrowserButton({ className, compact = false }: SessionsBr
           className: cn(
             'rounded-md text-sm font-medium text-text-primary shadow-none hover:bg-secondary-button-hover hover:text-ghost-button-text',
             compact
-              ? 'h-auto w-full flex-col gap-0.5 whitespace-normal px-1 py-3 text-[0.625rem] leading-tight !justify-center'
+              ? 'h-auto w-full flex-col gap-1.5 whitespace-normal px-1 py-3 text-[0.625rem] leading-tight !justify-center'
               : 'h-8 w-full !justify-start px-2.5',
             sessionsOpen &&
               'bg-primary-button-bg text-primary-button-text hover:bg-primary-button-hover hover:text-primary-button-text',

--- a/packages/trueforge-ui/src/atoms/ShellActions.tsx
+++ b/packages/trueforge-ui/src/atoms/ShellActions.tsx
@@ -20,7 +20,7 @@ export function ShellActions({ className, labeled = false }: { className?: strin
   const settingsChromeEnabled = isSettingsChromeEnabled({ catalog, capabilities });
 
   const labeledButtonClass =
-    'h-auto w-full flex-col gap-0.5 whitespace-normal px-1 py-3 text-[0.625rem] leading-tight !justify-center';
+    'h-auto w-full flex-col gap-1.5 whitespace-normal px-1 py-3 text-[0.625rem] leading-tight !justify-center';
   const hoverClass = 'hover:bg-secondary-button-hover hover:text-ghost-button-text';
 
   return (

--- a/packages/trueforge-ui/src/atoms/agent-details/AgentDetailsHeader.tsx
+++ b/packages/trueforge-ui/src/atoms/agent-details/AgentDetailsHeader.tsx
@@ -6,6 +6,8 @@ import { useShellMode } from '../../server/ShellModeContext.js';
 import { writeOpenSchedulesForAgentSearch } from '../../utils/scheduleShareUrl.js';
 import { AgentOverflowMenu } from '../AgentOverflowMenu.js';
 import { auiButtonClass } from '../lib/buttonClasses.js';
+import { cn } from '../lib/cn.js';
+import { PageHeader, pageHeaderTitleClassName } from '../PageHeader.js';
 import type { AgentDetailsHeaderProps } from './types.js';
 
 export function AgentDetailsHeader({ agentId, detail, onBack }: AgentDetailsHeaderProps) {
@@ -41,49 +43,54 @@ export function AgentDetailsHeader({ agentId, detail, onBack }: AgentDetailsHead
   };
 
   return (
-    <header className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border bg-primary-bg py-2.5 px-2">
-      <button
-        type="button"
-        aria-label="Back to Agents"
-        title="Back to Agents"
-        className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
-        onClick={onBack}
-      >
-        <Icon name="arrow-left" />
-      </button>
-      <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-center gap-1 truncate text-md font-semibold text-text-primary">
+    <PageHeader
+      className="bg-primary-bg"
+      start={
+        <button
+          type="button"
+          aria-label="Back to Agents"
+          title="Back to Agents"
+          className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
+          onClick={onBack}
+        >
+          <Icon name="arrow-left" />
+        </button>
+      }
+      title={
+        <div className={cn('flex min-w-0 items-center gap-1', pageHeaderTitleClassName)}>
           <button type="button" className="cursor-pointer truncate hover:text-text-primary" onClick={onBack}>
             Agents
           </button>
           <Icon name="chevron-right" className="size-3 shrink-0" />
           <span className="truncate">{detail?.name ?? agentId}</span>
         </div>
-      </div>
-      <div className="flex shrink-0 items-center gap-1.5">
-        <button
-          type="button"
-          aria-label="Try agent"
-          disabled={detail == null}
-          className={auiButtonClass({ variant: 'default', size: 'sm' })}
-          onClick={handleTry}
-        >
-          <Icon name="play" className="size-3.5" />
-          Try
-        </button>
-        {detail != null ? (
-          <AgentOverflowMenu
-            agentName={detail.name}
-            agentSpec={detail.agentSpec}
-            canMutate={canMutate}
-            canManageSchedules={canManageSchedules}
-            onEdit={handleEdit}
-            {...(canManageSchedules ? { onManageSchedules: handleManageSchedules } : {})}
-            onDeleted={onBack}
-          />
-        ) : null}
-      </div>
-    </header>
+      }
+      end={
+        <>
+          <button
+            type="button"
+            aria-label="Try agent"
+            disabled={detail == null}
+            className={auiButtonClass({ variant: 'default', size: 'sm' })}
+            onClick={handleTry}
+          >
+            <Icon name="play" className="size-3.5" />
+            Try
+          </button>
+          {detail != null ? (
+            <AgentOverflowMenu
+              agentName={detail.name}
+              agentSpec={detail.agentSpec}
+              canMutate={canMutate}
+              canManageSchedules={canManageSchedules}
+              onEdit={handleEdit}
+              {...(canManageSchedules ? { onManageSchedules: handleManageSchedules } : {})}
+              onDeleted={onBack}
+            />
+          ) : null}
+        </>
+      }
+    />
   );
 }
 

--- a/packages/trueforge-ui/src/atoms/agent-details/SessionsPage.tsx
+++ b/packages/trueforge-ui/src/atoms/agent-details/SessionsPage.tsx
@@ -3,7 +3,6 @@
 import { Suspense, useEffect, useMemo, useState } from 'react';
 
 import { useSessionShareSearch } from '../../hooks/useSessionShareSearch.js';
-import { Icon } from '../../icons/Icon.js';
 import { useOptionalAgentSessionsServer } from '../../server/ServerContext.js';
 import { useSlot } from '../../theme/SlotsProvider.js';
 import {
@@ -12,6 +11,7 @@ import {
   resolveSessionTimeRange,
   type SessionTimeRange,
 } from '../../utils/sessionShareUrl.js';
+import { PageHeader } from '../PageHeader.js';
 import { Skeleton } from '../primitives/Skeleton.js';
 
 export function SessionsPage() {
@@ -53,12 +53,9 @@ export function SessionsPage() {
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-primary-bg">
-      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 py-2.5 md:px-6">
-        <div className="flex min-w-0 items-center gap-2">
-          <Icon name="message-square-text" className="text-text-primary size-4" />
-          <h1 className="text-text-primary truncate text-md font-semibold">Agent Sessions</h1>
-        </div>
-        <div className="ml-auto">
+      <PageHeader
+        title="Agent Sessions"
+        end={
           <AgentSessionsFilters
             agentId={agentFilter}
             timeRange={timeRange}
@@ -71,8 +68,8 @@ export function SessionsPage() {
               updateShareSearch({ timeRange: nextRange, sessionId: null, view: 'sessions' });
             }}
           />
-        </div>
-      </div>
+        }
+      />
       <div className="min-h-0 flex-1">
         {sessionsServer == null ? (
           <p className="px-6 py-12 text-center text-sm text-text-secondary">Session history is not available.</p>

--- a/packages/trueforge-ui/src/atoms/draft/AgentConfigEditors.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentConfigEditors.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { AgentSkill, AgentSpec, ConnectorState, McpToolSelection, ModelSelection } from '../../server/types.js';
 import { useSlot } from '../../theme/SlotsProvider.js';
 import { editableMountsFromSpec } from './agentConfigMounts.js';
+import { connectorsWithSelectedStubs } from './mcpConnectorStubs.js';
 
 export type AgentConfigEditor = 'model' | 'model-settings' | 'runtime' | 'mcp' | 'skills';
 
@@ -49,13 +50,20 @@ export function AgentConfigEditors({
   const [toolsError, setToolsError] = useState<string | null>(null);
   const [toolsRequestEpoch, setToolsRequestEpoch] = useState(0);
   const mounts = useMemo(() => editableMountsFromSpec(spec.mcpServers), [spec.mcpServers]);
+  const catalogConnectors = useMemo(
+    () => connectorsWithSelectedStubs({ connectors, selected: mounts }),
+    [connectors, mounts],
+  );
   const activeConnectorAvailable =
-    activeConnectorId !== null && connectors.some(connector => connector.id === activeConnectorId);
+    activeConnectorId !== null && catalogConnectors.some(connector => connector.id === activeConnectorId);
   const firstMountedConnectorId = mounts
-    .map(mount => connectors.find(connector => connector.id === mount.id || connector.name === mount.name)?.id)
+    .map(mount => catalogConnectors.find(connector => connector.id === mount.id || connector.name === mount.name)?.id)
     .find((id): id is string => id !== undefined);
   const selectedConnectorId =
-    (activeConnectorAvailable ? activeConnectorId : null) ?? firstMountedConnectorId ?? connectors[0]?.id ?? null;
+    (activeConnectorAvailable ? activeConnectorId : null) ??
+    firstMountedConnectorId ??
+    catalogConnectors[0]?.id ??
+    null;
 
   useEffect(() => {
     if (editor !== 'mcp' || selectedConnectorId === null || loadMcpTools === undefined) return;

--- a/packages/trueforge-ui/src/atoms/draft/AgentConfigPanel.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentConfigPanel.tsx
@@ -178,7 +178,7 @@ export function AgentConfigPanel({
 
   return (
     <div className="bg-card-bg text-text-primary flex h-full min-h-0 flex-col">
-      <header className="flex h-14 shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5">
+      <header className="flex min-h-14 shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5">
         <Icon name="sliders" className="size-4" />
         <h2 className="text-sm font-semibold">Agent Config</h2>
         <span className="min-w-0 flex-1" />

--- a/packages/trueforge-ui/src/atoms/draft/AgentConfigPanel.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentConfigPanel.tsx
@@ -62,7 +62,7 @@ function McpServerChip({
             <span className="flex flex-col gap-1.5">
               <span className="flex items-center justify-between gap-3">
                 <span className="font-semibold">Preload tools</span>
-                <span className="text-primary-button-bg text-[10px] font-semibold tracking-wide uppercase">
+                <span className="text-primary-button-bg text-[0.625rem] font-semibold tracking-wide uppercase">
                   {preload ? 'ON' : 'OFF'}
                 </span>
               </span>
@@ -199,11 +199,11 @@ export function AgentConfigPanel({
             <ProviderMark
               logo={model?.provider.logo}
               label={model?.provider.name ?? spec.model.name}
-              className="size-4 text-[8px]"
+              className="size-4 text-[0.5rem]"
             />
             <span className="min-w-0 flex-1 truncate text-sm font-medium">{displayModelLabel(spec.model.name)}</span>
             {modelInfo.length ? (
-              <span title={modelInfoTitle} className="text-text-secondary shrink-0 whitespace-nowrap text-[11px]">
+              <span title={modelInfoTitle} className="text-text-secondary shrink-0 whitespace-nowrap text-[0.6875rem]">
                 {modelInfo.join(' · ')}
               </span>
             ) : null}

--- a/packages/trueforge-ui/src/atoms/draft/AgentMcpEditorContent.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentMcpEditorContent.tsx
@@ -8,6 +8,7 @@ import type { AgentSpec, ConnectorState, McpToolSelection } from '../../server/t
 import { auiButtonClass } from '../lib/buttonClasses.js';
 import { cn } from '../lib/cn.js';
 import { auiInputClass } from '../lib/inputClasses.js';
+import { useInfiniteScrollSentinel } from '../lib/useInfiniteScrollSentinel.js';
 import { CatalogLogo } from '../primitives/CatalogLogo.js';
 import { Spinner } from '../primitives/Spinner.js';
 import { Switch } from '../primitives/Switch.js';
@@ -19,6 +20,8 @@ import {
   withEnabledTools,
   withPreload,
 } from './agentConfigMounts.js';
+import { useDraftCatalog } from './DraftCatalogProvider.js';
+import { connectorsWithSelectedStubs } from './mcpConnectorStubs.js';
 
 export type AgentMcpEditorContentProps = {
   spec: AgentSpec;
@@ -102,10 +105,12 @@ export function AgentMcpEditorContent({
   onRefreshConnectors,
   onChange,
 }: AgentMcpEditorContentProps) {
+  const { connectorsHasMore, connectorsLoadingMore, loading, loadMoreConnectors } = useDraftCatalog();
   const [toolQuery, setToolQuery] = useState('');
   const [collapsedMountIds, setCollapsedMountIds] = useState<ReadonlySet<string>>(() => new Set());
   const mcpMounts = editableMountsFromSpec(spec.mcpServers);
-  const selectedConnector = connectors.find(item => item.id === activeConnectorId);
+  const catalogConnectors = connectorsWithSelectedStubs({ connectors, selected: mcpMounts });
+  const selectedConnector = catalogConnectors.find(item => item.id === activeConnectorId);
   const activeMount = selectedConnector
     ? mcpMounts.find(item => item.id === selectedConnector.id || item.name === selectedConnector.name)
     : undefined;
@@ -113,13 +118,19 @@ export function AgentMcpEditorContent({
   const canAddActiveConnector = selectedConnector !== undefined && selectedConnector.authenticated === true;
   const enabledTools = activeMount ? enabledToolsFromMount(activeMount.value) : [];
   const normalizedQuery = query.trim().toLowerCase();
-  const filteredConnectors = connectors.filter(item =>
+  const filteredConnectors = catalogConnectors.filter(item =>
     `${item.name} ${item.description ?? ''}`.toLowerCase().includes(normalizedQuery),
   );
   const normalizedToolQuery = toolQuery.trim().toLowerCase();
   const filteredTools =
     normalizedToolQuery === '' ? tools : tools.filter(tool => tool.name.toLowerCase().includes(normalizedToolQuery));
 
+  const { listRef: connectorsListRef, sentinelRef: connectorsSentinelRef } = useInfiniteScrollSentinel({
+    enabled: true,
+    hasMore: connectorsHasMore,
+    loading: connectorsLoadingMore || loading,
+    onLoadMore: loadMoreConnectors,
+  });
   const updateMount = (mountId: string, value: object) => {
     onChange({
       ...spec,
@@ -135,7 +146,7 @@ export function AgentMcpEditorContent({
   };
 
   const openMountConnector = (mount: (typeof mcpMounts)[number]) => {
-    const match = connectors.find(item => item.id === mount.id || item.name === mount.name);
+    const match = catalogConnectors.find(item => item.id === mount.id || item.name === mount.name);
     onSelectConnector(match?.id ?? mount.id);
   };
 
@@ -185,7 +196,7 @@ export function AgentMcpEditorContent({
             className={auiInputClass('h-9 w-full pl-7')}
           />
         </label>
-        <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        <div ref={connectorsListRef} className="min-h-0 flex-1 overflow-y-auto p-2">
           {filteredConnectors.map(connector => {
             const mounted = mcpMounts.some(item => item.id === connector.id || item.name === connector.name);
             const active = connector.id === activeConnectorId;
@@ -214,6 +225,11 @@ export function AgentMcpEditorContent({
               </button>
             );
           })}
+          {connectorsHasMore ? (
+            <div ref={connectorsSentinelRef} className="flex h-8 items-center justify-center" aria-hidden>
+              {connectorsLoadingMore ? <span className="text-text-secondary text-[10px]">Loading…</span> : null}
+            </div>
+          ) : null}
         </div>
       </div>
 

--- a/packages/trueforge-ui/src/atoms/draft/AgentMcpEditorContent.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentMcpEditorContent.tsx
@@ -105,7 +105,8 @@ export function AgentMcpEditorContent({
   onRefreshConnectors,
   onChange,
 }: AgentMcpEditorContentProps) {
-  const { connectorsHasMore, connectorsLoadingMore, loading, loadMoreConnectors } = useDraftCatalog();
+  const { connectorsHasMore, connectorsLoadMoreFailed, connectorsLoadingMore, loading, loadMoreConnectors } =
+    useDraftCatalog();
   const [toolQuery, setToolQuery] = useState('');
   const [collapsedMountIds, setCollapsedMountIds] = useState<ReadonlySet<string>>(() => new Set());
   const mcpMounts = editableMountsFromSpec(spec.mcpServers);
@@ -127,7 +128,7 @@ export function AgentMcpEditorContent({
 
   const { listRef: connectorsListRef, sentinelRef: connectorsSentinelRef } = useInfiniteScrollSentinel({
     enabled: true,
-    hasMore: connectorsHasMore,
+    hasMore: connectorsHasMore && !connectorsLoadMoreFailed,
     loading: connectorsLoadingMore || loading,
     onLoadMore: loadMoreConnectors,
   });
@@ -226,8 +227,21 @@ export function AgentMcpEditorContent({
             );
           })}
           {connectorsHasMore ? (
-            <div ref={connectorsSentinelRef} className="flex h-8 items-center justify-center" aria-hidden>
-              {connectorsLoadingMore ? <span className="text-text-secondary text-[10px]">Loading…</span> : null}
+            <div
+              ref={connectorsLoadMoreFailed ? undefined : connectorsSentinelRef}
+              className="flex h-8 items-center justify-center"
+            >
+              {connectorsLoadMoreFailed ? (
+                <button
+                  type="button"
+                  className={auiButtonClass({ variant: 'ghost', size: 'sm' })}
+                  onClick={loadMoreConnectors}
+                >
+                  Retry loading connectors
+                </button>
+              ) : connectorsLoadingMore ? (
+                <span className="text-text-secondary text-[0.625rem]">Loading…</span>
+              ) : null}
             </div>
           ) : null}
         </div>
@@ -424,7 +438,7 @@ export function AgentMcpEditorContent({
                     {selected === 'all' ? (
                       <button
                         type="button"
-                        className="text-text-secondary hover:bg-ghost-button-hover flex w-full cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 pl-7 text-left text-[11px] font-medium tracking-wide uppercase"
+                        className="text-text-secondary hover:bg-ghost-button-hover flex w-full cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 pl-7 text-left text-[0.6875rem] font-medium tracking-wide uppercase"
                         onClick={() => openMountConnector(mount)}
                       >
                         <Icon name="wrench" className="size-3 shrink-0" />
@@ -436,7 +450,7 @@ export function AgentMcpEditorContent({
                           key={`${mount.id}:${toolName}`}
                           type="button"
                           aria-label={`Open ${mount.name} for ${toolName}`}
-                          className="text-text-primary hover:bg-ghost-button-hover flex w-full cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 pl-7 text-left text-[11px]"
+                          className="text-text-primary hover:bg-ghost-button-hover flex w-full cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 pl-7 text-left text-[0.6875rem]"
                           onClick={() => openMountConnector(mount)}
                         >
                           <Icon name="wrench" className="text-text-secondary size-3 shrink-0" />
@@ -444,7 +458,7 @@ export function AgentMcpEditorContent({
                         </button>
                       ))
                     ) : (
-                      <p className="text-text-secondary px-2 py-1.5 pl-7 text-[11px]">No tools selected.</p>
+                      <p className="text-text-secondary px-2 py-1.5 pl-7 text-[0.6875rem]">No tools selected.</p>
                     )}
                   </details>
                 );

--- a/packages/trueforge-ui/src/atoms/draft/DraftCatalogProvider.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/DraftCatalogProvider.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 
 import { useOptionalServer } from '../../server/ServerContext.js';
-import type { AgentSkill, AgentUIServer, ConnectorState, ModelSelection } from '../../server/types.js';
+import type { AgentSkill, AgentUIServer, ConnectorState, ListResult, ModelSelection } from '../../server/types.js';
 import { getErrorMessage } from '../../utils/getErrorMessage.js';
+
+/** Picker page size for MCP infinite scroll. */
+export const MCP_CONNECTORS_PAGE_SIZE = 50;
 
 type DraftCatalogValue = {
   models: ModelSelection[];
   skills: AgentSkill[];
   connectors: ConnectorState[];
+  connectorsHasMore: boolean;
+  connectorsLoadingMore: boolean;
   loaded: boolean;
   loading: boolean;
   error: string | null;
@@ -19,6 +24,8 @@ type DraftCatalogValue = {
   refresh: () => void;
   /** Refresh connector auth state without reloading unrelated catalogs. */
   refreshConnectors: () => Promise<void>;
+  /** Append the next MCP page when `connectorsHasMore`. */
+  loadMoreConnectors: () => void;
 };
 
 type DraftCatalogContextValue = DraftCatalogValue & {
@@ -29,6 +36,36 @@ const DraftCatalogContext = createContext<DraftCatalogContextValue | null>(null)
 
 const IDLE_ENSURE = () => undefined;
 const IDLE_REFRESH = async () => undefined;
+
+function appendConnectors({
+  previous,
+  next,
+}: {
+  previous: ConnectorState[];
+  next: ConnectorState[];
+}): ConnectorState[] {
+  if (next.length === 0) return previous;
+  const seen = new Set(previous.map(connector => connector.id));
+  const appended = next.filter(connector => !seen.has(connector.id));
+  return appended.length === 0 ? previous : [...previous, ...appended];
+}
+
+async function fetchMcpPage({
+  server,
+  pageToken,
+}: {
+  server: AgentUIServer;
+  pageToken?: string;
+}): Promise<ListResult<ConnectorState>> {
+  if (server.listMcp != null) {
+    return server.listMcp({
+      limit: MCP_CONNECTORS_PAGE_SIZE,
+      ...(pageToken === undefined ? {} : { pageToken }),
+    });
+  }
+  const data = await server.getMcp();
+  return { data };
+}
 
 export function DraftCatalogProvider({ children }: { children: ReactNode }) {
   const server = useOptionalServer();
@@ -44,9 +81,17 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
   const [models, setModels] = useState<ModelSelection[]>([]);
   const [skills, setSkills] = useState<AgentSkill[]>([]);
   const [connectors, setConnectors] = useState<ConnectorState[]>([]);
+  const [connectorsNextPageToken, setConnectorsNextPageToken] = useState<string | undefined>(undefined);
+  const [connectorsLoadingMore, setConnectorsLoadingMore] = useState(false);
   const [completedEpoch, setCompletedEpoch] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const connectorsNextPageTokenRef = useRef(connectorsNextPageToken);
+  const connectorsLoadingMoreRef = useRef(connectorsLoadingMore);
+  const loadMoreFailedRef = useRef(false);
+  connectorsNextPageTokenRef.current = connectorsNextPageToken;
+  connectorsLoadingMoreRef.current = connectorsLoadingMore;
 
   const ensureLoaded = useCallback(() => {
     setRequestEpoch(current => current ?? 0);
@@ -61,13 +106,39 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
     setLoading(true);
     setError(null);
     try {
-      const nextConnectors = await server.getMcp();
-      setConnectors(nextConnectors);
+      const page = await fetchMcpPage({ server });
+      setConnectors(page.data);
+      setConnectorsNextPageToken(page.nextPageToken);
     } catch (reason: unknown) {
       setError(getErrorMessage(reason, 'Failed to load connectors.'));
     } finally {
       setLoading(false);
     }
+  }, [server]);
+
+  const loadMoreConnectors = useCallback(() => {
+    if (!server) return;
+    const pageToken = connectorsNextPageTokenRef.current;
+    if (pageToken == null || pageToken.length === 0 || connectorsLoadingMoreRef.current) return;
+
+    setConnectorsLoadingMore(true);
+    void fetchMcpPage({ server, pageToken })
+      .then(page => {
+        setConnectors(previous => appendConnectors({ previous, next: page.data }));
+        setConnectorsNextPageToken(page.nextPageToken);
+        // Clear a stale load-more failure once a retry succeeds.
+        if (loadMoreFailedRef.current) {
+          loadMoreFailedRef.current = false;
+          setError(null);
+        }
+      })
+      .catch((reason: unknown) => {
+        loadMoreFailedRef.current = true;
+        setError(getErrorMessage(reason, 'Failed to load more connectors.'));
+      })
+      .finally(() => {
+        setConnectorsLoadingMore(false);
+      });
   }, [server]);
 
   useEffect(() => {
@@ -76,8 +147,8 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
     setLoading(true);
     setError(null);
     // Settle each list alone so one failing picker does not blank the others.
-    void Promise.allSettled([server.getModels(), server.getSkills(), server.getMcp()])
-      .then(([modelsResult, skillsResult, mcpResult]) => {
+    void Promise.allSettled([server.getModels(), server.getSkills(), fetchMcpPage({ server })]).then(
+      ([modelsResult, skillsResult, mcpResult]) => {
         if (cancelled) return;
         const errors: string[] = [];
         if (modelsResult.status === 'fulfilled') {
@@ -91,27 +162,54 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
           errors.push(getErrorMessage(skillsResult.reason, 'Failed to load skills.'));
         }
         if (mcpResult.status === 'fulfilled') {
-          setConnectors(mcpResult.value);
+          setConnectors(mcpResult.value.data);
+          setConnectorsNextPageToken(mcpResult.value.nextPageToken);
         } else {
           errors.push(getErrorMessage(mcpResult.reason, 'Failed to load connectors.'));
         }
         setError(errors[0] ?? null);
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setCompletedEpoch(requestEpoch);
-          setLoading(false);
-        }
-      });
+        setCompletedEpoch(requestEpoch);
+        setLoading(false);
+      },
+    );
     return () => {
       cancelled = true;
     };
   }, [requestEpoch, server]);
 
+  const connectorsHasMore = connectorsNextPageToken != null && connectorsNextPageToken.length > 0;
   const loaded = requestEpoch !== null && completedEpoch === requestEpoch;
   const value = useMemo(
-    () => ({ server, models, skills, connectors, loaded, loading, error, ensureLoaded, refresh, refreshConnectors }),
-    [server, models, skills, connectors, loaded, loading, error, ensureLoaded, refresh, refreshConnectors],
+    () => ({
+      server,
+      models,
+      skills,
+      connectors,
+      connectorsHasMore,
+      connectorsLoadingMore,
+      loaded,
+      loading,
+      error,
+      ensureLoaded,
+      refresh,
+      refreshConnectors,
+      loadMoreConnectors,
+    }),
+    [
+      server,
+      models,
+      skills,
+      connectors,
+      connectorsHasMore,
+      connectorsLoadingMore,
+      loaded,
+      loading,
+      error,
+      ensureLoaded,
+      refresh,
+      refreshConnectors,
+      loadMoreConnectors,
+    ],
   );
 
   return <DraftCatalogContext.Provider value={value}>{children}</DraftCatalogContext.Provider>;
@@ -124,12 +222,15 @@ export function useDraftCatalog(): DraftCatalogValue {
       models: [],
       skills: [],
       connectors: [],
+      connectorsHasMore: false,
+      connectorsLoadingMore: false,
       loaded: false,
       loading: false,
       error: null,
       ensureLoaded: IDLE_ENSURE,
       refresh: IDLE_ENSURE,
       refreshConnectors: IDLE_REFRESH,
+      loadMoreConnectors: IDLE_ENSURE,
     };
   }
   return ctx;

--- a/packages/trueforge-ui/src/atoms/draft/DraftCatalogProvider.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/DraftCatalogProvider.tsx
@@ -14,6 +14,7 @@ type DraftCatalogValue = {
   skills: AgentSkill[];
   connectors: ConnectorState[];
   connectorsHasMore: boolean;
+  connectorsLoadMoreFailed: boolean;
   connectorsLoadingMore: boolean;
   loaded: boolean;
   loading: boolean;
@@ -82,6 +83,7 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
   const [skills, setSkills] = useState<AgentSkill[]>([]);
   const [connectors, setConnectors] = useState<ConnectorState[]>([]);
   const [connectorsNextPageToken, setConnectorsNextPageToken] = useState<string | undefined>(undefined);
+  const [connectorsLoadMoreFailed, setConnectorsLoadMoreFailed] = useState(false);
   const [connectorsLoadingMore, setConnectorsLoadingMore] = useState(false);
   const [completedEpoch, setCompletedEpoch] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
@@ -98,6 +100,8 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
   }, []);
 
   const refresh = useCallback(() => {
+    loadMoreFailedRef.current = false;
+    setConnectorsLoadMoreFailed(false);
     setRequestEpoch(current => (current ?? -1) + 1);
   }, []);
 
@@ -105,6 +109,8 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
     if (!server) return;
     setLoading(true);
     setError(null);
+    loadMoreFailedRef.current = false;
+    setConnectorsLoadMoreFailed(false);
     try {
       const page = await fetchMcpPage({ server });
       setConnectors(page.data);
@@ -121,6 +127,7 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
     const pageToken = connectorsNextPageTokenRef.current;
     if (pageToken == null || pageToken.length === 0 || connectorsLoadingMoreRef.current) return;
 
+    setConnectorsLoadMoreFailed(false);
     setConnectorsLoadingMore(true);
     void fetchMcpPage({ server, pageToken })
       .then(page => {
@@ -134,6 +141,7 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
       })
       .catch((reason: unknown) => {
         loadMoreFailedRef.current = true;
+        setConnectorsLoadMoreFailed(true);
         setError(getErrorMessage(reason, 'Failed to load more connectors.'));
       })
       .finally(() => {
@@ -146,6 +154,8 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
     let cancelled = false;
     setLoading(true);
     setError(null);
+    loadMoreFailedRef.current = false;
+    setConnectorsLoadMoreFailed(false);
     // Settle each list alone so one failing picker does not blank the others.
     void Promise.allSettled([server.getModels(), server.getSkills(), fetchMcpPage({ server })]).then(
       ([modelsResult, skillsResult, mcpResult]) => {
@@ -186,6 +196,7 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
       skills,
       connectors,
       connectorsHasMore,
+      connectorsLoadMoreFailed,
       connectorsLoadingMore,
       loaded,
       loading,
@@ -201,6 +212,7 @@ function DraftCatalogStore({ server, children }: { server: AgentUIServer | null;
       skills,
       connectors,
       connectorsHasMore,
+      connectorsLoadMoreFailed,
       connectorsLoadingMore,
       loaded,
       loading,
@@ -223,6 +235,7 @@ export function useDraftCatalog(): DraftCatalogValue {
       skills: [],
       connectors: [],
       connectorsHasMore: false,
+      connectorsLoadMoreFailed: false,
       connectorsLoadingMore: false,
       loaded: false,
       loading: false,

--- a/packages/trueforge-ui/src/atoms/draft/DraftCompositeSelector.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/DraftCompositeSelector.tsx
@@ -12,11 +12,13 @@ import { auiButtonClass } from '../lib/buttonClasses.js';
 import { cn } from '../lib/cn.js';
 import { useCompactLayout } from '../lib/CompactLayoutContext.js';
 import { auiInputClass } from '../lib/inputClasses.js';
+import { useInfiniteScrollSentinel } from '../lib/useInfiniteScrollSentinel.js';
 import { useIsMobile } from '../lib/useIsMobile.js';
 import { BottomSheet } from '../primitives/BottomSheet.js';
 import { Tooltip } from '../primitives/Tooltip.js';
 import { DraftCatalogEmptyState } from './DraftCatalogEmptyState.js';
 import { useDraftCatalog } from './DraftCatalogProvider.js';
+import { connectorsWithSelectedStubs } from './mcpConnectorStubs.js';
 
 /** Catalog-backed mount shape used by the draft picker (runtime mounts stay opaque). */
 export type DraftMount = { id: string; name: string };
@@ -222,7 +224,16 @@ function SectionHeading({ label, count }: { label: string; count: number }) {
 }
 
 export function DraftCompositeSelector({ disabled, isRunning, onAttach }: DraftCompositeSelectorProps) {
-  const { skills, connectors, loading, ensureLoaded, refreshConnectors } = useDraftCatalog();
+  const {
+    skills,
+    connectors,
+    connectorsHasMore,
+    connectorsLoadingMore,
+    loading,
+    ensureLoaded,
+    refreshConnectors,
+    loadMoreConnectors,
+  } = useDraftCatalog();
   const capabilities = useServerCapabilities();
   const settingsCatalog = useOptionalCatalogServer();
   const shell = useOptionalShellMode();
@@ -343,17 +354,29 @@ export function DraftCompositeSelector({ disabled, isRunning, onAttach }: DraftC
 
   useEffect(() => () => clearFlushTimer(), [clearFlushTimer]);
 
+  const { listRef: connectorsListRef, sentinelRef: connectorsSentinelRef } = useInfiniteScrollSentinel({
+    enabled: open && tab === 'connectors',
+    hasMore: connectorsHasMore,
+    loading: connectorsLoadingMore || loading,
+    onLoadMore: loadMoreConnectors,
+  });
+
+  const catalogConnectors = useMemo(
+    () => connectorsWithSelectedStubs({ connectors, selected: selectedMcp }),
+    [connectors, selectedMcp],
+  );
+
   const filteredConnectors = useMemo(() => {
     const needle = query.trim().toLowerCase();
     const matches = needle
-      ? connectors.filter(
+      ? catalogConnectors.filter(
           c => c.name.toLowerCase().includes(needle) || (c.description?.toLowerCase().includes(needle) ?? false),
         )
-      : connectors;
+      : catalogConnectors;
     return [...matches].sort(
       (left, right) => Number(isUnauthenticatedDcrConnector(left)) - Number(isUnauthenticatedDcrConnector(right)),
     );
-  }, [connectors, query]);
+  }, [catalogConnectors, query]);
 
   const filteredSkills = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -474,7 +497,10 @@ export function DraftCompositeSelector({ disabled, isRunning, onAttach }: DraftC
             <span className="text-xs leading-none">{skillsDisabledReason}</span>
           </div>
         ) : null}
-        <div className="min-h-0 flex-1 overflow-y-auto px-1 pb-2">
+        <div
+          ref={tab === 'connectors' ? connectorsListRef : undefined}
+          className="min-h-0 flex-1 overflow-y-auto px-1 pb-2"
+        >
           {tab === 'connectors' ? (
             <>
               {pinnedSelectedConnectors.length > 0 ? (
@@ -515,17 +541,21 @@ export function DraftCompositeSelector({ disabled, isRunning, onAttach }: DraftC
                   ))}
                 </>
               ) : null}
-              {filteredConnectors.length === 0 ? (
+              {filteredConnectors.length === 0 && connectors.length > 0 ? (
+                <DraftCatalogEmptyState loading={loading} emptyLabel="No connectors" settingsTarget="Connectors" />
+              ) : null}
+              {connectors.length === 0 ? (
                 <DraftCatalogEmptyState
                   loading={loading}
                   emptyLabel="No connectors"
                   settingsTarget="Connectors"
-                  onOpenSettings={
-                    connectors.length === 0 && shell && canConfigureConnectors
-                      ? () => openSettings('connectors')
-                      : undefined
-                  }
+                  onOpenSettings={shell && canConfigureConnectors ? () => openSettings('connectors') : undefined}
                 />
+              ) : null}
+              {connectorsHasMore ? (
+                <div ref={connectorsSentinelRef} className="flex h-8 items-center justify-center" aria-hidden>
+                  {connectorsLoadingMore ? <span className="text-text-secondary text-[10px]">Loading…</span> : null}
+                </div>
               ) : null}
             </>
           ) : (

--- a/packages/trueforge-ui/src/atoms/draft/DraftCompositeSelector.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/DraftCompositeSelector.tsx
@@ -217,7 +217,7 @@ export type DraftCompositeSelectorProps = {
 
 function SectionHeading({ label, count }: { label: string; count: number }) {
   return (
-    <div className="text-text-secondary px-3 pt-2 pb-1 text-[11px] font-medium tracking-wide uppercase">
+    <div className="text-text-secondary px-3 pt-2 pb-1 text-[0.6875rem] font-medium tracking-wide uppercase">
       {label} ({count})
     </div>
   );
@@ -228,6 +228,7 @@ export function DraftCompositeSelector({ disabled, isRunning, onAttach }: DraftC
     skills,
     connectors,
     connectorsHasMore,
+    connectorsLoadMoreFailed,
     connectorsLoadingMore,
     loading,
     ensureLoaded,
@@ -356,7 +357,7 @@ export function DraftCompositeSelector({ disabled, isRunning, onAttach }: DraftC
 
   const { listRef: connectorsListRef, sentinelRef: connectorsSentinelRef } = useInfiniteScrollSentinel({
     enabled: open && tab === 'connectors',
-    hasMore: connectorsHasMore,
+    hasMore: connectorsHasMore && !connectorsLoadMoreFailed,
     loading: connectorsLoadingMore || loading,
     onLoadMore: loadMoreConnectors,
   });
@@ -475,7 +476,7 @@ export function DraftCompositeSelector({ disabled, isRunning, onAttach }: DraftC
               <Icon name={t.icon} className="size-3.5" />
               {t.label}
               {count != null && count > 0 ? (
-                <span className="bg-secondary-bg rounded px-1 text-[10px]">{count}</span>
+                <span className="bg-secondary-bg rounded px-1 text-[0.625rem]">{count}</span>
               ) : null}
             </button>
           );
@@ -553,8 +554,21 @@ export function DraftCompositeSelector({ disabled, isRunning, onAttach }: DraftC
                 />
               ) : null}
               {connectorsHasMore ? (
-                <div ref={connectorsSentinelRef} className="flex h-8 items-center justify-center" aria-hidden>
-                  {connectorsLoadingMore ? <span className="text-text-secondary text-[10px]">Loading…</span> : null}
+                <div
+                  ref={connectorsLoadMoreFailed ? undefined : connectorsSentinelRef}
+                  className="flex h-8 items-center justify-center"
+                >
+                  {connectorsLoadMoreFailed ? (
+                    <button
+                      type="button"
+                      className={auiButtonClass({ variant: 'ghost', size: 'sm' })}
+                      onClick={loadMoreConnectors}
+                    >
+                      Retry loading connectors
+                    </button>
+                  ) : connectorsLoadingMore ? (
+                    <span className="text-text-secondary text-[0.625rem]">Loading…</span>
+                  ) : null}
                 </div>
               ) : null}
             </>

--- a/packages/trueforge-ui/src/atoms/draft/DraftSpecPreferenceBridge.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/DraftSpecPreferenceBridge.tsx
@@ -34,12 +34,15 @@ export function reconcileDraftSpecPreferences({
   models,
   skills,
   connectors,
+  connectorsHasMore = false,
   skillsEnabled,
 }: {
   agentSpec: AgentSpec;
   models: ModelSelection[];
   skills: AgentSkill[];
   connectors: ConnectorState[];
+  /** When more MCP pages remain, off-page selections must not be treated as deleted. */
+  connectorsHasMore?: boolean;
   skillsEnabled: boolean | undefined;
 }): Partial<AgentSpec> {
   const update: Partial<AgentSpec> = {};
@@ -55,9 +58,12 @@ export function reconcileDraftSpecPreferences({
     }
   }
 
-  const nextMcpServers = filterMounts(agentSpec.mcpServers, new Set(connectors.map(connector => connector.name)));
-  if (nextMcpServers !== agentSpec.mcpServers) {
-    update.mcpServers = nextMcpServers;
+  // Paginated catalogs only include loaded pages — prune MCP only once the full list is known.
+  if (!connectorsHasMore) {
+    const nextMcpServers = filterMounts(agentSpec.mcpServers, new Set(connectors.map(connector => connector.name)));
+    if (nextMcpServers !== agentSpec.mcpServers) {
+      update.mcpServers = nextMcpServers;
+    }
   }
 
   if (skillsEnabled === false) {
@@ -122,7 +128,7 @@ export function DraftSpecPreferenceBridge() {
   const updateAgentSpec = useTrueFoundryUpdateAgentSpec();
   const capabilities = useServerCapabilities();
   const sandboxEnabled = capabilities?.sandbox.enabled;
-  const { models, skills, connectors, loaded, error, ensureLoaded } = useDraftCatalog();
+  const { models, skills, connectors, connectorsHasMore, loaded, error, ensureLoaded } = useDraftCatalog();
   const isPlainDraft = mode.status === 'active' && mode.isMutable && mode.agentId == null && pendingSessionId == null;
   const preferenceKind = mode.status === 'active' && mode.isMutable && mode.isCreateAgent ? 'agent' : 'chat';
 
@@ -153,6 +159,7 @@ export function DraftSpecPreferenceBridge() {
       models,
       skills,
       connectors,
+      connectorsHasMore,
       skillsEnabled: capabilities?.skill.enabled,
     });
     if (Object.keys(update).length > 0) {
@@ -162,6 +169,7 @@ export function DraftSpecPreferenceBridge() {
     agentSpec,
     capabilities?.skill.enabled,
     connectors,
+    connectorsHasMore,
     error,
     isPlainDraft,
     loaded,

--- a/packages/trueforge-ui/src/atoms/draft/DraftSpecPreferenceBridge.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/DraftSpecPreferenceBridge.tsx
@@ -3,13 +3,22 @@
 import { useTrueFoundryAgentSpec, useTrueFoundryUpdateAgentSpec } from '@truefoundry/assistant-ui-runtime';
 import { useEffect } from 'react';
 
-import { withCapabilitiesSandbox } from '../../server/draftSpecPreferences.js';
+import { type DraftPreferenceKind, withCapabilitiesSandbox } from '../../server/draftSpecPreferences.js';
 import { useServerCapabilities } from '../../server/ServerContext.js';
 import { useShellMode } from '../../server/ShellModeContext.js';
 import type { AgentSkill, AgentSpec, ConnectorState, ModelSelection } from '../../server/types.js';
 import { mountName } from '../lib/mountName.js';
 import { useDraftCatalog } from './DraftCatalogProvider.js';
 import { modelPatchWithReasoningEffort } from './reasoningEffort.js';
+
+function readDraftSandboxEnabled(spec: AgentSpec): boolean | undefined {
+  if (spec.config === undefined) return undefined;
+  // `sandbox` is draft runtime config and may be absent from AgentRuntimeConfig typings.
+  const sandbox = Reflect.get(spec.config, 'sandbox');
+  if (typeof sandbox !== 'object' || sandbox === null) return undefined;
+  const enabled = Reflect.get(sandbox, 'enabled');
+  return typeof enabled === 'boolean' ? enabled : undefined;
+}
 
 function filterMounts<T extends object>(mounts: T[] | undefined, availableNames: Set<string>): T[] | undefined {
   if (mounts === undefined) return undefined;
@@ -70,10 +79,34 @@ export function reconcileDraftSpecPreferences({
 export function reconcileDraftSandbox({
   agentSpec,
   sandboxEnabled,
+  kind = 'agent',
 }: {
   agentSpec: AgentSpec;
   sandboxEnabled: boolean | null | undefined;
+  kind?: DraftPreferenceKind;
 }): Partial<AgentSpec> {
+  if (kind === 'chat') {
+    if (sandboxEnabled == null) return {};
+    const current = readDraftSandboxEnabled(agentSpec);
+    if (sandboxEnabled === true && current !== true) {
+      return {
+        config: {
+          ...agentSpec.config,
+          sandbox: { ...agentSpec.config?.sandbox, enabled: true },
+        },
+      };
+    }
+    if (sandboxEnabled === false && current === true) {
+      return {
+        config: {
+          ...agentSpec.config,
+          sandbox: { ...agentSpec.config?.sandbox, enabled: false },
+        },
+      };
+    }
+    return {};
+  }
+
   const nextSpec = withCapabilitiesSandbox(agentSpec, sandboxEnabled);
   return nextSpec === agentSpec ? {} : { config: nextSpec.config };
 }
@@ -104,9 +137,9 @@ export function DraftSpecPreferenceBridge() {
   }, [agentSpec, isPlainDraft, preferenceKind, rememberDraftSpec]);
 
   useEffect(() => {
-    // Sandbox / runtime config belongs to New Agent only.
-    if (!isPlainDraft || preferenceKind !== 'agent' || agentSpec == null || updateAgentSpec == null) return;
-    const update = reconcileDraftSandbox({ agentSpec, sandboxEnabled });
+    // New Chat mirrors capabilities onto the live draft; New Agent only disables when unavailable.
+    if (!isPlainDraft || agentSpec == null || updateAgentSpec == null) return;
+    const update = reconcileDraftSandbox({ agentSpec, sandboxEnabled, kind: preferenceKind });
     if (Object.keys(update).length > 0) {
       updateAgentSpec(update);
     }

--- a/packages/trueforge-ui/src/atoms/draft/mcpConnectorStubs.ts
+++ b/packages/trueforge-ui/src/atoms/draft/mcpConnectorStubs.ts
@@ -1,0 +1,20 @@
+import type { ConnectorState } from '../../server/types.js';
+
+/** Keep selected mounts visible when they are not yet on a loaded MCP page. */
+export function connectorsWithSelectedStubs({
+  connectors,
+  selected,
+}: {
+  connectors: ConnectorState[];
+  selected: ReadonlyArray<{ id: string; name: string }>;
+}): ConnectorState[] {
+  if (selected.length === 0) return connectors;
+  const byId = new Map(connectors.map(connector => [connector.id, connector]));
+  const stubs: ConnectorState[] = [];
+  for (const mount of selected) {
+    if (!byId.has(mount.id)) {
+      stubs.push({ id: mount.id, name: mount.name });
+    }
+  }
+  return stubs.length === 0 ? connectors : [...stubs, ...connectors];
+}

--- a/packages/trueforge-ui/src/atoms/lib/useInfiniteScrollSentinel.ts
+++ b/packages/trueforge-ui/src/atoms/lib/useInfiniteScrollSentinel.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const DEFAULT_ROOT_MARGIN = '48px';
+
+export type UseInfiniteScrollSentinelOptions = {
+  enabled: boolean;
+  hasMore: boolean;
+  loading: boolean;
+  onLoadMore: () => void;
+  rootMargin?: string;
+};
+
+/**
+ * IntersectionObserver sentinel for linear infinite-scroll lists.
+ * Attach `listRef` to the scroll container and `sentinelRef` to a footer element.
+ */
+export function useInfiniteScrollSentinel({
+  enabled,
+  hasMore,
+  loading,
+  onLoadMore,
+  rootMargin = DEFAULT_ROOT_MARGIN,
+}: UseInfiniteScrollSentinelOptions): {
+  listRef: (node: HTMLElement | null) => void;
+  sentinelRef: (node: HTMLElement | null) => void;
+} {
+  const hasMoreRef = useRef(hasMore);
+  const loadingRef = useRef(loading);
+  const onLoadMoreRef = useRef(onLoadMore);
+  hasMoreRef.current = hasMore;
+  loadingRef.current = loading;
+  onLoadMoreRef.current = onLoadMore;
+
+  const [listEl, setListEl] = useState<HTMLElement | null>(null);
+  const [sentinelEl, setSentinelEl] = useState<HTMLElement | null>(null);
+
+  const listRef = useCallback((node: HTMLElement | null) => {
+    setListEl(node);
+  }, []);
+
+  const sentinelRef = useCallback((node: HTMLElement | null) => {
+    setSentinelEl(node);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || listEl == null || sentinelEl == null) return;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (!entries.some(entry => entry.isIntersecting)) return;
+        if (!hasMoreRef.current || loadingRef.current) return;
+        onLoadMoreRef.current();
+      },
+      { root: listEl, rootMargin },
+    );
+    observer.observe(sentinelEl);
+    return () => observer.disconnect();
+  }, [enabled, listEl, sentinelEl, rootMargin]);
+
+  return { listRef, sentinelRef };
+}

--- a/packages/trueforge-ui/src/atoms/lib/useInfiniteScrollSentinel.ts
+++ b/packages/trueforge-ui/src/atoms/lib/useInfiniteScrollSentinel.ts
@@ -15,6 +15,8 @@ export type UseInfiniteScrollSentinelOptions = {
 /**
  * IntersectionObserver sentinel for linear infinite-scroll lists.
  * Attach `listRef` to the scroll container and `sentinelRef` to a footer element.
+ * Re-observes when `hasMore` / `loading` change so a still-visible sentinel (short
+ * filtered lists) continues requesting pages after each load settles.
  */
 export function useInfiniteScrollSentinel({
   enabled,
@@ -26,11 +28,7 @@ export function useInfiniteScrollSentinel({
   listRef: (node: HTMLElement | null) => void;
   sentinelRef: (node: HTMLElement | null) => void;
 } {
-  const hasMoreRef = useRef(hasMore);
-  const loadingRef = useRef(loading);
   const onLoadMoreRef = useRef(onLoadMore);
-  hasMoreRef.current = hasMore;
-  loadingRef.current = loading;
   onLoadMoreRef.current = onLoadMore;
 
   const [listEl, setListEl] = useState<HTMLElement | null>(null);
@@ -45,19 +43,18 @@ export function useInfiniteScrollSentinel({
   }, []);
 
   useEffect(() => {
-    if (!enabled || listEl == null || sentinelEl == null) return;
+    if (!enabled || !hasMore || loading || listEl == null || sentinelEl == null) return;
 
     const observer = new IntersectionObserver(
       entries => {
         if (!entries.some(entry => entry.isIntersecting)) return;
-        if (!hasMoreRef.current || loadingRef.current) return;
         onLoadMoreRef.current();
       },
       { root: listEl, rootMargin },
     );
     observer.observe(sentinelEl);
     return () => observer.disconnect();
-  }, [enabled, listEl, sentinelEl, rootMargin]);
+  }, [enabled, hasMore, loading, listEl, sentinelEl, rootMargin]);
 
   return { listRef, sentinelRef };
 }

--- a/packages/trueforge-ui/src/atoms/lib/useInfiniteScrollSentinel.ts
+++ b/packages/trueforge-ui/src/atoms/lib/useInfiniteScrollSentinel.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-const DEFAULT_ROOT_MARGIN = '48px';
+const DEFAULT_ROOT_MARGIN = '3rem';
 
 export type UseInfiniteScrollSentinelOptions = {
   enabled: boolean;

--- a/packages/trueforge-ui/src/atoms/schedules/SchedulesPage.tsx
+++ b/packages/trueforge-ui/src/atoms/schedules/SchedulesPage.tsx
@@ -12,6 +12,7 @@ import { EmptyScreen } from '../EmptyScreen.js';
 import { auiButtonClass } from '../lib/buttonClasses.js';
 import { cn } from '../lib/cn.js';
 import { searchAllAgents } from '../lib/useSearchAgentsList.js';
+import { PageHeader } from '../PageHeader.js';
 import { Button } from '../primitives/Button.js';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../primitives/Dialog.js';
 import { DropdownMenu, DropdownMenuItem } from '../primitives/DropdownMenu.js';
@@ -344,51 +345,49 @@ export function SchedulesPage() {
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-primary-bg">
-      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 py-2.5 md:px-6">
-        <div className="flex min-w-0 items-center gap-2">
-          <Icon name="calendar-clock" className="text-text-primary size-4" />
-          <h1 className="text-text-primary truncate text-md font-semibold">Scheduled Agents</h1>
-        </div>
-
-        <div className="ml-auto flex flex-wrap items-center gap-2">
-          <div className="w-full sm:w-56">
-            <SearchInput query={nameQuery} setQuery={setNameQuery} placeholder="Search schedules by name" />
-          </div>
-          <PopoverSelect
-            value={statusFilter}
-            onValueChange={setStatusFilter}
-            options={STATUS_FILTER_OPTIONS}
-            className="sm:w-40"
-            aria-label="Filter by status"
-          />
-          <PopoverSelect
-            value={agentFilter}
-            onValueChange={value => {
-              setAgentFilter(value);
-              setPageToken(undefined);
-              setPrevTokenStack([]);
-            }}
-            options={[
-              { value: 'all', label: 'All agents' },
-              ...agentOptions.map(agent => ({ value: agent.agentId, label: agent.name })),
-            ]}
-            className="sm:w-40"
-            aria-label="Filter by agent"
-          />
-          <Button
-            type="button"
-            onClick={() =>
-              setDrawer({
-                kind: 'create',
-                agentId: agentFilter !== 'all' ? agentFilter : undefined,
-              })
-            }
-          >
-            <Icon name="plus" className="size-3.5" />
-            Create Schedule
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        title="Scheduled Agents"
+        end={
+          <>
+            <div className="w-full sm:w-56">
+              <SearchInput query={nameQuery} setQuery={setNameQuery} placeholder="Search schedules by name" />
+            </div>
+            <PopoverSelect
+              value={statusFilter}
+              onValueChange={setStatusFilter}
+              options={STATUS_FILTER_OPTIONS}
+              className="sm:w-40"
+              aria-label="Filter by status"
+            />
+            <PopoverSelect
+              value={agentFilter}
+              onValueChange={value => {
+                setAgentFilter(value);
+                setPageToken(undefined);
+                setPrevTokenStack([]);
+              }}
+              options={[
+                { value: 'all', label: 'All agents' },
+                ...agentOptions.map(agent => ({ value: agent.agentId, label: agent.name })),
+              ]}
+              className="sm:w-40"
+              aria-label="Filter by agent"
+            />
+            <Button
+              type="button"
+              onClick={() =>
+                setDrawer({
+                  kind: 'create',
+                  agentId: agentFilter !== 'all' ? agentFilter : undefined,
+                })
+              }
+            >
+              <Icon name="plus" className="size-3.5" />
+              Create Schedule
+            </Button>
+          </>
+        }
+      />
 
       <div className="min-h-0 flex-1 overflow-auto px-4 py-4 md:px-6">
         {loading ? (

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/index.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/index.tsx
@@ -3,9 +3,9 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo } from 'react';
 
 import { useDraftCatalog } from '@/atoms/draft/DraftCatalogProvider.js';
-import { auiButtonClass } from '@/atoms/lib/buttonClasses.js';
 import { cn } from '@/atoms/lib/cn.js';
 import { useCompactLayout } from '@/atoms/lib/CompactLayoutContext.js';
+import { PageHeader } from '@/atoms/PageHeader.js';
 import { Spinner } from '@/atoms/primitives/Spinner.js';
 import { Icon } from '@/icons/Icon.js';
 import { useOptionalCatalogServer, useOptionalRefreshServerCapabilities } from '@/server/ServerContext.js';
@@ -98,18 +98,7 @@ const TruefoundrySettingsBuilder = () => {
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-primary-bg">
-      <header className="flex shrink-0 items-center gap-2 border-b border-border px-2 py-1.5">
-        <button
-          type="button"
-          aria-label="Back"
-          title="Back"
-          className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
-          onClick={closeSettings}
-        >
-          <Icon name="arrow-left" />
-        </button>
-        <h1 className="text-lg font-semibold tracking-tight text-text-primary">Settings</h1>
-      </header>
+      <PageHeader title="Settings" />
 
       <div className={cn('flex min-h-0 flex-1 flex-col', !compact && 'md:flex-row')}>
         <nav

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/index.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/index.tsx
@@ -3,6 +3,7 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo } from 'react';
 
 import { useDraftCatalog } from '@/atoms/draft/DraftCatalogProvider.js';
+import { auiButtonClass } from '@/atoms/lib/buttonClasses.js';
 import { cn } from '@/atoms/lib/cn.js';
 import { useCompactLayout } from '@/atoms/lib/CompactLayoutContext.js';
 import { PageHeader } from '@/atoms/PageHeader.js';
@@ -98,7 +99,20 @@ const TruefoundrySettingsBuilder = () => {
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-primary-bg">
-      <PageHeader title="Settings" />
+      <PageHeader
+        title="Settings"
+        start={
+          <button
+            type="button"
+            aria-label="Back"
+            title="Back"
+            className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
+            onClick={closeSettings}
+          >
+            <Icon name="arrow-left" />
+          </button>
+        }
+      />
 
       <div className={cn('flex min-h-0 flex-1 flex-col', !compact && 'md:flex-row')}>
         <nav

--- a/packages/trueforge-ui/src/hooks/useChatChromeActionsVisible.ts
+++ b/packages/trueforge-ui/src/hooks/useChatChromeActionsVisible.ts
@@ -9,8 +9,6 @@ import { isNewChatView } from '../utils/isNewChatView.js';
 export type NamedAgentHeaderState = {
   name: string;
   isEditing: boolean;
-  /** New Chat vs New Agent / named-agent differentiation. */
-  icon: 'square-pen' | 'agent-2';
   /** When true, prefer a non-empty thread/session title over `name`. */
   allowThreadTitle: boolean;
 };
@@ -25,7 +23,6 @@ export function useNamedAgentHeaderState(): NamedAgentHeaderState | null {
     return {
       name: identity,
       isEditing: shell.mode.isMutable,
-      icon: 'agent-2',
       allowThreadTitle: false,
     };
   }
@@ -36,7 +33,6 @@ export function useNamedAgentHeaderState(): NamedAgentHeaderState | null {
   return {
     name: isCreateAgent ? 'New Agent' : 'New Chat',
     isEditing: false,
-    icon: isCreateAgent ? 'agent-2' : 'square-pen',
     allowThreadTitle: true,
   };
 }

--- a/packages/trueforge-ui/src/layouts/DrawerLayout.tsx
+++ b/packages/trueforge-ui/src/layouts/DrawerLayout.tsx
@@ -4,6 +4,7 @@ import { lazy, Suspense, useRef } from 'react';
 
 import { useAui } from '../assistant-ui.js';
 import { NamedAgentHeaderLabel } from '../atoms/NamedAgentHeaderLabel.js';
+import { PageHeader } from '../atoms/PageHeader.js';
 import { ShellActions } from '../atoms/ShellActions.js';
 import { auiButtonClass } from '../atoms/lib/buttonClasses.js';
 import { cn } from '../atoms/lib/cn.js';
@@ -60,16 +61,12 @@ export function DrawerLayout({ className }: { className?: string }) {
   return (
     <div className={cn('relative flex h-full min-h-0 w-full flex-col bg-primary-bg', className)}>
       {/* Keep ShellActions mounted across Settings open/close so host action-slot state persists. */}
-      <header className="flex shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5">
-        {!overlayOpen ? (
-          <>
+      <PageHeader
+        className="bg-topbar-bg"
+        title={
+          !overlayOpen ? (
             <NamedAgentHeaderLabel />
-            <span className="min-w-0 flex-1" />
-            <ClearChatButton />
-            {!shell?.agentConfigOpen ? <SaveAgentButton /> : null}
-          </>
-        ) : libraryOpen || schedulesOpen ? (
-          <>
+          ) : libraryOpen || schedulesOpen ? (
             <button
               type="button"
               className={auiButtonClass({ variant: 'ghost', size: 'sm' })}
@@ -81,39 +78,46 @@ export function DrawerLayout({ className }: { className?: string }) {
               <Icon name="arrow-left" />
               Back to chat
             </button>
-            <span className="min-w-0 flex-1" />
-          </>
-        ) : (
-          <span className="min-w-0 flex-1" />
-        )}
-        <ShellActions key="shell-actions" />
-        {!overlayOpen ? (
+          ) : null
+        }
+        end={
           <>
-            {showNewActions ? (
-              <button
-                type="button"
-                aria-label="New Chat"
-                title="New Chat"
-                className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
-                onClick={handleNewChat}
-              >
-                <Icon name="square-pen" />
-              </button>
+            {!overlayOpen ? (
+              <>
+                <ClearChatButton />
+                {!shell?.agentConfigOpen ? <SaveAgentButton /> : null}
+              </>
             ) : null}
-            {showNewActions && shell?.isComposerEnabled ? (
-              <button
-                type="button"
-                aria-label="New Agent"
-                title="New Agent"
-                className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
-                onClick={handleNewAgent}
-              >
-                <Icon name="agent-2" />
-              </button>
+            <ShellActions key="shell-actions" />
+            {!overlayOpen ? (
+              <>
+                {showNewActions ? (
+                  <button
+                    type="button"
+                    aria-label="New Chat"
+                    title="New Chat"
+                    className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
+                    onClick={handleNewChat}
+                  >
+                    <Icon name="square-pen" />
+                  </button>
+                ) : null}
+                {showNewActions && shell?.isComposerEnabled ? (
+                  <button
+                    type="button"
+                    aria-label="New Agent"
+                    title="New Agent"
+                    className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
+                    onClick={handleNewAgent}
+                  >
+                    <Icon name="agent-2" />
+                  </button>
+                ) : null}
+              </>
             ) : null}
           </>
-        ) : null}
-      </header>
+        }
+      />
       <div className="flex min-h-0 min-w-0 flex-1">
         <div ref={mainRef} className="min-h-0 min-w-0 flex-1">
           {settingsOpen ? (

--- a/packages/trueforge-ui/src/layouts/SidebarLayout.tsx
+++ b/packages/trueforge-ui/src/layouts/SidebarLayout.tsx
@@ -15,6 +15,7 @@ import { useAui } from '../assistant-ui.js';
 import { auiButtonClass } from '../atoms/lib/buttonClasses.js';
 import { cn } from '../atoms/lib/cn.js';
 import { NamedAgentHeaderLabel } from '../atoms/NamedAgentHeaderLabel.js';
+import { PageHeader } from '../atoms/PageHeader.js';
 import { Spinner } from '../atoms/primitives/Spinner.js';
 import { ShellActions } from '../atoms/ShellActions.js';
 import { AgentConfigDrawerContainer } from '../containers/AgentConfigDrawerContainer.js';
@@ -35,7 +36,7 @@ const brandLogoClassName = 'h-5 w-5 max-w-40 shrink-0 object-contain';
 const railWidthClassName = 'w-18';
 
 const railActionButtonClassName =
-  'h-auto w-full flex-col gap-1 whitespace-normal px-1 py-3 text-[0.625rem] leading-tight !justify-center text-text-primary shadow-none hover:bg-secondary-button-hover hover:text-ghost-button-text';
+  'h-auto w-full flex-col gap-1.5 whitespace-normal px-1 py-3 text-[0.625rem] leading-tight !justify-center text-text-primary shadow-none hover:bg-secondary-button-hover hover:text-ghost-button-text';
 
 const railSelectedClassName =
   'bg-primary-button-bg text-primary-button-text hover:bg-primary-button-hover hover:text-primary-button-text';
@@ -212,18 +213,17 @@ export function SidebarLayout({ className }: { className?: string }) {
         {/* Desktop keeps shell chrome in the rail footer (always mounted, including
             when visually hidden on small screens so host action-slot state persists).
             Mobile reaches theme/settings via the nav drawer rail. */}
-        <header
+        <PageHeader
           className={cn(
-            'flex shrink-0 items-center gap-1 border-b border-border bg-topbar-bg px-2 py-1.5',
+            'bg-topbar-bg',
             // Desktop: hide when settings/idle or the thread header has nothing to show
             // (empty untitled draft). Mobile still needs the menu button.
             // Keep visible while Agent Config is open so New Agent / title stay in chrome;
             // SaveAgentButton is omitted below to avoid duplicating the drawer's save control.
             (overlayOpen || isIdle || !hasChatHeaderContent) && 'md:hidden',
           )}
-        >
-          {!overlayOpen ? (
-            <>
+          start={
+            !overlayOpen ? (
               <button
                 ref={menuBtnRef}
                 type="button"
@@ -234,15 +234,18 @@ export function SidebarLayout({ className }: { className?: string }) {
               >
                 <Icon name="bars" />
               </button>
-              <NamedAgentHeaderLabel />
-              <span className="min-w-0 flex-1" />
-              <ClearChatButton />
-              {!shell?.agentConfigOpen ? <SaveAgentButton /> : null}
-            </>
-          ) : (
-            <span className="min-w-0 flex-1" />
-          )}
-        </header>
+            ) : null
+          }
+          title={!overlayOpen ? <NamedAgentHeaderLabel /> : null}
+          end={
+            !overlayOpen ? (
+              <>
+                <ClearChatButton />
+                {!shell?.agentConfigOpen ? <SaveAgentButton /> : null}
+              </>
+            ) : null
+          }
+        />
 
         <div ref={mainRef} className="min-h-0 min-w-0 flex-1">
           {settingsOpen ? (

--- a/packages/trueforge-ui/src/layouts/StackChatPanel.tsx
+++ b/packages/trueforge-ui/src/layouts/StackChatPanel.tsx
@@ -4,6 +4,7 @@ import { lazy, Suspense, useEffect, type ReactNode } from 'react';
 
 import { useAui } from '../assistant-ui.js';
 import { NamedAgentHeaderLabel } from '../atoms/NamedAgentHeaderLabel.js';
+import { PageHeader } from '../atoms/PageHeader.js';
 import { ShellActions } from '../atoms/ShellActions.js';
 import { auiButtonClass } from '../atoms/lib/buttonClasses.js';
 import { cn } from '../atoms/lib/cn.js';
@@ -122,35 +123,42 @@ export function StackChatPanel({ className, threadHeaderEnd }: StackChatPanelPro
         </div>
       ) : (
         <>
-          <header className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5">
-            {showNewActions ? (
-              <button
-                type="button"
-                aria-label="New Chat"
-                title="New Chat"
-                className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
-                onClick={handleNewChat}
-              >
-                <Icon name="square-pen" />
-              </button>
-            ) : null}
-            {showNewActions && shell?.isComposerEnabled ? (
-              <button
-                type="button"
-                aria-label="New Agent"
-                title="New Agent"
-                className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
-                onClick={handleNewAgent}
-              >
-                <Icon name="agent-2" />
-              </button>
-            ) : null}
-            <NamedAgentHeaderLabel />
-            <span className="min-w-0 flex-1" />
-            <ClearChatButton />
-            <SaveAgentButton />
-            {threadHeaderEnd}
-          </header>
+          <PageHeader
+            start={
+              <>
+                {showNewActions ? (
+                  <button
+                    type="button"
+                    aria-label="New Chat"
+                    title="New Chat"
+                    className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
+                    onClick={handleNewChat}
+                  >
+                    <Icon name="square-pen" />
+                  </button>
+                ) : null}
+                {showNewActions && shell?.isComposerEnabled ? (
+                  <button
+                    type="button"
+                    aria-label="New Agent"
+                    title="New Agent"
+                    className={auiButtonClass({ variant: 'ghost', size: 'icon' })}
+                    onClick={handleNewAgent}
+                  >
+                    <Icon name="agent-2" />
+                  </button>
+                ) : null}
+              </>
+            }
+            title={<NamedAgentHeaderLabel />}
+            end={
+              <>
+                <ClearChatButton />
+                <SaveAgentButton />
+                {threadHeaderEnd}
+              </>
+            }
+          />
           <div className="min-h-0 flex-1">{isIdle ? <SelectAgentEmptyState /> : <Thread />}</div>
         </>
       )}

--- a/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/builderServer.ts
+++ b/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/builderServer.ts
@@ -3,11 +3,17 @@
  * Composer pickers + agent library backed by the Harness agents registry.
  */
 import type { TrueForge, TrueForgeApi } from '@truefoundry/trueforge-sdk';
-import type { AgentBuilderServer, AgentLibraryEntry, ModelSelection, SearchAgentsParams } from '../../server/types.js';
+import type {
+  AgentBuilderServer,
+  AgentLibraryEntry,
+  ModelSelection,
+  PageParams,
+  SearchAgentsParams,
+} from '../../server/types.js';
 import { toUiConnectorFromReadEntry, toUiTool } from './catalogs/connectorCatalog.js';
 import { toHarnessAgentSpec, toUiAgentSpec } from './chatServer.js';
 import { createTrueForgeClient, type CreateTrueForgeClientOptions } from './client.js';
-import { listConfiguredMcpServers, listSkills } from './lists.js';
+import { listConfiguredMcpServers, listConfiguredMcpServersPage, listSkills } from './lists.js';
 import type { HarnessAgentSpec } from './types.js';
 
 export type CreateHarnessBuilderServerOptions = CreateTrueForgeClientOptions & {
@@ -88,6 +94,13 @@ export function createHarnessBuilderServer(
       return skills.map(skill => ({ id: skill.name, name: skill.name, description: skill.description }));
     },
     getMcp: async () => (await listConfiguredMcpServers(client)).map(toUiConnectorFromReadEntry),
+    listMcp: async (req?: PageParams) => {
+      const page = await listConfiguredMcpServersPage(client, req ?? {});
+      return {
+        data: page.data.map(toUiConnectorFromReadEntry),
+        ...(page.nextPageToken === undefined ? {} : { nextPageToken: page.nextPageToken }),
+      };
+    },
     getMcpTools: async ({ connectorId }: { connectorId: string }) => {
       const body = await client.mcpServers.listTools(connectorId);
       return body.data.flatMap(tool =>

--- a/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/index.ts
+++ b/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/index.ts
@@ -56,7 +56,13 @@ export {
 } from './chatServer.js';
 export { createTrueForgeClient } from './client.js';
 export type { CreateTrueForgeClientOptions } from './client.js';
-export { getCapabilities, listConfiguredMcpServers, listModels, listSkills } from './lists.js';
+export {
+  getCapabilities,
+  listConfiguredMcpServers,
+  listConfiguredMcpServersPage,
+  listModels,
+  listSkills,
+} from './lists.js';
 export { createScheduleServer } from './schedules/scheduleServer.js';
 export type { HarnessAgentSpec, HarnessMcpServerMount, HarnessSkillMount } from './types.js';
 

--- a/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/lists.ts
+++ b/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/lists.ts
@@ -4,14 +4,31 @@
  */
 import type { TrueForge, TrueForgeApi } from '@truefoundry/trueforge-sdk';
 
+import type { ListResult, PageParams } from '../../server/types.js';
+import { drainListPages } from '../../utils/drainListPages.js';
+import { toListResult } from './chatServer.js';
+
 export async function listModels(client: TrueForge): Promise<TrueForgeApi.AvailableModel[]> {
   const body = await client.models.list();
   return body.data;
 }
 
+export async function listConfiguredMcpServersPage(
+  client: TrueForge,
+  req: PageParams = {},
+): Promise<ListResult<TrueForgeApi.AvailableMcpServer>> {
+  const page = await client.mcpServers.list({
+    ...(req.limit === undefined ? {} : { limit: req.limit }),
+    ...(req.pageToken === undefined ? {} : { pageToken: req.pageToken }),
+  });
+  return toListResult(page, server => server);
+}
+
+/** Drain every MCP page (full catalog for non-picker callers). */
 export async function listConfiguredMcpServers(client: TrueForge): Promise<TrueForgeApi.AvailableMcpServer[]> {
-  const body = await client.mcpServers.list();
-  return body.data;
+  return drainListPages({
+    fetchPage: pageToken => listConfiguredMcpServersPage(client, { pageToken }),
+  });
 }
 
 export async function listSkills(client: TrueForge): Promise<TrueForgeApi.AvailableSkill[]> {

--- a/packages/trueforge-ui/src/server/createTrueFoundryServer.ts
+++ b/packages/trueforge-ui/src/server/createTrueFoundryServer.ts
@@ -9,7 +9,9 @@ import type {
   AgentSpec,
   CatalogServer,
   ConnectorState,
+  ListResult,
   ModelSelection,
+  PageParams,
   SaveAgentRequest,
   SaveAgentResult,
   ScheduleServer,
@@ -35,6 +37,7 @@ export type CreateTrueFoundryServerOptions<
   getModels: () => Promise<TModel[]>;
   getSkills: () => Promise<TSkill[]>;
   getMcp: () => Promise<TMcp[]>;
+  listMcp?: (req?: PageParams) => Promise<ListResult<TMcp>>;
   getMcpTools?: AgentBuilderServer<TSpec, TModel, TSkill, TMcp, TAgent, TSave, TCapabilities>['getMcpTools'];
   searchAgents: (req?: SearchAgentsParams) => Promise<TAgent[]>;
   saveAgent: (req: SaveAgentRequest<TSpec>) => Promise<TSave>;
@@ -118,6 +121,7 @@ export function createTrueFoundryServer<
     getModels: opts.getModels,
     getSkills: opts.getSkills,
     getMcp: opts.getMcp,
+    ...(opts.listMcp === undefined ? {} : { listMcp: opts.listMcp }),
     ...(opts.getMcpTools === undefined ? {} : { getMcpTools: opts.getMcpTools }),
     searchAgents: opts.searchAgents,
     saveAgent: opts.saveAgent,

--- a/packages/trueforge-ui/test/atoms/PageHeader.test.tsx
+++ b/packages/trueforge-ui/test/atoms/PageHeader.test.tsx
@@ -8,7 +8,7 @@ describe('PageHeader', () => {
   it('renders a string title with shared header chrome', () => {
     render(<PageHeader title="Agent Sessions" end={<button type="button">Filter</button>} />);
 
-    expect(screen.getByRole('banner')).toHaveClass('h-14');
+    expect(screen.getByRole('banner')).toHaveClass('min-h-14');
     expect(screen.getByRole('heading', { name: 'Agent Sessions' })).toHaveClass('text-md', 'font-semibold');
     expect(screen.getByRole('button', { name: 'Filter' })).toBeInTheDocument();
   });

--- a/packages/trueforge-ui/test/atoms/PageHeader.test.tsx
+++ b/packages/trueforge-ui/test/atoms/PageHeader.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PageHeader } from '@/atoms/PageHeader.js';
+
+describe('PageHeader', () => {
+  it('renders a string title with shared header chrome', () => {
+    render(<PageHeader title="Agent Sessions" end={<button type="button">Filter</button>} />);
+
+    expect(screen.getByRole('banner')).toHaveClass('h-14');
+    expect(screen.getByRole('heading', { name: 'Agent Sessions' })).toHaveClass('text-md', 'font-semibold');
+    expect(screen.getByRole('button', { name: 'Filter' })).toBeInTheDocument();
+  });
+
+  it('renders a custom title node without wrapping another h1', () => {
+    render(
+      <PageHeader
+        title={<h1 className="text-md font-semibold">New Chat</h1>}
+        start={<button type="button">Menu</button>}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'New Chat' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Menu' })).toBeInTheDocument();
+    expect(screen.getAllByRole('heading')).toHaveLength(1);
+  });
+});

--- a/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
@@ -256,6 +256,37 @@ describe('AgentConfigEditors', () => {
     expect(screen.getByRole('button', { name: 'GitHub' })).toHaveAttribute('aria-current', 'true');
   });
 
+  it('keeps an off-page selected MCP active via catalog stubs', async () => {
+    const loadMcpTools = vi.fn(async (connectorId: string) => [
+      { id: `${connectorId}.tool`, name: `${connectorId}.tool` },
+    ]);
+
+    render(
+      <SlotsProvider>
+        <AgentConfigEditors
+          editor="mcp"
+          spec={{
+            model: { name: 'openai/gpt' },
+            mcpServers: [{ id: 'off-page', name: 'Off Page', enableTools: ['@all'] }],
+          }}
+          models={[]}
+          connectors={[{ id: 'github', name: 'GitHub', authenticated: true }]}
+          skills={[]}
+          loading={false}
+          error={null}
+          loadMcpTools={loadMcpTools}
+          onChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </SlotsProvider>,
+    );
+
+    await waitFor(() => expect(loadMcpTools).toHaveBeenCalledWith('off-page'));
+    expect(screen.getByRole('button', { name: 'Off Page' })).toHaveAttribute('aria-current', 'true');
+    fireEvent.click(screen.getByRole('button', { name: 'Off Page' }));
+    await waitFor(() => expect(loadMcpTools).toHaveBeenCalledTimes(1));
+  });
+
   it('loads MCP tools lazily and preserves unrelated mount selectors', async () => {
     const spec: AgentSpec = {
       model: { name: 'openai/gpt' },

--- a/packages/trueforge-ui/test/atoms/draft/AgentConfigPanel.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/AgentConfigPanel.test.tsx
@@ -70,7 +70,7 @@ describe('AgentConfigPanel', () => {
     expect(screen.queryByText('Initial messages')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Close agent config' })).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Agent Config' }).parentElement).toHaveClass(
-      'h-14',
+      'min-h-14',
       'border-b',
       'bg-topbar-bg',
       'px-2',

--- a/packages/trueforge-ui/test/atoms/draft/DraftCatalogProvider.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/DraftCatalogProvider.test.tsx
@@ -22,9 +22,14 @@ function CatalogProbe() {
       <button type="button" onClick={() => void catalog.refreshConnectors()}>
         Refresh connectors
       </button>
+      <button type="button" onClick={() => catalog.loadMoreConnectors()}>
+        Load more connectors
+      </button>
       <output data-testid="models">{catalog.models.map(model => model.name).join(',')}</output>
       <output data-testid="skills">{catalog.skills.map(skill => skill.name).join(',')}</output>
       <output data-testid="connectors">{catalog.connectors.map(connector => connector.name).join(',')}</output>
+      <output data-testid="connectors-has-more">{String(catalog.connectorsHasMore)}</output>
+      <output data-testid="connectors-loading-more">{String(catalog.connectorsLoadingMore)}</output>
       <output data-testid="loading">{String(catalog.loading)}</output>
       <output data-testid="error">{catalog.error ?? ''}</output>
     </div>
@@ -57,29 +62,64 @@ function deferred<T>() {
 }
 
 describe('DraftCatalogProvider', () => {
-  it('does not enable sandbox merely because the capability is available', () => {
+  it('does not enable sandbox merely because the capability is available for New Agent', () => {
     const update = reconcileDraftSandbox({
       agentSpec: { model: { name: 'model' } },
       sandboxEnabled: true,
+      kind: 'agent',
     });
 
     expect(update).toEqual({});
   });
 
-  it('does not update an active draft whose sandbox already matches capabilities', () => {
+  it('enables sandbox on New Chat when the capability is available', () => {
     const update = reconcileDraftSandbox({
-      agentSpec: { model: { name: 'model' }, config: { sandbox: { enabled: true } } },
+      agentSpec: { model: { name: 'model' } },
       sandboxEnabled: true,
+      kind: 'chat',
     });
 
-    expect(update).toEqual({});
+    expect(update).toEqual({
+      config: { sandbox: { enabled: true } },
+    });
+  });
+
+  it('disables sandbox on New Chat when the capability becomes unavailable', () => {
+    const update = reconcileDraftSandbox({
+      agentSpec: { model: { name: 'model' }, config: { sandbox: { enabled: true } } },
+      sandboxEnabled: false,
+      kind: 'chat',
+    });
+
+    expect(update).toEqual({
+      config: { sandbox: { enabled: false } },
+    });
+  });
+
+  it('does not update an active draft whose sandbox already matches capabilities', () => {
+    expect(
+      reconcileDraftSandbox({
+        agentSpec: { model: { name: 'model' }, config: { sandbox: { enabled: true } } },
+        sandboxEnabled: true,
+        kind: 'agent',
+      }),
+    ).toEqual({});
+    expect(
+      reconcileDraftSandbox({
+        agentSpec: { model: { name: 'model' }, config: { sandbox: { enabled: true } } },
+        sandboxEnabled: true,
+        kind: 'chat',
+      }),
+    ).toEqual({});
   });
 
   it('does not update an active draft while sandbox capabilities are unavailable', () => {
     const agentSpec = { model: { name: 'model' }, config: { sandbox: { enabled: true } } };
 
-    expect(reconcileDraftSandbox({ agentSpec, sandboxEnabled: undefined })).toEqual({});
-    expect(reconcileDraftSandbox({ agentSpec, sandboxEnabled: null })).toEqual({});
+    expect(reconcileDraftSandbox({ agentSpec, sandboxEnabled: undefined, kind: 'agent' })).toEqual({});
+    expect(reconcileDraftSandbox({ agentSpec, sandboxEnabled: null, kind: 'agent' })).toEqual({});
+    expect(reconcileDraftSandbox({ agentSpec, sandboxEnabled: undefined, kind: 'chat' })).toEqual({});
+    expect(reconcileDraftSandbox({ agentSpec, sandboxEnabled: null, kind: 'chat' })).toEqual({});
   });
 
   it('prunes unavailable remembered choices and falls back to the live model catalog', () => {
@@ -341,5 +381,42 @@ describe('DraftCatalogProvider', () => {
     await waitFor(() => expect(screen.getByTestId('models')).toHaveTextContent('inner/model'));
     expect(innerGetModels).toHaveBeenCalledOnce();
     expect(outerGetModels).not.toHaveBeenCalled();
+  });
+
+  it('loads the first MCP page via listMcp and appends on loadMoreConnectors', async () => {
+    const listMcp = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [{ id: 'a', name: 'Alpha' }],
+        nextPageToken: 'page-2',
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'b', name: 'Beta' }],
+      });
+    const getMcp = vi.fn(async (): Promise<ConnectorState[]> => {
+      throw new Error('getMcp should not run when listMcp is present');
+    });
+    const server = createMockAgentUIServer({ listMcp, getMcp });
+
+    render(
+      <ServerProvider server={server}>
+        <DraftCatalogProvider>
+          <CatalogProbe />
+        </DraftCatalogProvider>
+      </ServerProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load catalog' }));
+
+    await waitFor(() => expect(screen.getByTestId('connectors')).toHaveTextContent('Alpha'));
+    expect(screen.getByTestId('connectors-has-more')).toHaveTextContent('true');
+    expect(listMcp).toHaveBeenCalledWith({ limit: 50 });
+    expect(getMcp).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more connectors' }));
+
+    await waitFor(() => expect(screen.getByTestId('connectors')).toHaveTextContent('Alpha,Beta'));
+    expect(screen.getByTestId('connectors-has-more')).toHaveTextContent('false');
+    expect(listMcp).toHaveBeenCalledWith({ limit: 50, pageToken: 'page-2' });
   });
 });

--- a/packages/trueforge-ui/test/atoms/draft/DraftCatalogProvider.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/DraftCatalogProvider.test.tsx
@@ -149,6 +149,22 @@ describe('DraftCatalogProvider', () => {
     });
   });
 
+  it('keeps off-page MCP mounts while more connector pages remain', () => {
+    const update = reconcileDraftSpecPreferences({
+      agentSpec: {
+        model: { name: 'live/model' },
+        mcpServers: [{ name: 'Available MCP' }, { name: 'Off-page MCP' }],
+      },
+      models: [{ id: 'live/model', name: 'live/model', provider: { name: 'Live' }, properties: {} }],
+      skills: [],
+      connectors: [{ id: 'available-mcp', name: 'Available MCP' }],
+      connectorsHasMore: true,
+      skillsEnabled: true,
+    });
+
+    expect(update).toEqual({});
+  });
+
   it('clears remembered skills when skills are unavailable', () => {
     const update = reconcileDraftSpecPreferences({
       agentSpec: {

--- a/packages/trueforge-ui/test/atoms/draft/DraftCatalogProvider.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/DraftCatalogProvider.test.tsx
@@ -29,6 +29,7 @@ function CatalogProbe() {
       <output data-testid="skills">{catalog.skills.map(skill => skill.name).join(',')}</output>
       <output data-testid="connectors">{catalog.connectors.map(connector => connector.name).join(',')}</output>
       <output data-testid="connectors-has-more">{String(catalog.connectorsHasMore)}</output>
+      <output data-testid="connectors-load-more-failed">{String(catalog.connectorsLoadMoreFailed)}</output>
       <output data-testid="connectors-loading-more">{String(catalog.connectorsLoadingMore)}</output>
       <output data-testid="loading">{String(catalog.loading)}</output>
       <output data-testid="error">{catalog.error ?? ''}</output>
@@ -434,5 +435,40 @@ describe('DraftCatalogProvider', () => {
     await waitFor(() => expect(screen.getByTestId('connectors')).toHaveTextContent('Alpha,Beta'));
     expect(screen.getByTestId('connectors-has-more')).toHaveTextContent('false');
     expect(listMcp).toHaveBeenCalledWith({ limit: 50, pageToken: 'page-2' });
+  });
+
+  it('stops automatic pagination after failure and allows an explicit retry', async () => {
+    const listMcp = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [{ id: 'a', name: 'Alpha' }],
+        nextPageToken: 'page-2',
+      })
+      .mockRejectedValueOnce(new Error('Page unavailable'))
+      .mockResolvedValueOnce({
+        data: [{ id: 'b', name: 'Beta' }],
+      });
+    const server = createMockAgentUIServer({ listMcp });
+
+    render(
+      <ServerProvider server={server}>
+        <DraftCatalogProvider>
+          <CatalogProbe />
+        </DraftCatalogProvider>
+      </ServerProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load catalog' }));
+    await waitFor(() => expect(screen.getByTestId('connectors')).toHaveTextContent('Alpha'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more connectors' }));
+    await waitFor(() => expect(screen.getByTestId('connectors-load-more-failed')).toHaveTextContent('true'));
+    expect(screen.getByTestId('connectors-has-more')).toHaveTextContent('true');
+    expect(listMcp).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more connectors' }));
+    await waitFor(() => expect(screen.getByTestId('connectors')).toHaveTextContent('Alpha,Beta'));
+    expect(screen.getByTestId('connectors-load-more-failed')).toHaveTextContent('false');
+    expect(listMcp).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/trueforge-ui/test/atoms/draft/mcpConnectorStubs.test.ts
+++ b/packages/trueforge-ui/test/atoms/draft/mcpConnectorStubs.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { connectorsWithSelectedStubs } from '@/atoms/draft/mcpConnectorStubs.js';
+
+describe('connectorsWithSelectedStubs', () => {
+  it('returns connectors unchanged when every selection is present', () => {
+    const connectors = [{ id: 'a', name: 'A' }];
+    expect(connectorsWithSelectedStubs({ connectors, selected: [{ id: 'a', name: 'A' }] })).toBe(connectors);
+  });
+
+  it('prepends stubs for selected mounts missing from the loaded page', () => {
+    expect(
+      connectorsWithSelectedStubs({
+        connectors: [{ id: 'b', name: 'B' }],
+        selected: [
+          { id: 'a', name: 'A' },
+          { id: 'b', name: 'B' },
+        ],
+      }),
+    ).toEqual([
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+    ]);
+  });
+});

--- a/packages/trueforge-ui/test/atoms/lib/useInfiniteScrollSentinel.test.tsx
+++ b/packages/trueforge-ui/test/atoms/lib/useInfiniteScrollSentinel.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { act, render, waitFor } from '@testing-library/react';
+import { useEffect, useState, type ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useInfiniteScrollSentinel } from '@/atoms/lib/useInfiniteScrollSentinel.js';
+
+type ObserverCallback = IntersectionObserverCallback;
+
+let observerCallback: ObserverCallback | null = null;
+const observe = vi.fn();
+const disconnect = vi.fn();
+
+class FakeIntersectionObserver {
+  constructor(callback: ObserverCallback) {
+    observerCallback = callback;
+  }
+  observe = observe;
+  unobserve = vi.fn();
+  disconnect = disconnect;
+  takeRecords = () => [];
+  root = null;
+  rootMargin = '';
+  thresholds = [];
+}
+
+function Probe({
+  hasMore,
+  loading,
+  onLoadMore,
+}: {
+  hasMore: boolean;
+  loading: boolean;
+  onLoadMore: () => void;
+}): ReactElement {
+  const { listRef, sentinelRef } = useInfiniteScrollSentinel({
+    enabled: true,
+    hasMore,
+    loading,
+    onLoadMore,
+  });
+  return (
+    <div>
+      <div ref={listRef} data-testid="list" />
+      <div ref={sentinelRef} data-testid="sentinel" />
+    </div>
+  );
+}
+
+function ControlledProbe({ onLoadMore }: { onLoadMore: () => void }): ReactElement {
+  const [loading, setLoading] = useState(false);
+  const [pages, setPages] = useState(0);
+  const hasMore = pages < 2;
+
+  useEffect(() => {
+    if (!loading) return;
+    const timer = window.setTimeout(() => {
+      setPages(current => current + 1);
+      setLoading(false);
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [loading]);
+
+  return (
+    <Probe
+      hasMore={hasMore}
+      loading={loading}
+      onLoadMore={() => {
+        onLoadMore();
+        setLoading(true);
+      }}
+    />
+  );
+}
+
+describe('useInfiniteScrollSentinel', () => {
+  beforeEach(() => {
+    observerCallback = null;
+    observe.mockClear();
+    disconnect.mockClear();
+    vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('re-observes after loading settles so a still-visible sentinel can load again', async () => {
+    const onLoadMore = vi.fn();
+    render(<ControlledProbe onLoadMore={onLoadMore} />);
+
+    await waitFor(() => expect(observe).toHaveBeenCalled());
+    act(() => {
+      observerCallback?.(
+        [{ isIntersecting: true, target: document.createElement('div') } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    await waitFor(() => expect(onLoadMore).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(observe.mock.calls.length).toBeGreaterThan(1));
+
+    act(() => {
+      observerCallback?.(
+        [{ isIntersecting: true, target: document.createElement('div') } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    await waitFor(() => expect(onLoadMore).toHaveBeenCalledTimes(2));
+  });
+});

--- a/packages/trueforge-ui/test/atoms/lib/useInfiniteScrollSentinel.test.tsx
+++ b/packages/trueforge-ui/test/atoms/lib/useInfiniteScrollSentinel.test.tsx
@@ -8,14 +8,22 @@ import { useInfiniteScrollSentinel } from '@/atoms/lib/useInfiniteScrollSentinel
 type ObserverCallback = IntersectionObserverCallback;
 
 let observerCallback: ObserverCallback | null = null;
-let observer: IntersectionObserver | null = null;
 const observe = vi.fn();
 const disconnect = vi.fn();
+
+const observerStub: IntersectionObserver = {
+  observe,
+  unobserve: vi.fn(),
+  disconnect,
+  takeRecords: () => [],
+  root: null,
+  rootMargin: '',
+  thresholds: [],
+};
 
 class FakeIntersectionObserver implements IntersectionObserver {
   constructor(callback: ObserverCallback) {
     observerCallback = callback;
-    observer = this;
   }
   observe = observe;
   unobserve = vi.fn();
@@ -88,7 +96,6 @@ function ControlledProbe({ onLoadMore }: { onLoadMore: () => void }): ReactEleme
 describe('useInfiniteScrollSentinel', () => {
   beforeEach(() => {
     observerCallback = null;
-    observer = null;
     observe.mockClear();
     disconnect.mockClear();
     vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver);
@@ -104,14 +111,14 @@ describe('useInfiniteScrollSentinel', () => {
 
     await waitFor(() => expect(observe).toHaveBeenCalled());
     act(() => {
-      if (observer !== null) observerCallback?.([intersectionEntry()], observer);
+      observerCallback?.([intersectionEntry()], observerStub);
     });
 
     await waitFor(() => expect(onLoadMore).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(observe.mock.calls.length).toBeGreaterThan(1));
 
     act(() => {
-      if (observer !== null) observerCallback?.([intersectionEntry()], observer);
+      observerCallback?.([intersectionEntry()], observerStub);
     });
 
     await waitFor(() => expect(onLoadMore).toHaveBeenCalledTimes(2));

--- a/packages/trueforge-ui/test/atoms/lib/useInfiniteScrollSentinel.test.tsx
+++ b/packages/trueforge-ui/test/atoms/lib/useInfiniteScrollSentinel.test.tsx
@@ -8,21 +8,33 @@ import { useInfiniteScrollSentinel } from '@/atoms/lib/useInfiniteScrollSentinel
 type ObserverCallback = IntersectionObserverCallback;
 
 let observerCallback: ObserverCallback | null = null;
+let observer: IntersectionObserver | null = null;
 const observe = vi.fn();
 const disconnect = vi.fn();
 
-class FakeIntersectionObserver {
+class FakeIntersectionObserver implements IntersectionObserver {
   constructor(callback: ObserverCallback) {
     observerCallback = callback;
+    observer = this;
   }
   observe = observe;
   unobserve = vi.fn();
   disconnect = disconnect;
   takeRecords = () => [];
-  root = null;
+  root: Element | Document | null = null;
   rootMargin = '';
-  thresholds = [];
+  thresholds: ReadonlyArray<number> = [];
 }
+
+const intersectionEntry = (): IntersectionObserverEntry => ({
+  boundingClientRect: new DOMRect(),
+  intersectionRatio: 1,
+  intersectionRect: new DOMRect(),
+  isIntersecting: true,
+  rootBounds: null,
+  target: document.createElement('div'),
+  time: 0,
+});
 
 function Probe({
   hasMore,
@@ -76,6 +88,7 @@ function ControlledProbe({ onLoadMore }: { onLoadMore: () => void }): ReactEleme
 describe('useInfiniteScrollSentinel', () => {
   beforeEach(() => {
     observerCallback = null;
+    observer = null;
     observe.mockClear();
     disconnect.mockClear();
     vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver);
@@ -91,20 +104,14 @@ describe('useInfiniteScrollSentinel', () => {
 
     await waitFor(() => expect(observe).toHaveBeenCalled());
     act(() => {
-      observerCallback?.(
-        [{ isIntersecting: true, target: document.createElement('div') } as IntersectionObserverEntry],
-        {} as IntersectionObserver,
-      );
+      if (observer !== null) observerCallback?.([intersectionEntry()], observer);
     });
 
     await waitFor(() => expect(onLoadMore).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(observe.mock.calls.length).toBeGreaterThan(1));
 
     act(() => {
-      observerCallback?.(
-        [{ isIntersecting: true, target: document.createElement('div') } as IntersectionObserverEntry],
-        {} as IntersectionObserver,
-      );
+      if (observer !== null) observerCallback?.([intersectionEntry()], observer);
     });
 
     await waitFor(() => expect(onLoadMore).toHaveBeenCalledTimes(2));

--- a/packages/trueforge-ui/test/containers/SettingsBuilder/index.test.tsx
+++ b/packages/trueforge-ui/test/containers/SettingsBuilder/index.test.tsx
@@ -199,7 +199,7 @@ describe('TruefoundrySettingsBuilder', () => {
 
   it('refreshes composer catalogs when settings close', async () => {
     await expectCatalogsRefreshOnClose(() => {
-      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      fireEvent.keyDown(window, { key: 'Escape' });
     });
   });
 
@@ -217,7 +217,7 @@ describe('TruefoundrySettingsBuilder', () => {
       expect(screen.getByText('Skill settings content')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to agent' }));
     expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
 
     rerender(<TestShell server={createServer()} />);

--- a/packages/trueforge-ui/test/containers/SettingsBuilder/index.test.tsx
+++ b/packages/trueforge-ui/test/containers/SettingsBuilder/index.test.tsx
@@ -96,6 +96,7 @@ describe('TruefoundrySettingsBuilder', () => {
     expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
 
     await openSettings();
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
 
     rerender(<TestShell server={createServer({ catalog: false })} />);
     expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
@@ -167,6 +168,15 @@ describe('TruefoundrySettingsBuilder', () => {
 
     expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
     expect(parentKeyDown).not.toHaveBeenCalled();
+  });
+
+  it('closes via the Back control', async () => {
+    render(<TestShell server={createServer()} />);
+    await openSettings();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
   });
 
   async function expectCatalogsRefreshOnClose(close: () => void) {

--- a/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
+++ b/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
@@ -542,8 +542,8 @@ describe('SidebarLayout', () => {
     const chatColumn = config.nextElementSibling;
     expect(config).toHaveClass('border-r');
     expect(chatColumn).not.toBeNull();
-    expect(config.querySelector('header')).toHaveClass('h-14');
-    expect(chatColumn?.querySelector('header')).toHaveClass('h-14');
+    expect(config.querySelector('header')).toHaveClass('min-h-14');
+    expect(chatColumn?.querySelector('header')).toHaveClass('min-h-14');
     expect(screen.queryByRole('button', { name: 'Agent config' })).not.toBeInTheDocument();
 
     const [settingsButton] = screen.getAllByRole('button', { name: 'Settings' });

--- a/packages/trueforge-ui/test/plugins/trueforge-agent-server-adapter/harnessBuilderServer.test.ts
+++ b/packages/trueforge-ui/test/plugins/trueforge-agent-server-adapter/harnessBuilderServer.test.ts
@@ -377,4 +377,84 @@ describe('harnessBuilderServer', () => {
     assert.equal(requests.length, 1);
     assert.equal(requests[0]?.method, 'GET');
   });
+
+  it('listMcp maps a page and preserves nextPageToken', async () => {
+    const urls: string[] = [];
+    const fetchMock: typeof fetch = async input => {
+      const url = input instanceof Request ? input.url : String(input);
+      urls.push(url);
+      if (url.includes('/api/v1/mcp-servers')) {
+        return Response.json({
+          data: [
+            {
+              name: 'linear',
+              url: 'https://mcp.linear.app/mcp',
+              auth: { type: 'dcr' },
+              auth_status: { status: 'authenticated' },
+            },
+          ],
+          pagination: { limit: 50, next_page_token: 'tok-2' },
+        });
+      }
+      return new Response(`Unexpected request: ${url}`, { status: 500 });
+    };
+
+    const builder = createHarnessBuilderServer({ fetch: fetchMock });
+    assert.ok(builder.listMcp);
+    const page = await builder.listMcp({ limit: 50 });
+    assert.deepEqual(page.data, [
+      {
+        id: 'linear',
+        name: 'linear',
+        description: 'https://mcp.linear.app/mcp',
+        url: 'https://mcp.linear.app/mcp',
+        auth: { type: 'dcr' },
+        requiresAuth: false,
+        authenticated: true,
+      },
+    ]);
+    assert.equal(page.nextPageToken, 'tok-2');
+    assert.ok(urls[0]?.includes('limit=50'));
+  });
+
+  it('getMcp drains every page', async () => {
+    let calls = 0;
+    const fetchMock: typeof fetch = async input => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (!url.includes('/api/v1/mcp-servers')) {
+        return new Response(`Unexpected request: ${url}`, { status: 500 });
+      }
+      calls += 1;
+      if (calls === 1) {
+        return Response.json({
+          data: [
+            {
+              name: 'a',
+              url: 'https://a.example/mcp',
+              auth_status: { status: 'authenticated' },
+            },
+          ],
+          pagination: { limit: 100, next_page_token: 'next' },
+        });
+      }
+      return Response.json({
+        data: [
+          {
+            name: 'b',
+            url: 'https://b.example/mcp',
+            auth_status: { status: 'authenticated' },
+          },
+        ],
+        pagination: { limit: 100 },
+      });
+    };
+
+    const builder = createHarnessBuilderServer({ fetch: fetchMock });
+    const all = await builder.getMcp();
+    assert.deepEqual(
+      all.map(row => row.name),
+      ['a', 'b'],
+    );
+    assert.equal(calls, 2);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: 0.2.21
         version: 0.2.21(@assistant-ui/tap@0.9.5(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
       '@truefoundry/assistant-ui-runtime':
-        specifier: 0.1.26
-        version: 0.1.26(@assistant-ui/tap@0.9.5(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(assistant-cloud@0.1.41(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.2)(zustand@5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
+        specifier: 0.1.27
+        version: 0.1.27(@assistant-ui/tap@0.9.5(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(assistant-cloud@0.1.41(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.2)(zustand@5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
       '@truefoundry/trueforge-sdk':
         specifier: workspace:*
         version: link:../trueforge-sdk
@@ -354,8 +354,8 @@ importers:
         specifier: ^0.13.2
         version: 0.13.3(@openuidev/react-headless@0.9.4(react@19.2.8)(zustand@5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))))(@openuidev/react-lang@0.2.9(@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3))(react@19.2.8)(zod@4.4.3))(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(zod@4.4.3)(zustand@5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
       '@truefoundry/assistant-ui-runtime':
-        specifier: 0.1.26
-        version: 0.1.26(@assistant-ui/tap@0.9.5(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(assistant-cloud@0.1.41(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.2)(zustand@5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
+        specifier: 0.1.27
+        version: 0.1.27(@assistant-ui/tap@0.9.5(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(assistant-cloud@0.1.41(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.2)(zustand@5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
       '@truefoundry/trueforge-sdk':
         specifier: workspace:*
         version: link:../trueforge-sdk
@@ -1059,6 +1059,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
@@ -1073,6 +1079,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1095,6 +1107,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.28.2':
     resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
     engines: {node: '>=18'}
@@ -1109,6 +1127,12 @@ packages:
 
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1131,6 +1155,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.2':
     resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
@@ -1145,6 +1175,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1167,6 +1203,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.2':
     resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
@@ -1181,6 +1223,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1203,6 +1251,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.2':
     resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
@@ -1217,6 +1271,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1239,6 +1299,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.2':
     resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
@@ -1253,6 +1319,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1275,6 +1347,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.2':
     resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
@@ -1289,6 +1367,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1311,6 +1395,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.2':
     resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
@@ -1325,6 +1415,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1347,6 +1443,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.2':
     resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
@@ -1361,6 +1463,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1383,6 +1491,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.28.2':
     resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
     engines: {node: '>=18'}
@@ -1397,6 +1511,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1419,6 +1539,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.28.2':
     resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
     engines: {node: '>=18'}
@@ -1433,6 +1559,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1455,6 +1587,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.28.2':
     resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
     engines: {node: '>=18'}
@@ -1469,6 +1607,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1491,6 +1635,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.2':
     resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
@@ -1505,6 +1655,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3474,8 +3630,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@truefoundry/assistant-ui-runtime@0.1.26':
-    resolution: {integrity: sha512-MaCtVZWB1Vk7NBpLsTHd50444Jeyh53YwDUB7SYvi5qqoLadj8POva7kCfVXv1/QEZKmNAj3GRrN7WtgejRi1g==}
+  '@truefoundry/assistant-ui-runtime@0.1.27':
+    resolution: {integrity: sha512-GmUXHoA4wHnXhh0Cb5WuXQsHqMXLkbuDLkl0IhvswGtwjr9cCdx2uA+FItNj141AMnwb2eUHGMcD4YlLJRpk+w==}
     peerDependencies:
       '@types/react': '*'
       react: ^18 || ^19
@@ -4646,6 +4802,11 @@ packages:
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8306,6 +8467,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
@@ -8313,6 +8477,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm64@0.28.2':
@@ -8324,6 +8491,9 @@ snapshots:
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-arm@0.28.2':
     optional: true
 
@@ -8331,6 +8501,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/android-x64@0.28.2':
@@ -8342,6 +8515,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.2':
     optional: true
 
@@ -8349,6 +8525,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-x64@0.28.2':
@@ -8360,6 +8539,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.2':
     optional: true
 
@@ -8367,6 +8549,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.2':
@@ -8378,6 +8563,9 @@ snapshots:
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.2':
     optional: true
 
@@ -8385,6 +8573,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-arm@0.28.2':
@@ -8396,6 +8587,9 @@ snapshots:
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.2':
     optional: true
 
@@ -8403,6 +8597,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-loong64@0.28.2':
@@ -8414,6 +8611,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.2':
     optional: true
 
@@ -8421,6 +8621,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.2':
@@ -8432,6 +8635,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.2':
     optional: true
 
@@ -8439,6 +8645,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-s390x@0.28.2':
@@ -8450,6 +8659,9 @@ snapshots:
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/linux-x64@0.28.2':
     optional: true
 
@@ -8457,6 +8669,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.2':
@@ -8468,6 +8683,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.2':
     optional: true
 
@@ -8475,6 +8693,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.2':
@@ -8486,6 +8707,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.2':
     optional: true
 
@@ -8493,6 +8717,9 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.2':
@@ -8504,6 +8731,9 @@ snapshots:
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.2':
     optional: true
 
@@ -8511,6 +8741,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.28.2':
@@ -8522,6 +8755,9 @@ snapshots:
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.2':
     optional: true
 
@@ -8529,6 +8765,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-x64@0.28.2':
@@ -10639,7 +10878,7 @@ snapshots:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.5(@types/react@19.2.18)
 
-  '@truefoundry/assistant-ui-runtime@0.1.26(@assistant-ui/tap@0.9.5(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(assistant-cloud@0.1.41(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.2)(zustand@5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))':
+  '@truefoundry/assistant-ui-runtime@0.1.27(@assistant-ui/tap@0.9.5(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(assistant-cloud@0.1.41(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(truefoundry-gateway-sdk@0.4.2)(zustand@5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))':
     dependencies:
       '@assistant-ui/core': 0.2.22(@assistant-ui/store@0.2.21(@assistant-ui/tap@0.9.5(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@assistant-ui/tap@0.9.5(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(assistant-cloud@0.1.41(redis@5.12.1(@opentelemetry/api@1.9.1)))(react@19.2.8)(redis@5.12.1(@opentelemetry/api@1.9.1))(zustand@5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
       '@assistant-ui/store': 0.2.21(@assistant-ui/tap@0.9.5(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
@@ -11895,6 +12134,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   esbuild@0.28.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.2
@@ -11923,6 +12191,7 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.2
       '@esbuild/win32-ia32': 0.28.2
       '@esbuild/win32-x64': 0.28.2
+    optional: true
 
   escalade@3.2.0: {}
 
@@ -14996,7 +15265,7 @@ snapshots:
 
   tsx@4.23.12:
     dependencies:
-      esbuild: 0.28.2
+      esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
 


### PR DESCRIPTION
https://github.com/truefoundry/trueforge/pull/598


## Summary
- Share a single `PageHeader` across chat and list chrome so title size/height stay consistent; drop decorative title icons and the Settings back button
- MCP selectors (composer + agent config) infinite-scroll through `listMcp` pages via `DraftCatalogProvider`
- New Chat enables sandbox on the live draft agent config when capabilities report sandbox as available; bump `@truefoundry/assistant-ui-runtime` to 0.1.27

## Test plan
- [ ] Confirm chat, sessions, schedules, agents library, and settings headers share consistent title sizing/height
- [ ] Open MCP selector in composer and agent config; scroll to load additional `listMcp` pages
- [ ] Start New Chat when sandbox capability is available and verify sandbox is enabled on the draft agent
- [ ] Start New Chat when sandbox is unavailable and verify sandbox stays off
- [ ] Run `pnpm --filter @truefoundry/trueforge-ui test` for touched atom/provider/adapter tests


Made with [Cursor](https://cursor.com)