### PR TITLE
[Authz 4/N]: RBAC changes for listing agents, schedules, sessions

### DIFF
--- a/.changeset/agent-session-schedule-rbac.md
+++ b/.changeset/agent-session-schedule-rbac.md
@@ -1,0 +1,8 @@
+---
+'@truefoundry/trueforge-core': minor
+'@truefoundry/trueforge': minor
+---
+
+Agent access is decided only by the `Authorizer`: standalone/OIDC lets everyone list and use agents and restricts update/delete to the creator; TrueFoundry uses external permissions api.
+
+You can read a session, turn, events, metrics, schedule, or its runs if you created it, or if you manage the named agent it is bound to. Creating still requires permission to use that agent. Only the creator can update, delete, or cancel a session, create a turn, or download sandbox files. Only the creator can update, delete, pause, resume, or run a schedule. An OIDC settings admin can no longer see other users' schedules.

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -6704,7 +6704,7 @@
     },
     "/api/v1/schedules/{schedule_id}/runs": {
       "get": {
-        "description": "List runs of a schedule, newest `scheduled_for` first. Only the schedule creator (or an admin) may list its runs.",
+        "description": "List runs of a schedule, newest `scheduled_for` first. Available to its creator or a manager of its agent.",
         "parameters": [
           {
             "description": "Immutable schedule identifier.",
@@ -6738,7 +6738,7 @@
                 }
               }
             },
-            "description": "The caller is not the schedule creator."
+            "description": "The caller cannot read the schedule."
           },
           "404": {
             "content": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6704,7 +6704,7 @@
     },
     "/api/v1/schedules/{schedule_id}/runs": {
       "get": {
-        "description": "List runs of a schedule, newest `scheduled_for` first. Only the schedule creator (or an admin) may list its runs.",
+        "description": "List runs of a schedule, newest `scheduled_for` first. Available to its creator or a manager of its agent.",
         "parameters": [
           {
             "description": "Immutable schedule identifier.",
@@ -6738,7 +6738,7 @@
                 }
               }
             },
-            "description": "The caller is not the schedule creator."
+            "description": "The caller cannot read the schedule."
           },
           "404": {
             "content": {

--- a/packages/trueforge-core/src/agent-session/store/ISessionStore.ts
+++ b/packages/trueforge-core/src/agent-session/store/ISessionStore.ts
@@ -64,8 +64,13 @@ export interface ListSessionsInput {
   end_timestamp: Date | undefined;
   /** When set, only sessions bound to this named agent id. */
   agent_id: string | undefined;
-  /** When set, only sessions whose `created_by_subject.subject_id` matches. */
-  created_by_subject_id: string | undefined;
+  /** When set, match creator or named-agent binding. Empty `agent_ids` means creator-only. */
+  created_by_or_agent_ids:
+    | {
+        created_by_subject_id: string;
+        agent_ids: readonly string[];
+      }
+    | undefined;
 }
 
 /** Turn row fields without assembled snapshot (create input / listTurns). */
@@ -256,9 +261,9 @@ export interface ISessionStore<
    * (`order` defaults to `desc`, `session_id` tie-break). `page_token` is a
    * keyset cursor on `(updated_at, session_id)`. `start_timestamp` /
    * `end_timestamp` are inclusive instant bounds on `created_at`. Optional
-   * `agent_id` filters ref-bound sessions; optional `created_by_subject_id`
-   * filters by `created_by_subject.subject_id`. Does **not** bump
-   * `last_activity_timestamp_ms` (read path).
+   * `agent_id` filters ref-bound sessions. `created_by_or_agent_ids` matches
+   * rows created by its subject OR bound to one of its agent ids. Does **not**
+   * bump `last_activity_timestamp_ms` (read path).
    */
   listSessions(
     input: ListSessionsInput,

--- a/packages/trueforge-core/src/agent-session/store/InMemorySessionStore.ts
+++ b/packages/trueforge-core/src/agent-session/store/InMemorySessionStore.ts
@@ -263,6 +263,7 @@ export class InMemorySessionStore<
     input: ListSessionsInput,
   ): Promise<{ data: SessionRecord<TSessionCustom>[]; pagination: TokenPagination }> {
     const records: SessionRecord<TSessionCustom>[] = [];
+    const createdByOrAgentIds = input.created_by_or_agent_ids;
     for (const stored of this.sessions.values()) {
       if (stored.record.tenant_id !== input.tenant_id) {
         continue;
@@ -273,11 +274,14 @@ export class InMemorySessionStore<
       ) {
         continue;
       }
-      if (
-        input.created_by_subject_id !== undefined &&
-        stored.record.created_by_subject.subject_id !== input.created_by_subject_id
-      ) {
-        continue;
+      if (createdByOrAgentIds !== undefined) {
+        const creatorMatches =
+          stored.record.created_by_subject.subject_id === createdByOrAgentIds.created_by_subject_id;
+        const agentMatches =
+          stored.record.agent.type === 'reference' && createdByOrAgentIds.agent_ids.includes(stored.record.agent.id);
+        if (!creatorMatches && !agentMatches) {
+          continue;
+        }
       }
       const createdAt = stored.record.created_at.getTime();
       if (input.start_timestamp !== undefined && createdAt < input.start_timestamp.getTime()) {

--- a/packages/trueforge-core/tests/agent-session/store/storeContractSuite.ts
+++ b/packages/trueforge-core/tests/agent-session/store/storeContractSuite.ts
@@ -215,7 +215,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
         start_timestamp: undefined,
         end_timestamp: undefined,
         agent_id: undefined,
-        created_by_subject_id: undefined,
+        created_by_or_agent_ids: undefined,
       });
       expect(listed.data.map(s => s.session_id)).toContain('created-by-session');
       expect(listed.data.find(s => s.session_id === 'created-by-session')?.created_by_subject.subject_id).toBe(
@@ -241,7 +241,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
       const filtered = await store.listSessions({
         agent_id: 'agent-abc',
-        created_by_subject_id: undefined,
+        created_by_or_agent_ids: undefined,
         tenant_id: tenant,
         limit: 10,
         page_token: undefined,
@@ -578,7 +578,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
       const listed = await store.listSessions({
         agent_id: undefined,
-        created_by_subject_id: undefined,
+        created_by_or_agent_ids: undefined,
         tenant_id: tenant,
         limit: 10,
         page_token: undefined,
@@ -834,7 +834,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
       const desc = await store.listSessions({
         agent_id: undefined,
-        created_by_subject_id: undefined,
+        created_by_or_agent_ids: undefined,
         tenant_id: tenant,
         limit: 10,
         page_token: undefined,
@@ -846,7 +846,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
       const asc = await store.listSessions({
         agent_id: undefined,
-        created_by_subject_id: undefined,
+        created_by_or_agent_ids: undefined,
         tenant_id: tenant,
         limit: 10,
         page_token: undefined,
@@ -863,7 +863,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
       const first = await store.listSessions({
         agent_id: undefined,
-        created_by_subject_id: undefined,
+        created_by_or_agent_ids: undefined,
         tenant_id: tenant,
         limit: 2,
         page_token: undefined,
@@ -875,7 +875,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       expect(first.pagination.next_page_token).toBeDefined();
       const second = await store.listSessions({
         agent_id: undefined,
-        created_by_subject_id: undefined,
+        created_by_or_agent_ids: undefined,
         tenant_id: tenant,
         limit: 2,
         page_token: first.pagination.next_page_token,
@@ -888,7 +888,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
       const all = await store.listSessions({
         agent_id: undefined,
-        created_by_subject_id: undefined,
+        created_by_or_agent_ids: undefined,
         tenant_id: tenant,
         limit: 10,
         page_token: undefined,
@@ -903,7 +903,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       const middleCreatedAt = middleSession.created_at;
       const bounded = await store.listSessions({
         agent_id: undefined,
-        created_by_subject_id: undefined,
+        created_by_or_agent_ids: undefined,
         tenant_id: tenant,
         limit: 10,
         order: 'asc',
@@ -928,7 +928,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
       const listArgs = {
         agent_id: undefined,
-        created_by_subject_id: undefined,
+        created_by_or_agent_ids: undefined,
         tenant_id: tenant,
         order: undefined,
         start_timestamp: undefined,
@@ -954,7 +954,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
 
       const listArgs = {
         agent_id: undefined,
-        created_by_subject_id: undefined,
+        created_by_or_agent_ids: undefined,
         tenant_id: tenant,
         order: 'desc' as const,
         start_timestamp: undefined,
@@ -975,7 +975,7 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       expect(page2.pagination.next_page_token).toBeUndefined();
     });
 
-    it('filters by created_by_subject_id', async () => {
+    it('filters by creator or named-agent ids', async () => {
       const store = createStore();
       await store.createSession({
         tenant_id: tenant,
@@ -995,10 +995,31 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
         metadata: {},
         external_id: null,
       });
+      await store.createSession({
+        tenant_id: tenant,
+        session_id: 'managed-session',
+        created_by_subject: { subject_id: 'charlie', subject_type: 'user', subject_display_name: 'charlie' },
+        agent: { type: 'reference', id: 'managed-agent', name: null },
+        custom: null,
+        metadata: {},
+        external_id: null,
+      });
+      await store.createSession({
+        tenant_id: tenant,
+        session_id: 'unmanaged-session',
+        created_by_subject: { subject_id: 'dave', subject_type: 'user', subject_display_name: 'dave' },
+        agent: { type: 'reference', id: 'unmanaged-agent', name: null },
+        custom: null,
+        metadata: {},
+        external_id: null,
+      });
 
       const aliceOnly = await store.listSessions({
         agent_id: undefined,
-        created_by_subject_id: 'alice',
+        created_by_or_agent_ids: {
+          created_by_subject_id: 'alice',
+          agent_ids: [],
+        },
         tenant_id: tenant,
         limit: 10,
         page_token: undefined,
@@ -1009,9 +1030,42 @@ export function runStoreContractSuite(createStore: () => ISessionStore) {
       expect(aliceOnly.data.map(s => s.session_id)).toEqual(['alice-session']);
       expect(aliceOnly.data[0]?.created_by_subject.subject_id).toBe('alice');
 
+      const aliceOrManaged = await store.listSessions({
+        agent_id: undefined,
+        created_by_or_agent_ids: {
+          created_by_subject_id: 'alice',
+          agent_ids: ['managed-agent'],
+        },
+        tenant_id: tenant,
+        limit: 10,
+        page_token: undefined,
+        order: 'asc',
+        start_timestamp: undefined,
+        end_timestamp: undefined,
+      });
+      expect(aliceOrManaged.data.map(s => s.session_id)).toEqual(['alice-session', 'managed-session']);
+
+      const managedAgentOnly = await store.listSessions({
+        agent_id: 'managed-agent',
+        created_by_or_agent_ids: {
+          created_by_subject_id: 'alice',
+          agent_ids: ['managed-agent'],
+        },
+        tenant_id: tenant,
+        limit: 10,
+        page_token: undefined,
+        order: undefined,
+        start_timestamp: undefined,
+        end_timestamp: undefined,
+      });
+      expect(managedAgentOnly.data.map(s => s.session_id)).toEqual(['managed-session']);
+
       const unmatched = await store.listSessions({
         agent_id: undefined,
-        created_by_subject_id: 'nobody',
+        created_by_or_agent_ids: {
+          created_by_subject_id: 'nobody',
+          agent_ids: [],
+        },
         tenant_id: tenant,
         limit: 10,
         page_token: undefined,

--- a/packages/trueforge-sdk/reference.md
+++ b/packages/trueforge-sdk/reference.md
@@ -1171,7 +1171,7 @@ await client.schedules.delete("schedule_id");
 <dl>
 <dd>
 
-List runs of a schedule, newest `scheduled_for` first. Only the schedule creator (or an admin) may list its runs.
+List runs of a schedule, newest `scheduled_for` first. Available to its creator or a manager of its agent.
 </dd>
 </dl>
 </dd>

--- a/packages/trueforge-sdk/src/api/resources/schedules/client/Client.ts
+++ b/packages/trueforge-sdk/src/api/resources/schedules/client/Client.ts
@@ -751,7 +751,7 @@ export class SchedulesClient {
     }
 
     /**
-     * List runs of a schedule, newest `scheduled_for` first. Only the schedule creator (or an admin) may list its runs.
+     * List runs of a schedule, newest `scheduled_for` first. Available to its creator or a manager of its agent.
      *
      * @param {string} schedule_id - Immutable schedule identifier.
      * @param {SchedulesClient.RequestOptions} requestOptions - Request-specific configuration.

--- a/packages/trueforge/src/apis/agentAccess.ts
+++ b/packages/trueforge/src/apis/agentAccess.ts
@@ -41,3 +41,43 @@ export async function listAccessibleAgents<TTransaction>(input: {
     external_ids: access.agent_external_ids,
   });
 }
+
+/**
+ * Resolve only explicit manage grants to internal ids. An `all` scope does not
+ * identify explicit grants and must not widen related-resource visibility.
+ */
+export async function resolveManagedAgentIds<TTransaction>(input: {
+  store: IAgentStore<TTransaction>;
+  context: RequestContext;
+  authorizer: Authorizer;
+}): Promise<string[]> {
+  const { store, context, authorizer } = input;
+  const access = await authorizer.listAgentAccess({ context, action: 'manage' });
+  if (access.kind === 'all') {
+    return [];
+  }
+  const agents = await store.listAgents({
+    tenant_id: context.tenant_id,
+    external_ids: access.agent_external_ids,
+  });
+  return agents.map(agent => agent.id);
+}
+
+/** Related rows are readable by their creator or a manager of the bound named agent. */
+export async function canReadAgentBoundResource<TTransaction>(input: {
+  store: IAgentStore<TTransaction>;
+  context: RequestContext;
+  authorizer: Authorizer;
+  created_by_subject_id: string;
+  agent_id: string | undefined;
+}): Promise<boolean> {
+  const { store, context, authorizer, created_by_subject_id, agent_id } = input;
+  if (created_by_subject_id === context.subject.id) {
+    return true;
+  }
+  if (agent_id === undefined) {
+    return false;
+  }
+  const managedAgentIds = await resolveManagedAgentIds({ store, context, authorizer });
+  return managedAgentIds.includes(agent_id);
+}

--- a/packages/trueforge/src/apis/schedules.ts
+++ b/packages/trueforge/src/apis/schedules.ts
@@ -5,12 +5,7 @@ import { OpenAPIHono, type RouteHandler } from '@hono/zod-openapi';
 import { InvalidPageTokenError, type Sessions } from '@truefoundry/trueforge-core/agent-session';
 import type { Context } from 'hono';
 import type { Authorizer } from '../auth/authorizer';
-import {
-  createdBySubjectFromRequestContext,
-  hasAdminRole,
-  type RequestContext,
-  type ResolveRequestContext,
-} from '../auth/identity';
+import { createdBySubjectFromRequestContext, type RequestContext, type ResolveRequestContext } from '../auth/identity';
 import { ScheduleAgentNotFoundError, startScheduleRun } from '../controller/scheduleDispatch';
 import type { IAgentStore } from '../db/agentStore';
 import {
@@ -39,7 +34,7 @@ import {
   type ScheduleManifest,
   type ScheduleRun,
 } from '../schemas/schedule';
-import { agentIfAccessible } from './agentAccess';
+import { agentIfAccessible, canReadAgentBoundResource, resolveManagedAgentIds } from './agentAccess';
 import { getTurnExecutionError, startTurnInProcess, type BeginTurnExecutionDeps } from './turns';
 
 export interface SchedulesRouterDeps<TTransaction> {
@@ -110,32 +105,30 @@ export function validateManifest(manifest: Pick<ScheduleManifest, 'cron' | 'time
 
 const FORBIDDEN_SCHEDULE_ACCESS = 'Only the schedule creator can access this schedule';
 
-/**
- * A schedule is visible to its creator, and to any admin ({@link hasAdminRole}).
- *
- * Standalone auth stamps `roles: ['admin']` on the sole identity, which already
- * owns everything it created — so admin bypass is a no-op there.
- */
-function canAccessSchedule(
-  requestContext: Pick<RequestContext, 'roles' | 'subject'>,
-  created_by_subject_id: string,
-): boolean {
-  return hasAdminRole(requestContext) || requestContext.subject.id === created_by_subject_id;
+/** Schedule mutations remain creator-only in every auth mode. */
+function isScheduleOwner(requestContext: Pick<RequestContext, 'subject'>, created_by_subject_id: string): boolean {
+  return requestContext.subject.id === created_by_subject_id;
 }
 
 export function createSchedulesRouter<TTransaction>(deps: SchedulesRouterDeps<TTransaction>) {
   const listHandler: RouteHandler<typeof listSchedulesRoute> = async c => {
     const { agent_names: agentNames, limit, page_token: pageToken } = c.req.valid('query');
     const requestContext = deps.resolveRequestContext(c);
-    // Admins see every schedule; a regular user is scoped to their own via the
-    // store's `created_by_subject_id` filter (never a client-supplied param).
     try {
+      const managedAgentIds = await resolveManagedAgentIds({
+        store: deps.resolveAgentStore(c),
+        context: requestContext,
+        authorizer: deps.authorizer,
+      });
       const { data, pagination } = await deps.scheduleStore.listSchedules({
         tenant_id: requestContext.tenant_id,
         limit,
         page_token: pageToken,
         agent_names: agentNames,
-        created_by_subject_id: hasAdminRole(requestContext) ? undefined : requestContext.subject.id,
+        created_by_or_agent_ids: {
+          created_by_subject_id: requestContext.subject.id,
+          agent_ids: managedAgentIds,
+        },
       });
       return c.json({ data: data.map(toWireSchedule), pagination }, 200);
     } catch (error) {
@@ -156,7 +149,15 @@ export function createSchedulesRouter<TTransaction>(deps: SchedulesRouterDeps<TT
     if (schedule === undefined) {
       return c.json({ error: { message: `Schedule not found: ${scheduleId}` } }, 404);
     }
-    if (!canAccessSchedule(requestContext, schedule.created_by_subject.subject_id)) {
+    if (
+      !(await canReadAgentBoundResource({
+        store: deps.resolveAgentStore(c),
+        context: requestContext,
+        authorizer: deps.authorizer,
+        agent_id: schedule.agent_id,
+        created_by_subject_id: schedule.created_by_subject.subject_id,
+      }))
+    ) {
       return c.json({ error: { message: FORBIDDEN_SCHEDULE_ACCESS } }, 403);
     }
     const records = await deps.scheduleStore.listRuns({
@@ -177,7 +178,7 @@ export function createSchedulesRouter<TTransaction>(deps: SchedulesRouterDeps<TT
     if (schedule === undefined) {
       return c.json({ error: { message: `Schedule not found: ${scheduleId}` } }, 404);
     }
-    if (!canAccessSchedule(requestContext, schedule.created_by_subject.subject_id)) {
+    if (!isScheduleOwner(requestContext, schedule.created_by_subject.subject_id)) {
       return c.json({ error: { message: FORBIDDEN_SCHEDULE_ACCESS } }, 403);
     }
 
@@ -303,7 +304,15 @@ export function createSchedulesRouter<TTransaction>(deps: SchedulesRouterDeps<TT
     if (record === undefined) {
       return c.json({ error: { message: `Schedule not found: ${scheduleId}` } }, 404);
     }
-    if (!canAccessSchedule(requestContext, record.created_by_subject.subject_id)) {
+    if (
+      !(await canReadAgentBoundResource({
+        store: deps.resolveAgentStore(c),
+        context: requestContext,
+        authorizer: deps.authorizer,
+        agent_id: record.agent_id,
+        created_by_subject_id: record.created_by_subject.subject_id,
+      }))
+    ) {
       return c.json({ error: { message: FORBIDDEN_SCHEDULE_ACCESS } }, 403);
     }
     return c.json({ data: toWireSchedule(record) }, 200);
@@ -333,7 +342,7 @@ export function createSchedulesRouter<TTransaction>(deps: SchedulesRouterDeps<TT
     if (existing === undefined) {
       return c.json({ error: { message: `Schedule not found: ${scheduleId}` } }, 404);
     }
-    if (!canAccessSchedule(requestContext, existing.created_by_subject.subject_id)) {
+    if (!isScheduleOwner(requestContext, existing.created_by_subject.subject_id)) {
       return c.json({ error: { message: FORBIDDEN_SCHEDULE_ACCESS } }, 403);
     }
 
@@ -378,7 +387,7 @@ export function createSchedulesRouter<TTransaction>(deps: SchedulesRouterDeps<TT
     if (record === undefined) {
       return c.json({}, 200);
     }
-    if (!canAccessSchedule(requestContext, record.created_by_subject.subject_id)) {
+    if (!isScheduleOwner(requestContext, record.created_by_subject.subject_id)) {
       return c.json({ error: { message: FORBIDDEN_SCHEDULE_ACCESS } }, 403);
     }
     await deps.scheduleStore.deleteSchedule({

--- a/packages/trueforge/src/apis/sessionMetrics.ts
+++ b/packages/trueforge/src/apis/sessionMetrics.ts
@@ -2,17 +2,23 @@
  * Internal session metrics APIs (mounted at /api/internal/metrics).
  */
 import { OpenAPIHono, type RouteHandler } from '@hono/zod-openapi';
+import type { Context } from 'hono';
+import type { Authorizer } from '../auth/authorizer';
 import type { ResolveRequestContext } from '../auth/identity';
+import type { IAgentStore } from '../db/agentStore';
 import { buildSessionMetricsCharts, type ISessionMetricsStore } from '../db/sessionMetricsStore';
 import {
   getSessionMetricsChartsDataRoute,
   getSessionMetricsChartsRoute,
   getSessionMetricsMetersRoute,
 } from '../routes/sessionMetricsRoutes';
+import { resolveManagedAgentIds } from './agentAccess';
 
 export interface InternalMetricsRouterDeps {
   sessionMetricsStore: ISessionMetricsStore;
   resolveRequestContext: ResolveRequestContext;
+  resolveAgentStore: (c: Context) => IAgentStore;
+  authorizer: Authorizer;
 }
 
 export function createInternalMetricsRouter(deps: InternalMetricsRouterDeps) {
@@ -21,10 +27,15 @@ export function createInternalMetricsRouter(deps: InternalMetricsRouterDeps) {
   const getSessionMetricsMetersHandler: RouteHandler<typeof getSessionMetricsMetersRoute> = async c => {
     const query = c.req.valid('query');
     const requestContext = deps.resolveRequestContext(c);
+    const managedAgentIds = await resolveManagedAgentIds({
+      store: deps.resolveAgentStore(c),
+      context: requestContext,
+      authorizer: deps.authorizer,
+    });
     const metrics = await deps.sessionMetricsStore.getSessionMetricsMeters({
       tenant_id: requestContext.tenant_id,
       agent_id: query.agent_id,
-      created_by_subject_id: requestContext.subject.id,
+      created_by_subject_id: managedAgentIds.includes(query.agent_id) ? undefined : requestContext.subject.id,
       start_timestamp: query.start_timestamp,
       end_timestamp: query.end_timestamp,
     });
@@ -38,10 +49,15 @@ export function createInternalMetricsRouter(deps: InternalMetricsRouterDeps) {
   const getSessionMetricsChartsDataHandler: RouteHandler<typeof getSessionMetricsChartsDataRoute> = async c => {
     const query = c.req.valid('query');
     const requestContext = deps.resolveRequestContext(c);
+    const managedAgentIds = await resolveManagedAgentIds({
+      store: deps.resolveAgentStore(c),
+      context: requestContext,
+      authorizer: deps.authorizer,
+    });
     const chartData = await deps.sessionMetricsStore.getSessionMetricsChartData({
       tenant_id: requestContext.tenant_id,
       agent_id: query.agent_id,
-      created_by_subject_id: requestContext.subject.id,
+      created_by_subject_id: managedAgentIds.includes(query.agent_id) ? undefined : requestContext.subject.id,
       start_timestamp: query.start_timestamp,
       end_timestamp: query.end_timestamp,
       chart_name: query.chart_name,

--- a/packages/trueforge/src/apis/sessions.ts
+++ b/packages/trueforge/src/apis/sessions.ts
@@ -44,7 +44,7 @@ import { executorFromTurnId } from '../runtime/peeringIds';
 import { validateAgentSpec } from '../runtime/sessionResources';
 import { isSessionAgentNameRef, type Session } from '../schemas/session';
 import { newId } from '../utils/id';
-import { agentIfAccessible } from './agentAccess';
+import { agentIfAccessible, canReadAgentBoundResource, resolveManagedAgentIds } from './agentAccess';
 
 /** Request-reply path a replica serves to cancel a turn it owns. */
 export const SESSIONS_CANCEL_PATH = 'sessions/cancel';
@@ -217,7 +217,7 @@ async function freezeTurnIgnoringMissing(
 
 const FORBIDDEN_SESSION_ACCESS = 'Only the session creator can access this session';
 
-function checkSessionAccess({
+function isSessionOwner({
   subject_id,
   created_by_subject,
 }: {
@@ -252,10 +252,13 @@ function createGetOrCreateSessionByExternalIdHandler(
     });
     if (existing !== undefined) {
       if (
-        !checkSessionAccess({
-          subject_id: requestContext.subject.id,
-          created_by_subject: existing.record.created_by_subject,
-        })
+        !(await canReadAgentBoundResource({
+          store: deps.resolveAgentStore(c),
+          context: requestContext,
+          authorizer: deps.authorizer,
+          agent_id: existing.record.agent.type === 'reference' ? existing.record.agent.id : undefined,
+          created_by_subject_id: existing.record.created_by_subject.subject_id,
+        }))
       ) {
         return c.json({ error: { message: FORBIDDEN_SESSION_ACCESS } }, 403);
       }
@@ -297,10 +300,13 @@ function createGetOrCreateSessionByExternalIdHandler(
     });
     if (
       !created &&
-      !checkSessionAccess({
-        subject_id: requestContext.subject.id,
-        created_by_subject: session.record.created_by_subject,
-      })
+      !(await canReadAgentBoundResource({
+        store: deps.resolveAgentStore(c),
+        context: requestContext,
+        authorizer: deps.authorizer,
+        agent_id: session.record.agent.type === 'reference' ? session.record.agent.id : undefined,
+        created_by_subject_id: session.record.created_by_subject.subject_id,
+      }))
     ) {
       return c.json({ error: { message: FORBIDDEN_SESSION_ACCESS } }, 403);
     }
@@ -376,10 +382,13 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
       return c.json({ error: { message: `Session not found: ${sessionId}` } }, 404);
     }
     if (
-      !checkSessionAccess({
-        subject_id: requestContext.subject.id,
-        created_by_subject: record.created_by_subject,
-      })
+      !(await canReadAgentBoundResource({
+        store: deps.resolveAgentStore(c),
+        context: requestContext,
+        authorizer: deps.authorizer,
+        agent_id: record.agent.type === 'reference' ? record.agent.id : undefined,
+        created_by_subject_id: record.created_by_subject.subject_id,
+      }))
     ) {
       return c.json({ error: { message: FORBIDDEN_SESSION_ACCESS } }, 403);
     }
@@ -398,7 +407,7 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
       return c.body(null, 204);
     }
     if (
-      !checkSessionAccess({
+      !isSessionOwner({
         subject_id: requestContext.subject.id,
         created_by_subject: record.created_by_subject,
       })
@@ -424,7 +433,7 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
       return c.json({ error: { message: `Session not found: ${sessionId}` } }, 404);
     }
     if (
-      !checkSessionAccess({
+      !isSessionOwner({
         subject_id: requestContext.subject.id,
         created_by_subject: existing.created_by_subject,
       })
@@ -474,9 +483,17 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
     const query = c.req.valid('query');
     const requestContext = deps.resolveRequestContext(c);
     try {
+      const managedAgentIds = await resolveManagedAgentIds({
+        store: deps.resolveAgentStore(c),
+        context: requestContext,
+        authorizer: deps.authorizer,
+      });
       const { data, pagination } = await deps.sessionStore.listSessions({
         agent_id: query.agent_id,
-        created_by_subject_id: requestContext.subject.id,
+        created_by_or_agent_ids: {
+          created_by_subject_id: requestContext.subject.id,
+          agent_ids: managedAgentIds,
+        },
         tenant_id: requestContext.tenant_id,
         limit: query.limit,
         order: query.order,
@@ -504,7 +521,7 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
       return c.json({ error: { message: `Session not found: ${sessionId}` } }, 404);
     }
     if (
-      !checkSessionAccess({
+      !isSessionOwner({
         subject_id: requestContext.subject.id,
         created_by_subject: session.record.created_by_subject,
       })
@@ -532,10 +549,13 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
       return c.json({ error: { message: `Session not found: ${sessionId}` } }, 404);
     }
     if (
-      !checkSessionAccess({
-        subject_id: requestContext.subject.id,
-        created_by_subject: session.record.created_by_subject,
-      })
+      !(await canReadAgentBoundResource({
+        store: deps.resolveAgentStore(c),
+        context: requestContext,
+        authorizer: deps.authorizer,
+        agent_id: session.record.agent.type === 'reference' ? session.record.agent.id : undefined,
+        created_by_subject_id: session.record.created_by_subject.subject_id,
+      }))
     ) {
       return c.json({ error: { message: FORBIDDEN_SESSION_ACCESS } }, 403);
     }

--- a/packages/trueforge/src/apis/turns.ts
+++ b/packages/trueforge/src/apis/turns.ts
@@ -57,6 +57,7 @@ import {
   resolveSandboxProvider,
 } from '../runtime/sessionResources';
 import { checkSnapshotStatus } from '../sandbox/providerUtils';
+import { canReadAgentBoundResource } from './agentAccess';
 
 export function toWireTurn(record: TurnRecordWithoutSnapshot): Turn {
   return {
@@ -512,7 +513,7 @@ export function resolveAfterSequenceNumber(c: Context, bodyAfterSequenceNumber?:
 }
 
 /** True when the subject is the session creator (`created_by_subject.subject_id`). */
-function checkTurnAccess({
+function isSessionOwner({
   subject_id,
   created_by_subject,
 }: {
@@ -539,10 +540,13 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
       return c.json({ error: { message: `Session not found: ${sessionId}` } }, 404);
     }
     if (
-      !checkTurnAccess({
-        subject_id: requestContext.subject.id,
-        created_by_subject: session.record.created_by_subject,
-      })
+      !(await canReadAgentBoundResource({
+        store: deps.resolveAgentStore(c),
+        context: requestContext,
+        authorizer: deps.authorizer,
+        agent_id: session.record.agent.type === 'reference' ? session.record.agent.id : undefined,
+        created_by_subject_id: session.record.created_by_subject.subject_id,
+      }))
     ) {
       return c.json({ error: { message: FORBIDDEN_SESSION_ACCESS } }, 403);
     }
@@ -571,10 +575,13 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
       return c.json({ error: { message: `Session not found: ${sessionId}` } }, 404);
     }
     if (
-      !checkTurnAccess({
-        subject_id: requestContext.subject.id,
-        created_by_subject: session.record.created_by_subject,
-      })
+      !(await canReadAgentBoundResource({
+        store: deps.resolveAgentStore(c),
+        context: requestContext,
+        authorizer: deps.authorizer,
+        agent_id: session.record.agent.type === 'reference' ? session.record.agent.id : undefined,
+        created_by_subject_id: session.record.created_by_subject.subject_id,
+      }))
     ) {
       return c.json({ error: { message: FORBIDDEN_SESSION_ACCESS } }, 403);
     }
@@ -603,7 +610,7 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
         return c.json({ error: { message: `Session not found: ${sessionId}` } }, 404);
       }
       if (
-        !checkTurnAccess({
+        !isSessionOwner({
           subject_id: requestContext.subject.id,
           created_by_subject: session.record.created_by_subject,
         })
@@ -668,10 +675,13 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
       return c.json({ error: { message: `Session not found: ${sessionId}` } }, 404);
     }
     if (
-      !checkTurnAccess({
-        subject_id: requestContext.subject.id,
-        created_by_subject: session.record.created_by_subject,
-      })
+      !(await canReadAgentBoundResource({
+        store: deps.resolveAgentStore(c),
+        context: requestContext,
+        authorizer: deps.authorizer,
+        agent_id: session.record.agent.type === 'reference' ? session.record.agent.id : undefined,
+        created_by_subject_id: session.record.created_by_subject.subject_id,
+      }))
     ) {
       return c.json({ error: { message: FORBIDDEN_SESSION_ACCESS } }, 403);
     }
@@ -707,7 +717,7 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
       return c.json({ error: { message: `Session not found: ${sessionId}` } }, 404);
     }
     if (
-      !checkTurnAccess({
+      !isSessionOwner({
         subject_id: requestContext.subject.id,
         created_by_subject: session.record.created_by_subject,
       })
@@ -799,10 +809,13 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
       return c.json({ error: { message: `Session not found: ${sessionId}` } }, 404);
     }
     if (
-      !checkTurnAccess({
-        subject_id: requestContext.subject.id,
-        created_by_subject: session.record.created_by_subject,
-      })
+      !(await canReadAgentBoundResource({
+        store: deps.resolveAgentStore(c),
+        context: requestContext,
+        authorizer: deps.authorizer,
+        agent_id: session.record.agent.type === 'reference' ? session.record.agent.id : undefined,
+        created_by_subject_id: session.record.created_by_subject.subject_id,
+      }))
     ) {
       return c.json({ error: { message: FORBIDDEN_SESSION_ACCESS } }, 403);
     }

--- a/packages/trueforge/src/app.ts
+++ b/packages/trueforge/src/app.ts
@@ -370,6 +370,8 @@ export function createServerApp<TTransaction>(deps: ServerDeps<TTransaction>) {
       createInternalMetricsRouter({
         sessionMetricsStore: deps.sessionMetricsStore,
         resolveRequestContext,
+        resolveAgentStore: deps.resolveAgentStore,
+        authorizer: deps.authorizer,
       }),
       authMiddleware,
     ),

--- a/packages/trueforge/src/db/postgres/schedule-store/PostgresScheduleStore.ts
+++ b/packages/trueforge/src/db/postgres/schedule-store/PostgresScheduleStore.ts
@@ -3,7 +3,7 @@ import {
   decodeOffsetPageToken,
   paginateOffsetRows,
 } from '@truefoundry/trueforge-core/agent-session/store/OffsetPageToken';
-import { sql, type Kysely, type Selectable, type Transaction } from 'kysely';
+import type { Kysely, Selectable, Transaction } from 'kysely';
 import { nextTriggerAfter } from '../../../runtime/cron';
 import { newId } from '../../../utils/id';
 import { parseStoredCreatedBySubject } from '../../createdBySubject';
@@ -30,7 +30,7 @@ import {
   type UpdateScheduleRunStatusInput,
 } from '../../scheduleStore';
 import { isUniqueViolation } from '../client';
-import { json, now } from '../sqlExpressions';
+import { json, now, whereCreatedByOrAgentIds } from '../sqlExpressions';
 import type { Database, ScheduleRunTable, ScheduleTable } from '../types';
 
 function toScheduleRecord(row: Selectable<ScheduleTable>): ScheduleRecord {
@@ -230,9 +230,7 @@ export class PostgresScheduleStore implements IScheduleStore<Transaction<Databas
     if (input.agent_names !== undefined) {
       query = query.where('agent_name', 'in', [...input.agent_names]);
     }
-    if (input.created_by_subject_id !== undefined) {
-      query = query.where(sql`created_by_subject->>'subject_id'`, '=', input.created_by_subject_id);
-    }
+    query = whereCreatedByOrAgentIds(query, input.created_by_or_agent_ids);
     const rows = await query
       .orderBy('created_at', 'desc')
       .orderBy('id')

--- a/packages/trueforge/src/db/postgres/session-metrics/queries.ts
+++ b/packages/trueforge/src/db/postgres/session-metrics/queries.ts
@@ -17,7 +17,7 @@ async function fetchSessionMetricsAggregate(
 ): Promise<SessionMetricsAggregate> {
   // Every session in the window (including zero-turn / zero-duration); matches foldSessionMetricsAggregate.
   // COALESCE keeps empty windows at 0 (percentile_cont would otherwise be null).
-  const aggregateRow = await db
+  let query = db
     .selectFrom('session')
     .select([
       sql<number>`COUNT(*)::int`.as('total_sessions'),
@@ -44,8 +44,11 @@ async function fetchSessionMetricsAggregate(
       ),
     ])
     .where('tenant_id', '=', input.tenant_id)
-    .where('agent_id', '=', input.agent_id)
-    .where(sql`created_by_subject->>'subject_id'`, '=', input.created_by_subject_id)
+    .where('agent_id', '=', input.agent_id);
+  if (input.created_by_subject_id !== undefined) {
+    query = query.where(sql`created_by_subject->>'subject_id'`, '=', input.created_by_subject_id);
+  }
+  const aggregateRow = await query
     .where('created_at', '>=', input.start_timestamp)
     .where('created_at', '<=', input.end_timestamp)
     .executeTakeFirstOrThrow();
@@ -73,7 +76,7 @@ async function fetchSessionMetricsBuckets(
   const bucketTimestamp = sql<number>`
     (FLOOR(EXTRACT(EPOCH FROM created_at) / ${step_seconds}) * ${step_seconds})::double precision
   `;
-  const bucketRows = await db
+  let query = db
     .selectFrom('session')
     .select([
       bucketTimestamp.as('timestamp_seconds'),
@@ -82,8 +85,11 @@ async function fetchSessionMetricsBuckets(
       sql<number>`COALESCE(SUM((metrics->>'total_cost_in_usd')::double precision), 0)::double precision`.as('cost'),
     ])
     .where('tenant_id', '=', input.tenant_id)
-    .where('agent_id', '=', input.agent_id)
-    .where(sql`created_by_subject->>'subject_id'`, '=', input.created_by_subject_id)
+    .where('agent_id', '=', input.agent_id);
+  if (input.created_by_subject_id !== undefined) {
+    query = query.where(sql`created_by_subject->>'subject_id'`, '=', input.created_by_subject_id);
+  }
+  const bucketRows = await query
     .where('created_at', '>=', input.start_timestamp)
     .where('created_at', '<=', input.end_timestamp)
     .groupBy(sql`1`)

--- a/packages/trueforge/src/db/postgres/session-store/queries/sessions.ts
+++ b/packages/trueforge/src/db/postgres/session-store/queries/sessions.ts
@@ -29,7 +29,7 @@ import { parseStoredCreatedBySubject } from '../../../createdBySubject';
 import { SESSION_EXTERNAL_ID_UQ } from '../../../indexes';
 import { sessionAgentFromColumns, sessionAgentToColumns } from '../../../sessionAgentColumns';
 import { isPgConstraint, isUniqueViolation } from '../../client';
-import { json } from '../../sqlExpressions';
+import { json, whereCreatedByOrAgentIds } from '../../sqlExpressions';
 import type { Database } from '../../types';
 
 type SessionCustom = Record<string, never>;
@@ -246,9 +246,7 @@ export async function listSessions(
   if (input.agent_id !== undefined) {
     query = query.where('agent_id', '=', input.agent_id);
   }
-  if (input.created_by_subject_id !== undefined) {
-    query = query.where(sql`created_by_subject->>'subject_id'`, '=', input.created_by_subject_id);
-  }
+  query = whereCreatedByOrAgentIds(query, input.created_by_or_agent_ids);
   if (input.start_timestamp !== undefined) {
     query = query.where('created_at', '>=', input.start_timestamp);
   }

--- a/packages/trueforge/src/db/postgres/sqlExpressions.ts
+++ b/packages/trueforge/src/db/postgres/sqlExpressions.ts
@@ -1,7 +1,8 @@
 /**
  * Shared Kysely SQL expression helpers for Postgres stores.
  */
-import { sql, type Expression, type RawBuilder } from 'kysely';
+import { sql, type Expression, type RawBuilder, type SelectQueryBuilder } from 'kysely';
+import type { Database } from './types';
 
 /** Bind a JS value as jsonb (stringified + cast). Required for arrays and for `||` / jsonb_set operands. */
 export function json<T>(value: T): RawBuilder<T> {
@@ -28,4 +29,28 @@ export function now(): RawBuilder<Date> {
 
 export function nowMinusMs(ms: number): RawBuilder<Date> {
   return sql<Date>`now() - ${ms}::double precision * interval '1 millisecond'`;
+}
+
+/** Creator match, or creator OR `agent_id IN agent_ids` when the list is non-empty. */
+export function whereCreatedByOrAgentIds<TB extends 'session' | 'schedule', O>(
+  query: SelectQueryBuilder<Database, TB, O>,
+  filter:
+    | {
+        created_by_subject_id: string;
+        agent_ids: readonly string[];
+      }
+    | undefined,
+): SelectQueryBuilder<Database, TB, O> {
+  if (filter === undefined) {
+    return query;
+  }
+  if (filter.agent_ids.length === 0) {
+    return query.where(sql`created_by_subject->>'subject_id'`, '=', filter.created_by_subject_id);
+  }
+  return query.where(eb =>
+    eb.or([
+      eb(sql<string>`created_by_subject->>'subject_id'`, '=', filter.created_by_subject_id),
+      eb(sql<string>`agent_id`, 'in', [...filter.agent_ids]),
+    ]),
+  );
 }

--- a/packages/trueforge/src/db/scheduleStore.ts
+++ b/packages/trueforge/src/db/scheduleStore.ts
@@ -94,7 +94,13 @@ export interface ListSchedulesInput {
   page_token: string | undefined;
   /** When set, only schedules for these agent names */
   agent_names: readonly string[] | undefined;
-  created_by_subject_id?: string | undefined;
+  /** When set, match creator or agent binding. Empty `agent_ids` means creator-only. */
+  created_by_or_agent_ids:
+    | {
+        created_by_subject_id: string;
+        agent_ids: readonly string[];
+      }
+    | undefined;
 }
 
 /** User-facing run listing, scoped to one schedule. */

--- a/packages/trueforge/src/db/sessionMetricsStore.ts
+++ b/packages/trueforge/src/db/sessionMetricsStore.ts
@@ -10,7 +10,7 @@ import type {
 export interface GetSessionMetricsInput {
   tenant_id: string;
   agent_id: string;
-  created_by_subject_id: string;
+  created_by_subject_id: string | undefined;
   start_timestamp: Date;
   end_timestamp: Date;
 }

--- a/packages/trueforge/src/db/sqlite/schedule-store/SqliteScheduleStore.ts
+++ b/packages/trueforge/src/db/sqlite/schedule-store/SqliteScheduleStore.ts
@@ -3,7 +3,7 @@ import {
   decodeOffsetPageToken,
   paginateOffsetRows,
 } from '@truefoundry/trueforge-core/agent-session/store/OffsetPageToken';
-import { sql, type ExpressionBuilder, type Kysely, type Transaction } from 'kysely';
+import type { ExpressionBuilder, Kysely, Transaction } from 'kysely';
 import { nextTriggerAfter } from '../../../runtime/cron';
 import type { ScheduleManifest, ScheduleRunStatus, ScheduleStatus } from '../../../schemas/schedule';
 import { newId } from '../../../utils/id';
@@ -31,7 +31,7 @@ import {
   type UpdateScheduleRunStatusInput,
 } from '../../scheduleStore';
 import { isUniqueViolation } from '../client';
-import { jsonbBind, jsonText, nowIso } from '../sqlExpressions';
+import { jsonbBind, jsonText, nowIso, whereCreatedByOrAgentIds } from '../sqlExpressions';
 import type { Database } from '../types';
 
 /** Column list projecting the JSONB manifest as parsed JSON (see JSON_RESULT_COLUMNS). */
@@ -278,9 +278,7 @@ export class SqliteScheduleStore implements IScheduleStore<Transaction<Database>
     if (input.agent_names !== undefined) {
       query = query.where('agent_name', 'in', [...input.agent_names]);
     }
-    if (input.created_by_subject_id !== undefined) {
-      query = query.where(sql`json_extract(created_by_subject, '$.subject_id')`, '=', input.created_by_subject_id);
-    }
+    query = whereCreatedByOrAgentIds(query, input.created_by_or_agent_ids);
     const rows = await query
       .orderBy('created_at', 'desc')
       .orderBy('id')

--- a/packages/trueforge/src/db/sqlite/session-metrics/queries.ts
+++ b/packages/trueforge/src/db/sqlite/session-metrics/queries.ts
@@ -19,7 +19,7 @@ async function fetchSessionMetricsAggregate(
   const start_timestamp = input.start_timestamp.toISOString();
   const end_timestamp = input.end_timestamp.toISOString();
   // Scan rows; fold via foldSessionMetricsAggregate (same as InMemory / Postgres).
-  const rows = await db
+  let query = db
     .selectFrom('session')
     .select([
       sql<number>`CAST(COALESCE(metrics->>'total_turns', 0) AS INTEGER)`.as('total_turns'),
@@ -27,8 +27,11 @@ async function fetchSessionMetricsAggregate(
       sql<number>`CAST(COALESCE(metrics->>'total_cost_in_usd', 0) AS REAL)`.as('total_cost_in_usd'),
     ])
     .where('tenant_id', '=', input.tenant_id)
-    .where('agent_id', '=', input.agent_id)
-    .where(sql`json_extract(created_by_subject, '$.subject_id')`, '=', input.created_by_subject_id)
+    .where('agent_id', '=', input.agent_id);
+  if (input.created_by_subject_id !== undefined) {
+    query = query.where(sql`json_extract(created_by_subject, '$.subject_id')`, '=', input.created_by_subject_id);
+  }
+  const rows = await query
     .where('created_at', '>=', start_timestamp)
     .where('created_at', '<=', end_timestamp)
     .execute();
@@ -45,7 +48,7 @@ async function fetchSessionMetricsBuckets(
   const end_timestamp = input.end_timestamp.toISOString();
   // Sparse buckets only; builders zero-fill missing intervals for the chart line.
   const bucketTimestamp = sql<number>`CAST(unixepoch(created_at) / ${step_seconds} AS INTEGER) * ${step_seconds}`;
-  const buckets = await db
+  let query = db
     .selectFrom('session')
     .select([
       bucketTimestamp.as('timestamp_seconds'),
@@ -54,8 +57,11 @@ async function fetchSessionMetricsBuckets(
       sql<number>`COALESCE(SUM(metrics->>'total_cost_in_usd'), 0)`.as('cost'),
     ])
     .where('tenant_id', '=', input.tenant_id)
-    .where('agent_id', '=', input.agent_id)
-    .where(sql`json_extract(created_by_subject, '$.subject_id')`, '=', input.created_by_subject_id)
+    .where('agent_id', '=', input.agent_id);
+  if (input.created_by_subject_id !== undefined) {
+    query = query.where(sql`json_extract(created_by_subject, '$.subject_id')`, '=', input.created_by_subject_id);
+  }
+  const buckets = await query
     .where('created_at', '>=', start_timestamp)
     .where('created_at', '<=', end_timestamp)
     .groupBy(sql`1`)

--- a/packages/trueforge/src/db/sqlite/session-store/queries/sessions.ts
+++ b/packages/trueforge/src/db/sqlite/session-store/queries/sessions.ts
@@ -28,7 +28,7 @@ import { sql, type Kysely } from 'kysely';
 import { parseStoredCreatedBySubject } from '../../../createdBySubject';
 import { sessionAgentFromColumns, sessionAgentToColumns } from '../../../sessionAgentColumns';
 import { isUniqueViolation } from '../../client';
-import { jsonbBind, jsonText, nowIso } from '../../sqlExpressions';
+import { jsonbBind, jsonText, nowIso, whereCreatedByOrAgentIds } from '../../sqlExpressions';
 import type { Database } from '../../types';
 
 type SessionCustom = Record<string, never>;
@@ -262,9 +262,7 @@ export async function listSessions(
   if (input.agent_id !== undefined) {
     query = query.where('agent_id', '=', input.agent_id);
   }
-  if (input.created_by_subject_id !== undefined) {
-    query = query.where(sql`json_extract(created_by_subject, '$.subject_id')`, '=', input.created_by_subject_id);
-  }
+  query = whereCreatedByOrAgentIds(query, input.created_by_or_agent_ids);
   if (input.start_timestamp !== undefined) {
     query = query.where('created_at', '>=', input.start_timestamp.toISOString());
   }

--- a/packages/trueforge/src/db/sqlite/sqlExpressions.ts
+++ b/packages/trueforge/src/db/sqlite/sqlExpressions.ts
@@ -3,7 +3,8 @@
  * JSON authority: SQLite JSON1 — bind text via jsonb(?); read via json(column).
  * ParseJSONResultsPlugin parses top-level json() columns only (see createSqliteDb).
  */
-import { sql, type Expression, type RawBuilder } from 'kysely';
+import { sql, type Expression, type RawBuilder, type SelectQueryBuilder } from 'kysely';
+import type { Database } from './types';
 
 /** Bind a JS value as SQLite JSONB BLOB (stringify in JS, convert in SQL). */
 export function jsonbBind(value: unknown): RawBuilder<string> {
@@ -33,4 +34,28 @@ export function nowIso(): string {
 
 export function isoMsAgo(ms: number): string {
   return new Date(Date.now() - ms).toISOString();
+}
+
+/** Creator match, or creator OR `agent_id IN agent_ids` when the list is non-empty. */
+export function whereCreatedByOrAgentIds<TB extends 'session' | 'schedule', O>(
+  query: SelectQueryBuilder<Database, TB, O>,
+  filter:
+    | {
+        created_by_subject_id: string;
+        agent_ids: readonly string[];
+      }
+    | undefined,
+): SelectQueryBuilder<Database, TB, O> {
+  if (filter === undefined) {
+    return query;
+  }
+  if (filter.agent_ids.length === 0) {
+    return query.where(sql`json_extract(created_by_subject, '$.subject_id')`, '=', filter.created_by_subject_id);
+  }
+  return query.where(eb =>
+    eb.or([
+      eb(sql<string>`json_extract(created_by_subject, '$.subject_id')`, '=', filter.created_by_subject_id),
+      eb(sql<string>`agent_id`, 'in', [...filter.agent_ids]),
+    ]),
+  );
 }

--- a/packages/trueforge/src/routes/scheduleRoutes.ts
+++ b/packages/trueforge/src/routes/scheduleRoutes.ts
@@ -80,7 +80,7 @@ export const listScheduleRunsRoute = createRoute({
   tags: [OpenApiTag.SCHEDULES],
   summary: 'List runs of a schedule',
   description:
-    'List runs of a schedule, newest `scheduled_for` first. Only the schedule creator (or an admin) may list its runs.',
+    'List runs of a schedule, newest `scheduled_for` first. Available to its creator or a manager of its agent.',
   'x-fern-sdk-group-name': ['schedules'],
   'x-fern-sdk-method-name': 'list_runs',
   request: {
@@ -93,7 +93,7 @@ export const listScheduleRunsRoute = createRoute({
     },
     403: {
       content: { 'application/json': { schema: RequestErrorResponseSchema } },
-      description: 'The caller is not the schedule creator.',
+      description: 'The caller cannot read the schedule.',
     },
     404: {
       content: { 'application/json': { schema: RequestErrorResponseSchema } },

--- a/packages/trueforge/tests/db/scheduleStoreContractSuite.ts
+++ b/packages/trueforge/tests/db/scheduleStoreContractSuite.ts
@@ -540,6 +540,7 @@ export function runScheduleStoreContractSuite(deps: {
       limit: 25,
       page_token: undefined,
       agent_names: [agentA.name],
+      created_by_or_agent_ids: undefined,
     });
     expect(forA.data.map(row => row.id)).toEqual([newer.schedule.id, older.schedule.id]);
     expect(forA.data.every(row => row.agent_name === agentA.name)).toBe(true);
@@ -550,6 +551,7 @@ export function runScheduleStoreContractSuite(deps: {
       limit: 25,
       page_token: undefined,
       agent_names: [agentB.name],
+      created_by_or_agent_ids: undefined,
     });
     expect(forB.data.map(row => row.id)).toEqual([otherAgent.schedule.id]);
 
@@ -558,6 +560,7 @@ export function runScheduleStoreContractSuite(deps: {
       limit: 25,
       page_token: undefined,
       agent_names: [agentA.name, agentB.name],
+      created_by_or_agent_ids: undefined,
     });
     expect(forBoth.data.map(row => row.id)).toEqual([otherAgent.schedule.id, newer.schedule.id, older.schedule.id]);
 
@@ -566,6 +569,7 @@ export function runScheduleStoreContractSuite(deps: {
       limit: 25,
       page_token: undefined,
       agent_names: undefined,
+      created_by_or_agent_ids: undefined,
     });
     expect(all.data.map(row => row.id)).toEqual(
       expect.arrayContaining([newer.schedule.id, older.schedule.id, otherAgent.schedule.id]),
@@ -581,6 +585,7 @@ export function runScheduleStoreContractSuite(deps: {
       limit: 2,
       page_token: undefined,
       agent_names: undefined,
+      created_by_or_agent_ids: undefined,
     });
     expect(page1.data).toHaveLength(2);
     expect(page1.pagination.limit).toBe(2);
@@ -591,11 +596,88 @@ export function runScheduleStoreContractSuite(deps: {
       limit: 2,
       page_token: page1.pagination.next_page_token,
       agent_names: undefined,
+      created_by_or_agent_ids: undefined,
     });
     expect(page2.data).toHaveLength(1);
     expect(page1.data.map(row => row.id)).not.toContain(page2.data[0]?.id);
     expect(page2.pagination.previous_page_token).toEqual(expect.any(String));
     expect(page2.pagination.next_page_token).toBeUndefined();
+  });
+
+  it('listSchedules unions creator and included agent ids before other filters', async () => {
+    const store = deps.getScheduleStore();
+    const ownedAgent = await seedAgent();
+    const managedAgent = await seedAgent();
+    const otherSubject: CreatedBySubject = {
+      subject_id: 'other-user',
+      subject_type: 'user',
+      subject_display_name: 'Other',
+    };
+
+    const owned = await store.createScheduleAndRun({
+      tenant_id: TENANT,
+      agent_id: ownedAgent.id,
+      agent_name: ownedAgent.name,
+      name: 'owned',
+      manifest: manifest({ status: 'paused' }),
+      created_by_subject: USER_SUBJECT,
+      runFrom: new Date(),
+    });
+    const managed = await store.createScheduleAndRun({
+      tenant_id: TENANT,
+      agent_id: managedAgent.id,
+      agent_name: managedAgent.name,
+      name: 'managed',
+      manifest: manifest({ status: 'paused' }),
+      created_by_subject: otherSubject,
+      runFrom: new Date(),
+    });
+    await store.createScheduleAndRun({
+      tenant_id: TENANT,
+      agent_id: ownedAgent.id,
+      agent_name: ownedAgent.name,
+      name: 'unmanaged',
+      manifest: manifest({ status: 'paused' }),
+      created_by_subject: otherSubject,
+      runFrom: new Date(),
+    });
+
+    const visible = await store.listSchedules({
+      tenant_id: TENANT,
+      limit: 25,
+      page_token: undefined,
+      agent_names: undefined,
+      created_by_or_agent_ids: {
+        created_by_subject_id: USER_SUBJECT.subject_id,
+        agent_ids: [managedAgent.id],
+      },
+    });
+    expect(visible.data.map(row => row.id)).toEqual(expect.arrayContaining([owned.schedule.id, managed.schedule.id]));
+    expect(visible.data).toHaveLength(2);
+
+    const creatorOnly = await store.listSchedules({
+      tenant_id: TENANT,
+      limit: 25,
+      page_token: undefined,
+      agent_names: undefined,
+      created_by_or_agent_ids: {
+        created_by_subject_id: USER_SUBJECT.subject_id,
+        agent_ids: [],
+      },
+    });
+    expect(creatorOnly.data.map(row => row.id)).toEqual([owned.schedule.id]);
+
+    const managedNameOnly = await store.listSchedules({
+      tenant_id: TENANT,
+      limit: 25,
+      page_token: undefined,
+      agent_names: [managedAgent.name],
+      created_by_or_agent_ids: {
+        created_by_subject_id: USER_SUBJECT.subject_id,
+        agent_ids: [managedAgent.id],
+      },
+    });
+    expect(managedNameOnly.data.map(row => row.id)).toEqual([managed.schedule.id]);
   });
 
   it('listRuns returns newest scheduled_for first and filters by schedule_id', async () => {

--- a/packages/trueforge/tests/db/session-metrics/metricsContractSuite.ts
+++ b/packages/trueforge/tests/db/session-metrics/metricsContractSuite.ts
@@ -97,6 +97,15 @@ export function runSessionMetricsStoreContractSuite(
       expect(costChart.graphs[0]?.graph_lines[0]?.values.reduce((sum, point) => sum + point.value, 0)).toBe(1.25);
       expect(sessionsChart.graphs[0]?.graph_lines[0]?.values.some(point => point.value === 0)).toBe(true);
 
+      const allCreatorsQuery = { ...metricsQuery, created_by_subject_id: undefined };
+      const allCreatorsMeters = await metricsStore.getSessionMetricsMeters(allCreatorsQuery);
+      const allCreatorsChart = await metricsStore.getSessionMetricsChartData({
+        ...allCreatorsQuery,
+        chart_name: 'sessions_over_time',
+      });
+      expect(allCreatorsMeters.meters.find(meter => meter.name === 'total_sessions')?.aggregate_value).toBe(2);
+      expect(allCreatorsChart.graphs[0]?.graph_lines[0]?.values.reduce((sum, point) => sum + point.value, 0)).toBe(2);
+
       const dailyChart = await metricsStore.getSessionMetricsChartData({
         ...metricsQuery,
         start_timestamp: new Date(start.getTime() - 24 * 60 * 60 * 1000),

--- a/packages/trueforge/tests/unit/apis/schedules.test.ts
+++ b/packages/trueforge/tests/unit/apis/schedules.test.ts
@@ -62,7 +62,7 @@ async function setup(authorizer: Authorizer = new TrueForgeAuthorizer()) {
     },
     name: 'reporter',
     manifest: AgentSpecSchema.parse({ model: { name: 'test-provider/test-model' }, instructions: 'test' }),
-    external_id: null,
+    external_id: 'reporter-external-id',
   });
 
   let current: RequestContext = ALICE;
@@ -107,7 +107,7 @@ async function setup(authorizer: Authorizer = new TrueForgeAuthorizer()) {
   return { app, asUser, setAuthorizer, postJson, agentStore, scheduleStore };
 }
 
-describe('schedule RBAC — creator-scoped, admin sees all', () => {
+describe('schedule RBAC', () => {
   it("hides another user's schedule from get, update, delete, list, and run trigger", async () => {
     const { app, asUser, postJson } = await setup();
 
@@ -156,7 +156,7 @@ describe('schedule RBAC — creator-scoped, admin sees all', () => {
     expect((await postJson('/runs', 'POST', { schedule_id: '01jqzz000000000000000nope' })).status).toBe(404);
   });
 
-  it("lets an admin see and manage any user's schedule", async () => {
+  it("does not let an OIDC settings admin access another user's schedule", async () => {
     const { app, asUser, postJson } = await setup();
 
     asUser(ALICE);
@@ -164,56 +164,38 @@ describe('schedule RBAC — creator-scoped, admin sees all', () => {
     const { id } = ((await created.json()) as { data: { id: string } }).data;
 
     asUser(ADMIN);
-    expect((await app.request(`/${id}`)).status).toBe(200);
-
+    expect((await app.request(`/${id}`)).status).toBe(403);
     const adminList = await app.request('/');
-    expect(ListSchedulesResponseSchema.parse(await adminList.json()).data).toHaveLength(1);
-    const adminRuns = await app.request(`/${id}/runs`);
-    expect(ListScheduleRunsResponseSchema.parse(await adminRuns.json()).data).toHaveLength(1);
-
-    const renamed = await postJson(`/${id}`, 'PUT', { name: 'admin-renamed', manifest: scheduleBody.manifest });
-    expect(renamed.status).toBe(200);
-    expect((await app.request(`/${id}`, { method: 'DELETE' })).status).toBe(200);
+    expect(ListSchedulesResponseSchema.parse(await adminList.json()).data).toEqual([]);
+    expect((await app.request(`/${id}/runs`)).status).toBe(403);
+    expect((await postJson(`/${id}`, 'PUT', { name: 'admin-renamed', manifest: scheduleBody.manifest })).status).toBe(
+      403,
+    );
+    expect((await app.request(`/${id}`, { method: 'DELETE' })).status).toBe(403);
+    expect((await postJson('/runs', 'POST', { schedule_id: id })).status).toBe(403);
   });
 
-  it('shows an admin schedules across multiple creators in list', async () => {
-    const { app, asUser, agentStore, postJson } = await setup();
-    // A second agent so both schedules can share the same name without colliding.
-    await agentStore.createAgent({
-      tenant_id: 'default',
-      created_by_subject: {
-        subject_id: 'alice',
-        subject_type: 'user',
-        subject_display_name: 'alice',
-      },
-      name: 'reporter-two',
-      manifest: AgentSpecSchema.parse({ model: { name: 'test-provider/test-model' }, instructions: 'test' }),
-      external_id: null,
-    });
-
+  it('lets an agent manager read schedules and runs but keeps mutations creator-only', async () => {
+    const { app, asUser, setAuthorizer, postJson } = await setup();
     asUser(ALICE);
-    const aliceCreated = await postJson('/', 'POST', scheduleBody);
-    const aliceId = ((await aliceCreated.json()) as { data: { id: string } }).data.id;
+    const created = await postJson('/', 'POST', scheduleBody);
+    const id = ((await created.json()) as { data: { id: string } }).data.id;
+    setAuthorizer({
+      listAgentAccess: input =>
+        Promise.resolve(
+          input.action === 'manage'
+            ? { kind: 'agent_external_ids', agent_external_ids: ['reporter-external-id'] }
+            : { kind: 'agent_external_ids', agent_external_ids: [] },
+        ),
+      canAccessAgent: () => Promise.resolve(false),
+    });
     asUser(BOB);
-    const bobCreated = await postJson('/', 'POST', { ...scheduleBody, agent_name: 'reporter-two' });
-    const bobId = ((await bobCreated.json()) as { data: { id: string } }).data.id;
-
-    asUser(ADMIN);
-    const adminList = await app.request('/');
-    expect(ListSchedulesResponseSchema.parse(await adminList.json()).data).toHaveLength(2);
-    // An admin reaches the runs of a schedule created by anyone.
-    expect(ListScheduleRunsResponseSchema.parse(await (await app.request(`/${bobId}/runs`)).json()).data).toEqual([
-      expect.objectContaining({ schedule_id: bobId }),
-    ]);
-
-    // A regular user still sees only their own.
-    asUser(BOB);
-    const bobList = await app.request('/');
-    expect(ListSchedulesResponseSchema.parse(await bobList.json()).data).toHaveLength(1);
-    expect(ListScheduleRunsResponseSchema.parse(await (await app.request(`/${bobId}/runs`)).json()).data).toHaveLength(
-      1,
-    );
-    expect((await app.request(`/${aliceId}/runs`)).status).toBe(403);
+    expect((await app.request(`/${id}`)).status).toBe(200);
+    expect(ListSchedulesResponseSchema.parse(await (await app.request('/')).json()).data).toHaveLength(1);
+    expect(ListScheduleRunsResponseSchema.parse(await (await app.request(`/${id}/runs`)).json()).data).toHaveLength(1);
+    expect((await postJson(`/${id}`, 'PUT', { name: 'renamed', manifest: scheduleBody.manifest })).status).toBe(403);
+    expect((await app.request(`/${id}`, { method: 'DELETE' })).status).toBe(403);
+    expect((await postJson('/runs', 'POST', { schedule_id: id })).status).toBe(403);
   });
 });
 
@@ -323,7 +305,7 @@ describe('create schedule run', () => {
     expect(runs.map(r => r.status).sort()).toEqual(['scheduled', 'triggered']);
   });
 
-  it('lets an admin trigger a run owned by another user', async () => {
+  it('does not let an OIDC settings admin trigger another creator schedule', async () => {
     const { asUser, postJson } = await setup();
 
     asUser(ALICE);
@@ -332,14 +314,8 @@ describe('create schedule run', () => {
 
     asUser(ADMIN);
     const res = await postJson('/runs', 'POST', { schedule_id: scheduleId });
-    expect(res.status).toBe(201);
-    const body = CreateScheduleRunResponseSchema.parse(await res.json());
-    expect(body.data.created_by_subject).toEqual({
-      subject_id: 'root',
-      subject_type: 'user',
-      subject_display_name: 'root',
-    });
-    expect(mockedStartScheduleRun).toHaveBeenCalled();
+    expect(res.status).toBe(403);
+    expect(mockedStartScheduleRun).not.toHaveBeenCalled();
   });
 
   it('marks the run failed and returns 404 when startScheduleRun reports a missing agent', async () => {

--- a/packages/trueforge/tests/unit/apis/sessionHttp.test.ts
+++ b/packages/trueforge/tests/unit/apis/sessionHttp.test.ts
@@ -21,6 +21,7 @@ import { SqliteSessionMetricsStore } from '../../../src/db/sqlite/session-metric
 import { SqliteSessionStore } from '../../../src/db/sqlite/session-store/SqliteSessionStore';
 import { SqliteSkillStore } from '../../../src/db/sqlite/skill-store/SqliteSkillStore';
 import { ActiveTurnRegistry } from '../../../src/runtime/activeTurns';
+import { ListSessionsResponseSchema } from '../../../src/schemas/session';
 import {
   GetSessionMetricsChartDataResponseSchema,
   GetSessionMetricsChartResponseSchema,
@@ -49,13 +50,14 @@ describe('sessions HTTP agent binding', () => {
   let app: OpenAPIHono;
   let agentStore: SqliteAgentStore;
   let sessionStore: SqliteSessionStore;
+  let sessionMetricsStore: SqliteSessionMetricsStore;
   let sessionDeps: SessionsRouterDeps;
 
   beforeEach(async () => {
     const db = createSqliteDb(':memory:');
     await migrateSqliteToLatest(db);
     sessionStore = new SqliteSessionStore(db);
-    const sessionMetricsStore = new SqliteSessionMetricsStore(db);
+    sessionMetricsStore = new SqliteSessionMetricsStore(db);
     const sessions = new Sessions({ sessionStore });
     const modelProviderStore = new SqliteModelProviderStore(db);
     const mcpServerStore = new SqliteMcpServerStore(db);
@@ -104,6 +106,8 @@ describe('sessions HTTP agent binding', () => {
       createInternalMetricsRouter({
         sessionMetricsStore,
         resolveRequestContext: deps.resolveRequestContext,
+        resolveAgentStore: deps.resolveAgentStore,
+        authorizer: deps.authorizer,
       }),
     );
   });
@@ -229,6 +233,71 @@ describe('sessions HTTP agent binding', () => {
     expect(sessionsChartResponse.status).toBe(200);
     const sessionsChart = GetSessionMetricsChartDataResponseSchema.parse(await sessionsChartResponse.json());
     expect(sessionsChart.data.graphs[0]?.graph_lines[0]?.values.reduce((sum, point) => sum + point.value, 0)).toBe(1);
+  });
+
+  it('lets an agent manager read named sessions, events, and metrics but not mutate them', async () => {
+    const agent = await agentStore.createAgent({
+      tenant_id: 'default',
+      created_by_subject: { subject_id: 'owner', subject_type: 'user', subject_display_name: 'Owner' },
+      name: 'managed-agent',
+      manifest: inlineSpec,
+      external_id: 'managed-agent-external',
+    });
+    await sessionStore.createSession({
+      tenant_id: 'default',
+      session_id: 'managed-session',
+      created_by_subject: { subject_id: 'owner', subject_type: 'user', subject_display_name: 'Owner' },
+      agent: { type: 'reference', id: agent.id, name: agent.name },
+      custom: null,
+      metadata: {},
+      external_id: null,
+    });
+    const managerAuthorizer: Authorizer = {
+      listAgentAccess: input =>
+        Promise.resolve(
+          input.action === 'manage'
+            ? { kind: 'agent_external_ids', agent_external_ids: ['managed-agent-external'] }
+            : { kind: 'agent_external_ids', agent_external_ids: [] },
+        ),
+      canAccessAgent: () => Promise.resolve(false),
+    };
+    const managerDeps = {
+      ...sessionDeps,
+      requestReplyRouter: new RequestReplyRouter(),
+      authorizer: managerAuthorizer,
+    };
+    const managerApp = new OpenAPIHono();
+    managerApp.route('/', createSessionsRouter(managerDeps));
+    managerApp.route(
+      '/api/internal/metrics',
+      createInternalMetricsRouter({
+        sessionMetricsStore,
+        resolveRequestContext: managerDeps.resolveRequestContext,
+        resolveAgentStore: managerDeps.resolveAgentStore,
+        authorizer: managerAuthorizer,
+      }),
+    );
+
+    expect((await managerApp.request('/managed-session')).status).toBe(200);
+    expect((await managerApp.request('/managed-session/events')).status).toBe(200);
+    const listed = await managerApp.request('/');
+    expect(ListSessionsResponseSchema.parse(await listed.json()).data.map(session => session.id)).toContain(
+      'managed-session',
+    );
+
+    const query = new URLSearchParams({
+      agent_id: agent.id,
+      start_timestamp: new Date(Date.now() - 60_000).toISOString(),
+      end_timestamp: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const metrics = GetSessionMetricsMeterResponseSchema.parse(
+      await (await managerApp.request(`/api/internal/metrics/meters?${query.toString()}`)).json(),
+    );
+    expect(metrics.data.meters.find(meter => meter.name === 'total_sessions')?.aggregate_value).toBe(1);
+
+    expect((await managerApp.request('/managed-session', jsonInit('PATCH', {}))).status).toBe(403);
+    expect((await managerApp.request('/managed-session', { method: 'DELETE' })).status).toBe(403);
+    expect((await managerApp.request('/managed-session/cancel', { method: 'POST' })).status).toBe(403);
   });
 
   it('returns the static session metrics charts', async () => {

--- a/packages/trueforge/tests/unit/apis/turns.test.ts
+++ b/packages/trueforge/tests/unit/apis/turns.test.ts
@@ -110,6 +110,76 @@ describe('turns', () => {
       expect(downloadResponse.status).toBe(403);
       expect(await downloadResponse.json()).toEqual(forbiddenAccess);
     });
+
+    it('lets an agent manager use read routes but keeps create-turn and sandbox download creator-only', async () => {
+      const db = createSqliteDb(':memory:');
+      await migrateSqliteToLatest(db);
+      const sessionStore = new SqliteSessionStore(db);
+      const agentStore = new SqliteAgentStore(db);
+      const agent = await agentStore.createAgent({
+        tenant_id: 'default',
+        name: 'managed-agent',
+        manifest: AgentSpecSchema.parse({ model: { name: 'test-provider/test-model' } }),
+        external_id: 'managed-agent-external',
+        created_by_subject: { subject_id: 'owner', subject_type: 'user', subject_display_name: 'Owner' },
+      });
+      await sessionStore.createSession({
+        tenant_id: 'default',
+        session_id: 'managed-session',
+        created_by_subject: { subject_id: 'owner', subject_type: 'user', subject_display_name: 'Owner' },
+        agent: { type: 'reference', id: agent.id, name: agent.name },
+        custom: null,
+        metadata: {},
+        external_id: null,
+      });
+      const app = new OpenAPIHono();
+      app.route(
+        '/',
+        createTurnsRouter({
+          sessions: new Sessions({ sessionStore }),
+          sessionStore,
+          activeTurns: new ActiveTurnRegistry(),
+          resolveModelProviderStore: () => new SqliteModelProviderStore(db),
+          resolveMcpServerStore: () => mcpServerStoreWithAuth(db, new SqliteOAuthTokenStore(db)),
+          skillStore: new SqliteSkillStore(db),
+          resolveAgentStore: () => agentStore,
+          eventSubscriptions: new EventSubscriptionRegistry(undefined),
+          sandboxProviderStore: new SqliteSandboxProviderStore(db),
+          logger: createLogger({ silent: true }),
+          resolveRequestContext: () => STANDALONE_REQUEST_CONTEXT,
+          authorizer: {
+            listAgentAccess: input =>
+              Promise.resolve(
+                input.action === 'manage'
+                  ? { kind: 'agent_external_ids', agent_external_ids: ['managed-agent-external'] }
+                  : { kind: 'agent_external_ids', agent_external_ids: [] },
+              ),
+            canAccessAgent: () => Promise.resolve(false),
+          },
+        }),
+      );
+
+      expect((await app.request('/managed-session/turns')).status).toBe(200);
+      expect((await app.request('/managed-session/turns/missing')).status).toBe(404);
+      expect((await app.request('/managed-session/turns/missing/events')).status).toBe(404);
+      expect((await app.request('/managed-session/turns/missing/subscribe')).status).toBe(404);
+      expect(
+        (
+          await app.request(
+            `/managed-session/turns/missing/download-sandbox-file?path=${encodeURIComponent('/workspace/file.txt')}`,
+          )
+        ).status,
+      ).toBe(403);
+      expect(
+        (
+          await app.request('/managed-session/turns', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ stream: false }),
+          })
+        ).status,
+      ).toBe(403);
+    });
   });
 
   describe('create turn non-streaming', () => {


### PR DESCRIPTION
## Summary

You can read a session, turn, events, metrics, schedule, or its runs if you created it, or if you manage the named agent it is bound to. Creating still requires permission to use that agent. Only the creator can update, delete, or cancel a session, create a turn, or download sandbox files. Only the creator can update, delete, pause, resume, or run a schedule. An OIDC settings admin can no longer see other users' schedules.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Authorization behavior changes across sessions, turns, schedules, and metrics APIs, including removing admin bypass for schedules; mistakes could leak or over-restrict tenant data.
> 
> **Overview**
> **Read access** for sessions, turns, events, internal metrics, schedules, and schedule runs now follows a shared rule: the **creator** or someone with **`manage`** on the session/schedule’s **named agent** (via `canReadAgentBoundResource` / `resolveManagedAgentIds`). **Writes stay creator-only**—update/delete/cancel sessions, create turns, sandbox downloads, and schedule update/delete/manual run still require ownership.
> 
> **Listing** no longer uses OIDC **admin** to see every schedule or session. List handlers pass `created_by_or_agent_ids` (creator OR managed agent ids) into session/schedule stores; Postgres/SQLite gain shared `whereCreatedByOrAgentIds`. An authorizer **`all`** manage scope intentionally returns **no** extra agent ids so broad grants do not widen related-resource visibility.
> 
> **Session metrics** can aggregate all creators for an agent when the caller manages that agent. OpenAPI/SDK copy for listing schedule runs reflects the new read rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 246cf71690d41cd202446eb1f292b22f8987747c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->