### PR TITLE
added agent instructions drawer

### DIFF
--- a/.changeset/agent-config-chrome.md
+++ b/.changeset/agent-config-chrome.md
@@ -2,4 +2,4 @@
 "@truefoundry/trueforge-ui": minor
 ---
 
-Keep agent configuration visible on the left in full-width builder layouts, make mobile config overlays closable, save the current instruction draft, align builder chrome, and preserve open widgets across chat runtime changes.
+Keep agent configuration visible on the left in full-width builder layouts, add a responsive instructions and initial-messages drawer with explicit save, make mobile config overlays closable, save the current instruction draft, align builder chrome, and preserve open widgets across chat runtime changes.

--- a/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
+++ b/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
@@ -170,6 +170,10 @@ function SaveAgentButtonContent({
     });
   };
 
+  const updateDraftInstructions = (instructions: string) => {
+    setDraftSpec((current: AgentSpec | null) => (current === null ? null : { ...current, instructions }));
+  };
+
   const isUpdateMode =
     shell?.mode.status === 'active' &&
     shell.mode.isMutable &&
@@ -241,6 +245,8 @@ function SaveAgentButtonContent({
           error={catalog.error}
           skillsDisabled={serverCapabilities?.skill.enabled !== true}
           sandboxAvailable={serverCapabilities?.sandbox.enabled === true}
+          instructions={draftSpec.instructions ?? ''}
+          onInstructionsChange={updateDraftInstructions}
           loadMcpTools={loadMcpTools}
           onRefreshConnectors={catalog.refreshConnectors}
           onChange={setDraftSpec}

--- a/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
+++ b/packages/trueforge-ui/src/atoms/SaveAgentButton.tsx
@@ -170,10 +170,6 @@ function SaveAgentButtonContent({
     });
   };
 
-  const updateDraftInstructions = (instructions: string) => {
-    setDraftSpec((current: AgentSpec | null) => (current === null ? null : { ...current, instructions }));
-  };
-
   const isUpdateMode =
     shell?.mode.status === 'active' &&
     shell.mode.isMutable &&
@@ -245,8 +241,6 @@ function SaveAgentButtonContent({
           error={catalog.error}
           skillsDisabled={serverCapabilities?.skill.enabled !== true}
           sandboxAvailable={serverCapabilities?.sandbox.enabled === true}
-          instructions={draftSpec.instructions ?? ''}
-          onInstructionsChange={updateDraftInstructions}
           loadMcpTools={loadMcpTools}
           onRefreshConnectors={catalog.refreshConnectors}
           onChange={setDraftSpec}

--- a/packages/trueforge-ui/src/atoms/draft/AgentConfigEditors.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentConfigEditors.tsx
@@ -21,8 +21,7 @@ export type AgentConfigEditorsProps = {
   skillsDisabled?: boolean;
   sandboxAvailable?: boolean;
   instructions?: string;
-  onInstructionsChange?: (value: string) => void;
-  onInstructionsBlur?: () => void;
+  onInstructionsSave?: (draft: AgentInstructionsDraft) => void;
   loadMcpTools?: (connectorId: string) => Promise<McpToolSelection[]>;
   onRefreshConnectors?: () => Promise<void>;
   onChange: (spec: AgentSpec) => void;
@@ -40,8 +39,7 @@ export function AgentConfigEditors({
   skillsDisabled = false,
   sandboxAvailable = false,
   instructions,
-  onInstructionsChange,
-  onInstructionsBlur,
+  onInstructionsSave,
   loadMcpTools,
   onRefreshConnectors,
   onChange,
@@ -98,14 +96,16 @@ export function AgentConfigEditors({
   const modelEditor = editor === 'model' || editor === 'model-settings' ? editor : null;
   const resourceEditor = editor === 'mcp' || editor === 'skills' ? editor : null;
   const saveInstructions = (draft: AgentInstructionsDraft) => {
+    if (onInstructionsSave !== undefined) {
+      onInstructionsSave(draft);
+      return;
+    }
     onChange(
       withInitialUserMessages({
         spec: { ...spec, instructions: draft.instructions || undefined },
         messages: draft.messages,
       }),
     );
-    onInstructionsChange?.(draft.instructions);
-    onInstructionsBlur?.();
   };
 
   return (

--- a/packages/trueforge-ui/src/atoms/draft/AgentConfigEditors.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentConfigEditors.tsx
@@ -4,9 +4,11 @@ import { useEffect, useMemo, useState } from 'react';
 
 import type { AgentSkill, AgentSpec, ConnectorState, McpToolSelection, ModelSelection } from '../../server/types.js';
 import { useSlot } from '../../theme/SlotsProvider.js';
+import type { AgentInstructionsDraft } from './AgentInstructionsDrawer.js';
+import { initialUserMessagesFromSpec, withInitialUserMessages } from './agentConfigMessages.js';
 import { editableMountsFromSpec } from './agentConfigMounts.js';
 
-export type AgentConfigEditor = 'model' | 'model-settings' | 'runtime' | 'mcp' | 'skills';
+export type AgentConfigEditor = 'instructions' | 'model' | 'model-settings' | 'runtime' | 'mcp' | 'skills';
 
 export type AgentConfigEditorsProps = {
   editor: AgentConfigEditor | null;
@@ -18,6 +20,9 @@ export type AgentConfigEditorsProps = {
   error: string | null;
   skillsDisabled?: boolean;
   sandboxAvailable?: boolean;
+  instructions?: string;
+  onInstructionsChange?: (value: string) => void;
+  onInstructionsBlur?: () => void;
   loadMcpTools?: (connectorId: string) => Promise<McpToolSelection[]>;
   onRefreshConnectors?: () => Promise<void>;
   onChange: (spec: AgentSpec) => void;
@@ -34,6 +39,9 @@ export function AgentConfigEditors({
   error,
   skillsDisabled = false,
   sandboxAvailable = false,
+  instructions,
+  onInstructionsChange,
+  onInstructionsBlur,
   loadMcpTools,
   onRefreshConnectors,
   onChange,
@@ -42,6 +50,7 @@ export function AgentConfigEditors({
   const AgentModelConfigModal = useSlot('AgentModelConfigModal');
   const AgentResourceConfigModal = useSlot('AgentResourceConfigModal');
   const AgentRuntimeConfigModal = useSlot('AgentRuntimeConfigModal');
+  const AgentInstructionsDrawer = useSlot('AgentInstructionsDrawer');
   const [query, setQuery] = useState('');
   const [activeConnectorId, setActiveConnectorId] = useState<string | null>(null);
   const [tools, setTools] = useState<McpToolSelection[]>([]);
@@ -88,9 +97,28 @@ export function AgentConfigEditors({
 
   const modelEditor = editor === 'model' || editor === 'model-settings' ? editor : null;
   const resourceEditor = editor === 'mcp' || editor === 'skills' ? editor : null;
+  const saveInstructions = (draft: AgentInstructionsDraft) => {
+    onChange(
+      withInitialUserMessages({
+        spec: { ...spec, instructions: draft.instructions || undefined },
+        messages: draft.messages,
+      }),
+    );
+    onInstructionsChange?.(draft.instructions);
+    onInstructionsBlur?.();
+  };
 
   return (
     <>
+      {editor === 'instructions' ? (
+        <AgentInstructionsDrawer
+          open
+          instructions={instructions ?? spec.instructions ?? ''}
+          messages={initialUserMessagesFromSpec(spec)}
+          onSave={saveInstructions}
+          onClose={close}
+        />
+      ) : null}
       {modelEditor ? (
         <AgentModelConfigModal
           editor={modelEditor}

--- a/packages/trueforge-ui/src/atoms/draft/AgentConfigPanel.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentConfigPanel.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { useId, type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { Icon } from '../../icons/Icon.js';
 import type { AgentSpec, ModelSelection } from '../../server/types.js';
 import { useSlot } from '../../theme/SlotsProvider.js';
 import { auiButtonClass } from '../lib/buttonClasses.js';
 import { cn } from '../lib/cn.js';
-import { auiInputClass } from '../lib/inputClasses.js';
 import { Tooltip } from '../primitives/Tooltip.js';
 import type { AgentConfigEditor } from './AgentConfigEditors.js';
+import { initialUserMessagesFromSpec } from './agentConfigMessages.js';
 import {
   editableMountsFromSpec,
   enabledToolsFromMount,
@@ -26,8 +26,6 @@ export type AgentConfigPanelProps = {
   model?: ModelSelection;
   skillsAvailable: boolean;
   instructions: string;
-  onInstructionsChange: (value: string) => void;
-  onInstructionsBlur: () => void;
   onOpenEditor: (editor: AgentConfigEditor) => void;
   onChange?: (spec: AgentSpec) => void;
   onClose?: () => void;
@@ -150,18 +148,17 @@ export function AgentConfigPanel({
   model,
   skillsAvailable,
   instructions,
-  onInstructionsChange,
-  onInstructionsBlur,
   onOpenEditor,
   onChange,
   onClose,
 }: AgentConfigPanelProps) {
-  const instructionsId = useId();
   const Section = useSlot('AgentConfigSection');
   const mcp = editableMountsFromSpec(spec.mcpServers);
   const skills = editableMountsFromSpec(spec.skills);
   const modelParams = modelParamSummary(spec.model.params);
   const runtimeConfig = runtimeConfigSummary(spec.config);
+  const instructionPreview = instructions.trim();
+  const userMessageCount = initialUserMessagesFromSpec(spec).length;
   const modelInfo = [
     model?.properties.contextLength === undefined ? null : formatTokens(model.properties.contextLength),
   ].filter((value): value is string => value !== null);
@@ -247,18 +244,27 @@ export function AgentConfigPanel({
         </Section>
 
         <Section title="Instructions" description="Define the agent's role, goals, and behavior.">
-          <label htmlFor={instructionsId} className="sr-only">
-            Agent instructions
-          </label>
-          <textarea
-            id={instructionsId}
-            value={instructions}
-            rows={5}
-            placeholder="Enter detailed instructions for your agent…"
-            className={auiInputClass('resize-y py-2')}
-            onChange={event => onInstructionsChange(event.target.value)}
-            onBlur={onInstructionsBlur}
-          />
+          <button
+            type="button"
+            aria-label="Edit Instructions"
+            className="border-border hover:bg-ghost-button-hover flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-colors"
+            onClick={() => onOpenEditor('instructions')}
+          >
+            <div className="min-w-0 flex-1">
+              <p
+                className={cn(
+                  'line-clamp-3 whitespace-pre-wrap text-sm',
+                  instructionPreview ? 'text-text-primary' : 'text-text-secondary',
+                )}
+              >
+                {instructionPreview || 'No instructions added.'}
+              </p>
+              <p className="text-text-secondary mt-2 text-xs">
+                {userMessageCount} user {userMessageCount === 1 ? 'message' : 'messages'}
+              </p>
+            </div>
+            <Icon name="chevron-right" className="text-text-secondary size-4 shrink-0" />
+          </button>
         </Section>
 
         <Section

--- a/packages/trueforge-ui/src/atoms/draft/AgentInstructionsDrawer.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentInstructionsDrawer.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import type { TrueForgeApi } from '@truefoundry/trueforge-sdk';
+import { useId, useRef, useState } from 'react';
+
+import { Icon } from '../../icons/Icon.js';
+import { auiButtonClass } from '../lib/buttonClasses.js';
+import { auiInputClass } from '../lib/inputClasses.js';
+import { SideDrawer } from '../primitives/SideDrawer.js';
+
+type UserMessageDraft = {
+  id: number;
+  content: string;
+};
+
+export type AgentInstructionsDraft = {
+  instructions: string;
+  messages: TrueForgeApi.InitialUserMessage[];
+};
+
+export type AgentInstructionsDrawerProps = {
+  open: boolean;
+  instructions: string;
+  messages?: TrueForgeApi.InitialUserMessage[];
+  onSave: (draft: AgentInstructionsDraft) => void;
+  onClose: () => void;
+};
+
+function persistedMessages(rows: UserMessageDraft[]): TrueForgeApi.InitialUserMessage[] {
+  return rows.filter(row => row.content.trim().length > 0).map(row => ({ type: 'user.message', content: row.content }));
+}
+
+export function AgentInstructionsDrawer({
+  open,
+  instructions,
+  messages = [],
+  onSave,
+  onClose,
+}: AgentInstructionsDrawerProps) {
+  const fieldId = useId();
+  const nextMessageId = useRef(messages.length);
+  const [instructionDraft, setInstructionDraft] = useState(instructions);
+  const [messageDrafts, setMessageDrafts] = useState<UserMessageDraft[]>(() =>
+    messages.map((message, id) => ({ id, content: message.content })),
+  );
+
+  const updateMessageDrafts = (next: UserMessageDraft[]) => {
+    setMessageDrafts(next);
+  };
+
+  const addUserMessage = () => {
+    const next = [...messageDrafts, { id: nextMessageId.current, content: '' }];
+    nextMessageId.current += 1;
+    setMessageDrafts(next);
+  };
+
+  const updateUserMessage = ({ id, content }: UserMessageDraft) => {
+    updateMessageDrafts(messageDrafts.map(message => (message.id === id ? { id, content } : message)));
+  };
+
+  const removeUserMessage = (id: number) => {
+    updateMessageDrafts(messageDrafts.filter(message => message.id !== id));
+  };
+
+  const save = () => {
+    onSave({ instructions: instructionDraft, messages: persistedMessages(messageDrafts) });
+    onClose();
+  };
+
+  return (
+    <SideDrawer
+      open={open}
+      onOpenChange={nextOpen => !nextOpen && onClose()}
+      title="Instructions"
+      description="Define the agent behavior and messages added at the start of every session."
+      anchor="right"
+      size="lg"
+      aria-label="Edit Instructions"
+      footer={
+        <div className="flex justify-end">
+          <button type="button" className={auiButtonClass({ variant: 'default' })} onClick={save}>
+            Save
+          </button>
+        </div>
+      }
+    >
+      <div className="flex min-h-0 flex-1 flex-col gap-6 p-5">
+        <section>
+          <label htmlFor={`${fieldId}-instructions`} className="text-text-primary text-sm font-semibold">
+            Agent instructions
+          </label>
+          <p className="text-text-secondary mt-1 text-xs">Describe the agent&apos;s role, goals, and constraints.</p>
+          <textarea
+            id={`${fieldId}-instructions`}
+            value={instructionDraft}
+            rows={14}
+            placeholder="Enter detailed instructions for your agent…"
+            className={auiInputClass('mt-3 min-h-64 resize-y py-3')}
+            onChange={event => setInstructionDraft(event.target.value)}
+          />
+        </section>
+
+        <section className="border-border border-t pt-5">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h3 className="text-text-primary text-sm font-semibold">User Messages</h3>
+              <p className="text-text-secondary mt-1 text-xs">Add initial messages to every new agent session.</p>
+            </div>
+            <button
+              type="button"
+              className={auiButtonClass({ variant: 'outline', size: 'sm' })}
+              onClick={addUserMessage}
+            >
+              <Icon name="plus" className="size-3.5" />
+              Add User Message
+            </button>
+          </div>
+
+          {messageDrafts.length > 0 ? (
+            <div className="mt-4 flex flex-col gap-4">
+              {messageDrafts.map((message, index) => {
+                const messageId = `${fieldId}-user-message-${message.id}`;
+                return (
+                  <div key={message.id} className="border-border rounded-lg border p-3">
+                    <div className="mb-2 flex items-center gap-2">
+                      <Icon name="user" className="text-text-secondary size-4" />
+                      <label htmlFor={messageId} className="text-text-primary flex-1 text-sm font-medium">
+                        User Message {index + 1}
+                      </label>
+                      <button
+                        type="button"
+                        aria-label={`Remove User Message ${index + 1}`}
+                        className={auiButtonClass({ variant: 'ghost', size: 'icon', className: 'size-7' })}
+                        onClick={() => removeUserMessage(message.id)}
+                      >
+                        <Icon name="trash" className="size-3.5" />
+                      </button>
+                    </div>
+                    <textarea
+                      id={messageId}
+                      value={message.content}
+                      rows={4}
+                      placeholder="Type message content…"
+                      className={auiInputClass('min-h-24 resize-y py-2')}
+                      onChange={event => updateUserMessage({ id: message.id, content: event.target.value })}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-text-secondary mt-4 text-sm">No initial user messages.</p>
+          )}
+        </section>
+      </div>
+    </SideDrawer>
+  );
+}
+
+declare module '../../theme/SlotsProvider.js' {
+  interface AtomSlots {
+    AgentInstructionsDrawer: typeof AgentInstructionsDrawer;
+  }
+}

--- a/packages/trueforge-ui/src/atoms/draft/agentConfigMessages.ts
+++ b/packages/trueforge-ui/src/atoms/draft/agentConfigMessages.ts
@@ -1,0 +1,25 @@
+import type { TrueForgeApi } from '@truefoundry/trueforge-sdk';
+
+import type { AgentSpec } from '../../server/types.js';
+
+function isInitialUserMessage(value: unknown): value is TrueForgeApi.InitialUserMessage {
+  if (typeof value !== 'object' || value === null) return false;
+  return Reflect.get(value, 'type') === 'user.message' && typeof Reflect.get(value, 'content') === 'string';
+}
+
+// Adapts the SDK-owned messages field until the UI runtime contract exposes it
+export function initialUserMessagesFromSpec(spec: AgentSpec): TrueForgeApi.InitialUserMessage[] {
+  const value: unknown = Reflect.get(spec, 'messages');
+  return Array.isArray(value) ? value.filter(isInitialUserMessage) : [];
+}
+
+export function withInitialUserMessages({
+  spec,
+  messages,
+}: {
+  spec: AgentSpec;
+  messages: TrueForgeApi.InitialUserMessage[];
+}): AgentSpec {
+  const next = { ...spec, messages: messages.length > 0 ? messages : undefined };
+  return next;
+}

--- a/packages/trueforge-ui/src/containers/AgentConfigDrawerContainer.tsx
+++ b/packages/trueforge-ui/src/containers/AgentConfigDrawerContainer.tsx
@@ -106,8 +106,6 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
         model={model}
         skillsAvailable={capabilities?.skill.enabled === true}
         instructions={instructionDraft}
-        onInstructionsChange={onInstructionChange}
-        onInstructionsBlur={flushInstructions}
         onOpenEditor={setEditor}
         onChange={updateSpec}
         onClose={showClose ? closeDrawer : undefined}
@@ -122,6 +120,9 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
         error={catalog.error}
         skillsDisabled={capabilities?.skill.enabled !== true}
         sandboxAvailable={capabilities?.sandbox.enabled === true}
+        instructions={instructionDraft}
+        onInstructionsChange={onInstructionChange}
+        onInstructionsBlur={flushInstructions}
         loadMcpTools={loadMcpTools}
         onRefreshConnectors={catalog.refreshConnectors}
         onChange={updateSpec}

--- a/packages/trueforge-ui/src/containers/AgentConfigDrawerContainer.tsx
+++ b/packages/trueforge-ui/src/containers/AgentConfigDrawerContainer.tsx
@@ -9,7 +9,9 @@ import { useCallback, useEffect, useState } from 'react';
 
 import type { AgentConfigEditor } from '../atoms/draft/AgentConfigEditors.js';
 import { useAgentConfigInstructions } from '../atoms/draft/AgentConfigInstructionsContext.js';
+import type { AgentInstructionsDraft } from '../atoms/draft/AgentInstructionsDrawer.js';
 import { useDraftCatalog } from '../atoms/draft/DraftCatalogProvider.js';
+import { withInitialUserMessages } from '../atoms/draft/agentConfigMessages.js';
 import { useOptionalServer, useServerCapabilities } from '../server/ServerContext.js';
 import { shellIsCreateAgent, useShellMode } from '../server/ShellModeContext.js';
 import type { AgentSpec, McpToolSelection } from '../server/types.js';
@@ -27,11 +29,7 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
   const AgentConfigEditors = useSlot('AgentConfigEditors');
   const [editor, setEditor] = useState<AgentConfigEditor | null>(null);
   const isBuilder = shellIsCreateAgent(shell.mode);
-  const {
-    draft: instructionDraft,
-    onChange: onInstructionChange,
-    flush: flushInstructions,
-  } = useAgentConfigInstructions();
+  const { draft: instructionDraft, flush: flushInstructions } = useAgentConfigInstructions();
   const closeDrawer = useCallback(() => {
     flushInstructions();
     void flushAgentSpec();
@@ -67,12 +65,12 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
     [flushAgentSpec, flushInstructions],
   );
 
-  const updateSpec = useCallback(
-    (next: AgentSpec) => {
+  const commitSpec = useCallback(
+    ({ next, instructions }: { next: AgentSpec; instructions: string }) => {
       if (next.skills && next.skills.length > 0 && capabilities?.sandbox.enabled === true) {
         updateAgentSpec?.({
           ...next,
-          instructions: instructionDraft,
+          instructions: instructions || undefined,
           config: {
             ...next.config,
             sandbox: { ...next.config?.sandbox, enabled: true },
@@ -80,9 +78,27 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
         });
         return;
       }
-      updateAgentSpec?.({ ...next, instructions: instructionDraft });
+      updateAgentSpec?.({ ...next, instructions: instructions || undefined });
     },
-    [capabilities?.sandbox.enabled, instructionDraft, updateAgentSpec],
+    [capabilities?.sandbox.enabled, updateAgentSpec],
+  );
+
+  const updateSpec = useCallback(
+    (next: AgentSpec) => {
+      commitSpec({ next, instructions: instructionDraft });
+    },
+    [commitSpec, instructionDraft],
+  );
+
+  const saveInstructions = useCallback(
+    (draft: AgentInstructionsDraft) => {
+      if (agentSpec === null) return;
+      commitSpec({
+        next: withInitialUserMessages({ spec: agentSpec, messages: draft.messages }),
+        instructions: draft.instructions,
+      });
+    },
+    [agentSpec, commitSpec],
   );
 
   const loadMcpTools = useCallback(
@@ -121,8 +137,7 @@ export function AgentConfigDrawerContainer({ showClose = false }: { showClose?: 
         skillsDisabled={capabilities?.skill.enabled !== true}
         sandboxAvailable={capabilities?.sandbox.enabled === true}
         instructions={instructionDraft}
-        onInstructionsChange={onInstructionChange}
-        onInstructionsBlur={flushInstructions}
+        onInstructionsSave={saveInstructions}
         loadMcpTools={loadMcpTools}
         onRefreshConnectors={catalog.refreshConnectors}
         onChange={updateSpec}

--- a/packages/trueforge-ui/src/index.ts
+++ b/packages/trueforge-ui/src/index.ts
@@ -464,6 +464,8 @@ export { AgentConfigEditors } from './atoms/draft/AgentConfigEditors.js';
 export type { AgentConfigEditor, AgentConfigEditorsProps } from './atoms/draft/AgentConfigEditors.js';
 export { AgentConfigPanel, AgentConfigSection } from './atoms/draft/AgentConfigPanel.js';
 export type { AgentConfigPanelProps } from './atoms/draft/AgentConfigPanel.js';
+export { AgentInstructionsDrawer } from './atoms/draft/AgentInstructionsDrawer.js';
+export type { AgentInstructionsDrawerProps } from './atoms/draft/AgentInstructionsDrawer.js';
 export { AgentMcpEditorContent } from './atoms/draft/AgentMcpEditorContent.js';
 export type { AgentMcpEditorContentProps } from './atoms/draft/AgentMcpEditorContent.js';
 export { AgentModelConfigModal } from './atoms/draft/AgentModelConfigModal.js';

--- a/packages/trueforge-ui/src/theme/defaultSlots.ts
+++ b/packages/trueforge-ui/src/theme/defaultSlots.ts
@@ -43,6 +43,7 @@ import { ComposerLeftSection, ComposerRightSection, ComposerSendButton } from '.
 import { ComposerShell } from '../atoms/ComposerShell.js';
 import { AgentConfigEditors } from '../atoms/draft/AgentConfigEditors.js';
 import { AgentConfigPanel, AgentConfigSection } from '../atoms/draft/AgentConfigPanel.js';
+import { AgentInstructionsDrawer } from '../atoms/draft/AgentInstructionsDrawer.js';
 import { AgentMcpEditorContent } from '../atoms/draft/AgentMcpEditorContent.js';
 import { AgentModelConfigModal } from '../atoms/draft/AgentModelConfigModal.js';
 import { AgentModelEditorContent } from '../atoms/draft/AgentModelEditorContent.js';
@@ -145,6 +146,7 @@ export const defaultSlots = {
   DraftAgentConfigTrigger,
   DraftCapabilitiesPanel,
   AgentConfigEditors,
+  AgentInstructionsDrawer,
   AgentModelEditorContent,
   AgentModelSettingsContent,
   AgentMcpEditorContent,

--- a/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { AgentConfigEditors } from '@/atoms/draft/AgentConfigEditors.js';
+import { withInitialUserMessages } from '@/atoms/draft/agentConfigMessages.js';
 import type { AgentSpec } from '@/server/types.js';
 import { SlotsProvider } from '@/theme/SlotsProvider.js';
 
@@ -17,6 +18,118 @@ beforeAll(() => {
 });
 
 describe('AgentConfigEditors', () => {
+  it('edits instructions and initial user messages in a drawer', () => {
+    const baseSpec: AgentSpec = { model: { name: 'openai/gpt' } };
+    const spec = withInitialUserMessages({
+      spec: baseSpec,
+      messages: [{ type: 'user.message', content: 'Existing message' }],
+    });
+    const onInstructionsChange = vi.fn();
+    const onChange = vi.fn();
+
+    render(
+      <SlotsProvider>
+        <AgentConfigEditors
+          editor="instructions"
+          spec={spec}
+          models={[]}
+          connectors={[]}
+          skills={[]}
+          loading={false}
+          error={null}
+          instructions="Existing instructions"
+          onInstructionsChange={onInstructionsChange}
+          onChange={onChange}
+          onClose={vi.fn()}
+        />
+      </SlotsProvider>,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Instructions' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Agent instructions')).toHaveClass('min-h-64');
+
+    fireEvent.change(screen.getByLabelText('Agent instructions'), {
+      target: { value: 'Updated instructions' },
+    });
+    expect(onInstructionsChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add User Message' }));
+    fireEvent.change(screen.getByLabelText('User Message 2'), {
+      target: { value: 'New message' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Remove User Message 1' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onInstructionsChange).toHaveBeenCalledWith('Updated instructions');
+    expect(onChange).toHaveBeenCalledWith(
+      withInitialUserMessages({
+        spec: { ...spec, instructions: 'Updated instructions' },
+        messages: [{ type: 'user.message', content: 'New message' }],
+      }),
+    );
+  });
+
+  it('does not persist blank initial user messages', () => {
+    const spec: AgentSpec = { model: { name: 'openai/gpt' } };
+    const onChange = vi.fn();
+
+    render(
+      <SlotsProvider>
+        <AgentConfigEditors
+          editor="instructions"
+          spec={spec}
+          models={[]}
+          connectors={[]}
+          skills={[]}
+          loading={false}
+          error={null}
+          onChange={onChange}
+          onClose={vi.fn()}
+        />
+      </SlotsProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add User Message' }));
+    fireEvent.change(screen.getByLabelText('User Message 1'), { target: { value: '   ' } });
+
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onChange).toHaveBeenCalledWith(withInitialUserMessages({ spec, messages: [] }));
+  });
+
+  it('discards instruction changes when the drawer closes without saving', () => {
+    const spec: AgentSpec = { model: { name: 'openai/gpt' }, instructions: 'Original' };
+    const onInstructionsChange = vi.fn();
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <SlotsProvider>
+        <AgentConfigEditors
+          editor="instructions"
+          spec={spec}
+          models={[]}
+          connectors={[]}
+          skills={[]}
+          loading={false}
+          error={null}
+          onInstructionsChange={onInstructionsChange}
+          onChange={onChange}
+          onClose={onClose}
+        />
+      </SlotsProvider>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Agent instructions'), { target: { value: 'Discarded' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(onInstructionsChange).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
   it('renders model context metadata', () => {
     render(
       <SlotsProvider>

--- a/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
@@ -24,7 +24,7 @@ describe('AgentConfigEditors', () => {
       spec: baseSpec,
       messages: [{ type: 'user.message', content: 'Existing message' }],
     });
-    const onInstructionsChange = vi.fn();
+    const onInstructionsSave = vi.fn();
     const onChange = vi.fn();
 
     render(
@@ -38,7 +38,7 @@ describe('AgentConfigEditors', () => {
           loading={false}
           error={null}
           instructions="Existing instructions"
-          onInstructionsChange={onInstructionsChange}
+          onInstructionsSave={onInstructionsSave}
           onChange={onChange}
           onClose={vi.fn()}
         />
@@ -51,7 +51,7 @@ describe('AgentConfigEditors', () => {
     fireEvent.change(screen.getByLabelText('Agent instructions'), {
       target: { value: 'Updated instructions' },
     });
-    expect(onInstructionsChange).not.toHaveBeenCalled();
+    expect(onInstructionsSave).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Add User Message' }));
     fireEvent.change(screen.getByLabelText('User Message 2'), {
@@ -62,13 +62,11 @@ describe('AgentConfigEditors', () => {
     expect(onChange).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    expect(onInstructionsChange).toHaveBeenCalledWith('Updated instructions');
-    expect(onChange).toHaveBeenCalledWith(
-      withInitialUserMessages({
-        spec: { ...spec, instructions: 'Updated instructions' },
-        messages: [{ type: 'user.message', content: 'New message' }],
-      }),
-    );
+    expect(onInstructionsSave).toHaveBeenCalledWith({
+      instructions: 'Updated instructions',
+      messages: [{ type: 'user.message', content: 'New message' }],
+    });
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('does not persist blank initial user messages', () => {
@@ -101,7 +99,7 @@ describe('AgentConfigEditors', () => {
 
   it('discards instruction changes when the drawer closes without saving', () => {
     const spec: AgentSpec = { model: { name: 'openai/gpt' }, instructions: 'Original' };
-    const onInstructionsChange = vi.fn();
+    const onInstructionsSave = vi.fn();
     const onChange = vi.fn();
     const onClose = vi.fn();
 
@@ -115,7 +113,7 @@ describe('AgentConfigEditors', () => {
           skills={[]}
           loading={false}
           error={null}
-          onInstructionsChange={onInstructionsChange}
+          onInstructionsSave={onInstructionsSave}
           onChange={onChange}
           onClose={onClose}
         />
@@ -125,7 +123,7 @@ describe('AgentConfigEditors', () => {
     fireEvent.change(screen.getByLabelText('Agent instructions'), { target: { value: 'Discarded' } });
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
 
-    expect(onInstructionsChange).not.toHaveBeenCalled();
+    expect(onInstructionsSave).not.toHaveBeenCalled();
     expect(onChange).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledOnce();
   });

--- a/packages/trueforge-ui/test/atoms/draft/AgentConfigPanel.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/AgentConfigPanel.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AgentConfigPanel } from '@/atoms/draft/AgentConfigPanel.js';
+import { withInitialUserMessages } from '@/atoms/draft/agentConfigMessages.js';
 import type { AgentSpec, ModelSelection } from '@/server/types.js';
 import { SlotsProvider } from '@/theme/SlotsProvider.js';
 
@@ -43,8 +44,6 @@ describe('AgentConfigPanel', () => {
           model={model}
           skillsAvailable
           instructions={spec.instructions ?? ''}
-          onInstructionsChange={vi.fn()}
-          onInstructionsBlur={vi.fn()}
           onOpenEditor={vi.fn()}
         />
       </SlotsProvider>,
@@ -78,8 +77,7 @@ describe('AgentConfigPanel', () => {
     );
   });
 
-  it('routes editor actions and live instruction changes', () => {
-    const onInstructionsChange = vi.fn();
+  it('routes editor actions from the configuration summary', () => {
     const onOpenEditor = vi.fn();
     render(
       <SlotsProvider>
@@ -88,8 +86,6 @@ describe('AgentConfigPanel', () => {
           model={model}
           skillsAvailable
           instructions={spec.instructions ?? ''}
-          onInstructionsChange={onInstructionsChange}
-          onInstructionsBlur={vi.fn()}
           onOpenEditor={onOpenEditor}
         />
       </SlotsProvider>,
@@ -101,10 +97,33 @@ describe('AgentConfigPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Edit Runtime Config' }));
     expect(onOpenEditor).toHaveBeenCalledWith('runtime');
 
-    fireEvent.change(screen.getByPlaceholderText('Enter detailed instructions for your agent…'), {
-      target: { value: 'New instructions' },
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Instructions' }));
+    expect(onOpenEditor).toHaveBeenCalledWith('instructions');
+  });
+
+  it('previews instructions and summarizes initial user messages', () => {
+    const specWithMessages = withInitialUserMessages({
+      spec,
+      messages: [
+        { type: 'user.message', content: 'First prompt' },
+        { type: 'user.message', content: 'Second prompt' },
+      ],
     });
-    expect(onInstructionsChange).toHaveBeenCalledWith('New instructions');
+
+    render(
+      <SlotsProvider>
+        <AgentConfigPanel
+          spec={specWithMessages}
+          model={model}
+          skillsAvailable
+          instructions="Use the configured tools carefully."
+          onOpenEditor={vi.fn()}
+        />
+      </SlotsProvider>,
+    );
+
+    expect(screen.getByText('Use the configured tools carefully.')).toBeInTheDocument();
+    expect(screen.getByText('2 user messages')).toBeInTheDocument();
   });
 
   it('removes an MCP server directly from its config chip', () => {
@@ -116,8 +135,6 @@ describe('AgentConfigPanel', () => {
           model={model}
           skillsAvailable
           instructions={spec.instructions ?? ''}
-          onInstructionsChange={vi.fn()}
-          onInstructionsBlur={vi.fn()}
           onOpenEditor={vi.fn()}
           onChange={onChange}
         />
@@ -137,8 +154,6 @@ describe('AgentConfigPanel', () => {
           model={model}
           skillsAvailable
           instructions={spec.instructions ?? ''}
-          onInstructionsChange={vi.fn()}
-          onInstructionsBlur={vi.fn()}
           onOpenEditor={vi.fn()}
           onChange={onChange}
         />
@@ -161,8 +176,6 @@ describe('AgentConfigPanel', () => {
           model={model}
           skillsAvailable
           instructions={spec.instructions ?? ''}
-          onInstructionsChange={vi.fn()}
-          onInstructionsBlur={vi.fn()}
           onOpenEditor={onOpenEditor}
           onChange={vi.fn()}
         />
@@ -181,8 +194,6 @@ describe('AgentConfigPanel', () => {
           model={model}
           skillsAvailable
           instructions={spec.instructions ?? ''}
-          onInstructionsChange={vi.fn()}
-          onInstructionsBlur={vi.fn()}
           onOpenEditor={vi.fn()}
         />
       </SlotsProvider>,
@@ -202,8 +213,6 @@ describe('AgentConfigPanel', () => {
           model={model}
           skillsAvailable
           instructions={spec.instructions ?? ''}
-          onInstructionsChange={vi.fn()}
-          onInstructionsBlur={vi.fn()}
           onOpenEditor={vi.fn()}
           onClose={onClose}
         />

--- a/packages/trueforge-ui/test/containers/AgentConfigDrawerContainer.test.tsx
+++ b/packages/trueforge-ui/test/containers/AgentConfigDrawerContainer.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SaveAgentButton } from '@/atoms/SaveAgentButton.js';
 import { AgentConfigInstructionsProvider } from '@/atoms/draft/AgentConfigInstructionsContext.js';
@@ -11,6 +11,7 @@ import { SlotsProvider } from '@/theme/SlotsProvider.js';
 import { createMockAgentUIServer } from '../server/mockServer.js';
 
 const flushAgentSpec = vi.fn(async () => undefined);
+const updateAgentSpec = vi.fn();
 
 vi.mock('@truefoundry/assistant-ui-runtime', () => ({
   useTrueFoundryAgentSpec: () => ({
@@ -18,7 +19,7 @@ vi.mock('@truefoundry/assistant-ui-runtime', () => ({
     draftSessionId: 'draft-1',
   }),
   useTrueFoundryFlushAgentSpec: () => flushAgentSpec,
-  useTrueFoundryUpdateAgentSpec: () => vi.fn(),
+  useTrueFoundryUpdateAgentSpec: () => updateAgentSpec,
   useTrueFoundryAdoptAgentSpec: () => vi.fn(),
 }));
 
@@ -30,6 +31,10 @@ beforeAll(() => {
     this.removeAttribute('open');
     this.dispatchEvent(new Event('close'));
   };
+});
+
+beforeEach(() => {
+  updateAgentSpec.mockReset();
 });
 
 function TestView({ compact = true }: { compact?: boolean }) {
@@ -96,5 +101,33 @@ describe('AgentConfigDrawerContainer', () => {
 
     expect(screen.getByTestId('config-open')).toHaveTextContent('true');
     expect(screen.queryByRole('button', { name: 'Close agent config' })).not.toBeInTheDocument();
+  });
+
+  it('commits drawer instructions and messages in one spec update', () => {
+    render(
+      <SlotsProvider>
+        <ServerProvider server={createMockAgentUIServer()}>
+          <ShellModeProvider agentConfig={{ mode: 'AgentComposer' }}>
+            <AgentConfigInstructionsProvider>
+              <TestView compact={false} />
+            </AgentConfigInstructionsProvider>
+          </ShellModeProvider>
+        </ServerProvider>
+      </SlotsProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open config' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Instructions' }));
+    fireEvent.change(screen.getByLabelText('Agent instructions'), { target: { value: 'Updated instructions' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add User Message' }));
+    fireEvent.change(screen.getByLabelText('User Message 1'), { target: { value: 'Start here' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(updateAgentSpec).toHaveBeenCalledOnce();
+    expect(updateAgentSpec).toHaveBeenCalledWith({
+      model: { name: 'openai/gpt-4.1' },
+      instructions: 'Updated instructions',
+      messages: [{ type: 'user.message', content: 'Start here' }],
+    });
   });
 });

--- a/packages/trueforge-ui/test/publicUiExports.test.ts
+++ b/packages/trueforge-ui/test/publicUiExports.test.ts
@@ -11,6 +11,7 @@ const expectedRuntimeExports: Array<keyof typeof sdk> = [
   'AgentDetailsPage',
   'AgentDetailsTabs',
   'AgentDetailsUnavailable',
+  'AgentInstructionsDrawer',
   'AgentModelEditorContent',
   'AgentModelConfigModal',
   'AgentModelSettingsContent',


### PR DESCRIPTION
## Summary

https://linear.app/truefoundry/issue/FRONTEN-2452/agent-builder-make-instructions-experience-same-as-our-product


<img width="1519" height="1311" alt="Screenshot 2026-09-04 at 7 12 47 PM" src="https://github.com/user-attachments/assets/d706c2b1-8a9c-4840-ba90-0fe100a4391b" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how agent instructions are edited and persisted, and introduces initial `messages` on the agent spec alongside existing instruction draft behavior.
> 
> **Overview**
> Replaces the **inline instructions textarea** in the agent config panel with a **summary row** (preview + initial user message count) that opens a dedicated **`instructions` editor**.
> 
> The new **`AgentInstructionsDrawer`** uses a right **`SideDrawer`** to edit agent instructions and **session-start user messages** (add/remove rows), with **explicit Save**; closing without saving discards edits. **`agentConfigMessages`** reads/writes `spec.messages` via SDK-shaped helpers until the UI type exposes the field.
> 
> **`AgentConfigDrawerContainer`** commits instructions and messages in a **single** `updateAgentSpec` on Save; the panel no longer wires live `onInstructionsChange` / blur flush for that section. **`AgentInstructionsDrawer`** is exported and registered as a default slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89bc7d80d7389b81d6c44609f70ef19051a683b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->