### PR TITLE
end: add my sessions and my schedules filter

### DIFF
--- a/.changeset/created-by-me-list-filter.md
+++ b/.changeset/created-by-me-list-filter.md
@@ -1,0 +1,6 @@
+---
+"@truefoundry/trueforge": patch
+"@truefoundry/trueforge-sdk": patch
+---
+
+Add `created_by_me` to list sessions and list schedules so callers can restrict results to resources they created (excluding managed-agent visibility).

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -6304,12 +6304,12 @@
             }
           },
           {
-            "description": "When true, only schedules created by the authenticated subject. When omitted or false, also includes schedules for agents the caller manages.",
+            "description": "When true, only schedules created by the authenticated subject.",
             "in": "query",
             "name": "created_by_me",
             "required": false,
             "schema": {
-              "description": "When true, only schedules created by the authenticated subject. When omitted or false, also includes schedules for agents the caller manages.",
+              "description": "When true, only schedules created by the authenticated subject.",
               "type": "boolean"
             }
           }
@@ -6848,7 +6848,7 @@
             "required": false,
             "schema": {
               "description": "When true, only sessions created by the authenticated subject.",
-              "type": "string"
+              "type": "boolean"
             }
           }
         ],

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -6268,7 +6268,7 @@
     },
     "/api/v1/schedules": {
       "get": {
-        "description": "List schedules for the tenant, newest first. Optionally filter by `agent_names`.",
+        "description": "List schedules for the tenant, newest first.",
         "parameters": [
           {
             "description": "Page size. Defaults to 25",
@@ -6301,6 +6301,16 @@
             "schema": {
               "description": "Filter by one or more agent names (comma-separated). When set, at least one name is required.",
               "type": "string"
+            }
+          },
+          {
+            "description": "When true, only schedules created by the authenticated subject. When omitted or false, also includes schedules for agents the caller manages.",
+            "in": "query",
+            "name": "created_by_me",
+            "required": false,
+            "schema": {
+              "description": "When true, only schedules created by the authenticated subject. When omitted or false, also includes schedules for agents the caller manages.",
+              "type": "boolean"
             }
           }
         ],
@@ -6763,7 +6773,7 @@
     },
     "/api/v1/sessions": {
       "get": {
-        "description": "List the caller's sessions (newest first by default), token-paginated. Results are scoped to the authenticated identity via the session store's `created_by_subject.subject_id` filter (not a client query param). Optional `agent_id` filters to sessions bound to that named agent. Pass `page_token` to fetch the next page, keeping the other query params constant.",
+        "description": "List the caller's sessions (newest first by default).",
         "parameters": [
           {
             "description": "Page size. Defaults to 25, max 25.",
@@ -6828,6 +6838,16 @@
             "schema": {
               "description": "When set, only sessions bound to this agent id are returned.",
               "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "When true, only sessions created by the authenticated subject.",
+            "in": "query",
+            "name": "created_by_me",
+            "required": false,
+            "schema": {
+              "description": "When true, only sessions created by the authenticated subject.",
               "type": "string"
             }
           }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6304,12 +6304,12 @@
             }
           },
           {
-            "description": "When true, only schedules created by the authenticated subject. When omitted or false, also includes schedules for agents the caller manages.",
+            "description": "When true, only schedules created by the authenticated subject.",
             "in": "query",
             "name": "created_by_me",
             "required": false,
             "schema": {
-              "description": "When true, only schedules created by the authenticated subject. When omitted or false, also includes schedules for agents the caller manages.",
+              "description": "When true, only schedules created by the authenticated subject.",
               "type": "boolean"
             }
           }
@@ -6848,7 +6848,7 @@
             "required": false,
             "schema": {
               "description": "When true, only sessions created by the authenticated subject.",
-              "type": "string"
+              "type": "boolean"
             }
           }
         ],

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6268,7 +6268,7 @@
     },
     "/api/v1/schedules": {
       "get": {
-        "description": "List schedules for the tenant, newest first. Optionally filter by `agent_names`.",
+        "description": "List schedules for the tenant, newest first.",
         "parameters": [
           {
             "description": "Page size. Defaults to 25",
@@ -6301,6 +6301,16 @@
             "schema": {
               "description": "Filter by one or more agent names (comma-separated). When set, at least one name is required.",
               "type": "string"
+            }
+          },
+          {
+            "description": "When true, only schedules created by the authenticated subject. When omitted or false, also includes schedules for agents the caller manages.",
+            "in": "query",
+            "name": "created_by_me",
+            "required": false,
+            "schema": {
+              "description": "When true, only schedules created by the authenticated subject. When omitted or false, also includes schedules for agents the caller manages.",
+              "type": "boolean"
             }
           }
         ],
@@ -6763,7 +6773,7 @@
     },
     "/api/v1/sessions": {
       "get": {
-        "description": "List the caller's sessions (newest first by default), token-paginated. Results are scoped to the authenticated identity via the session store's `created_by_subject.subject_id` filter (not a client query param). Optional `agent_id` filters to sessions bound to that named agent. Pass `page_token` to fetch the next page, keeping the other query params constant.",
+        "description": "List the caller's sessions (newest first by default).",
         "parameters": [
           {
             "description": "Page size. Defaults to 25, max 25.",
@@ -6828,6 +6838,16 @@
             "schema": {
               "description": "When set, only sessions bound to this agent id are returned.",
               "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "When true, only sessions created by the authenticated subject.",
+            "in": "query",
+            "name": "created_by_me",
+            "required": false,
+            "schema": {
+              "description": "When true, only sessions created by the authenticated subject.",
               "type": "string"
             }
           }

--- a/packages/trueforge-sdk/reference.md
+++ b/packages/trueforge-sdk/reference.md
@@ -770,7 +770,7 @@ await client.models.list();
 <dl>
 <dd>
 
-List schedules for the tenant, newest first. Optionally filter by `agent_names`.
+List schedules for the tenant, newest first.
 </dd>
 </dl>
 </dd>
@@ -1235,7 +1235,7 @@ await client.schedules.listRuns("schedule_id");
 <dl>
 <dd>
 
-List the caller's sessions (newest first by default), token-paginated. Results are scoped to the authenticated identity via the session store's `created_by_subject.subject_id` filter (not a client query param). Optional `agent_id` filters to sessions bound to that named agent. Pass `page_token` to fetch the next page, keeping the other query params constant.
+List the caller's sessions (newest first by default).
 </dd>
 </dl>
 </dd>

--- a/packages/trueforge-sdk/src/api/resources/schedules/client/Client.ts
+++ b/packages/trueforge-sdk/src/api/resources/schedules/client/Client.ts
@@ -24,7 +24,7 @@ export class SchedulesClient {
     }
 
     /**
-     * List schedules for the tenant, newest first. Optionally filter by `agent_names`.
+     * List schedules for the tenant, newest first.
      *
      * @param {TrueForge.ListSchedulesRequest} request
      * @param {SchedulesClient.RequestOptions} requestOptions - Request-specific configuration.
@@ -45,11 +45,12 @@ export class SchedulesClient {
             async (
                 request: TrueForge.ListSchedulesRequest,
             ): Promise<core.WithRawResponse<TrueForge.ListSchedulesResponse>> => {
-                const { limit = 25, pageToken, agentNames } = request;
+                const { limit = 25, pageToken, agentNames, createdByMe } = request;
                 const _queryParams: Record<string, unknown> = {
                     limit,
                     page_token: pageToken,
                     agent_names: agentNames,
+                    created_by_me: createdByMe,
                 };
                 const _authRequest: core.AuthRequest = await this._options.authProvider.getAuthRequest();
                 const _headers: core.Fetcher.Args["headers"] = mergeHeaders(

--- a/packages/trueforge-sdk/src/api/resources/schedules/client/requests/ListSchedulesRequest.ts
+++ b/packages/trueforge-sdk/src/api/resources/schedules/client/requests/ListSchedulesRequest.ts
@@ -11,4 +11,6 @@ export interface ListSchedulesRequest {
     pageToken?: string;
     /** Filter by one or more agent names (comma-separated). When set, at least one name is required. */
     agentNames?: string;
+    /** When true, only schedules created by the authenticated subject. When omitted or false, also includes schedules for agents the caller manages. */
+    createdByMe?: boolean;
 }

--- a/packages/trueforge-sdk/src/api/resources/schedules/client/requests/ListSchedulesRequest.ts
+++ b/packages/trueforge-sdk/src/api/resources/schedules/client/requests/ListSchedulesRequest.ts
@@ -11,6 +11,6 @@ export interface ListSchedulesRequest {
     pageToken?: string;
     /** Filter by one or more agent names (comma-separated). When set, at least one name is required. */
     agentNames?: string;
-    /** When true, only schedules created by the authenticated subject. When omitted or false, also includes schedules for agents the caller manages. */
+    /** When true, only schedules created by the authenticated subject. */
     createdByMe?: boolean;
 }

--- a/packages/trueforge-sdk/src/api/resources/sessions/client/Client.ts
+++ b/packages/trueforge-sdk/src/api/resources/sessions/client/Client.ts
@@ -24,7 +24,7 @@ export class SessionsClient {
     }
 
     /**
-     * List the caller's sessions (newest first by default), token-paginated. Results are scoped to the authenticated identity via the session store's `created_by_subject.subject_id` filter (not a client query param). Optional `agent_id` filters to sessions bound to that named agent. Pass `page_token` to fetch the next page, keeping the other query params constant.
+     * List the caller's sessions (newest first by default).
      *
      * @param {TrueForge.ListSessionsRequest} request
      * @param {SessionsClient.RequestOptions} requestOptions - Request-specific configuration.
@@ -44,7 +44,7 @@ export class SessionsClient {
             async (
                 request: TrueForge.ListSessionsRequest,
             ): Promise<core.WithRawResponse<TrueForge.ListSessionsResponse>> => {
-                const { limit = 25, order, pageToken, startTimestamp, endTimestamp, agentId } = request;
+                const { limit = 25, order, pageToken, startTimestamp, endTimestamp, agentId, createdByMe } = request;
                 const _queryParams: Record<string, unknown> = {
                     limit,
                     order:
@@ -60,6 +60,7 @@ export class SessionsClient {
                     start_timestamp: startTimestamp != null ? startTimestamp?.toISOString() : undefined,
                     end_timestamp: endTimestamp != null ? endTimestamp?.toISOString() : undefined,
                     agent_id: agentId,
+                    created_by_me: createdByMe,
                 };
                 const _authRequest: core.AuthRequest = await this._options.authProvider.getAuthRequest();
                 const _headers: core.Fetcher.Args["headers"] = mergeHeaders(

--- a/packages/trueforge-sdk/src/api/resources/sessions/client/requests/ListSessionsRequest.ts
+++ b/packages/trueforge-sdk/src/api/resources/sessions/client/requests/ListSessionsRequest.ts
@@ -19,4 +19,6 @@ export interface ListSessionsRequest {
     endTimestamp?: Date;
     /** When set, only sessions bound to this agent id are returned. */
     agentId?: string;
+    /** When true, only sessions created by the authenticated subject. */
+    createdByMe?: string;
 }

--- a/packages/trueforge-sdk/src/api/resources/sessions/client/requests/ListSessionsRequest.ts
+++ b/packages/trueforge-sdk/src/api/resources/sessions/client/requests/ListSessionsRequest.ts
@@ -20,5 +20,5 @@ export interface ListSessionsRequest {
     /** When set, only sessions bound to this agent id are returned. */
     agentId?: string;
     /** When true, only sessions created by the authenticated subject. */
-    createdByMe?: string;
+    createdByMe?: boolean;
 }

--- a/packages/trueforge/src/apis/schedules.ts
+++ b/packages/trueforge/src/apis/schedules.ts
@@ -112,14 +112,16 @@ function isScheduleOwner(requestContext: Pick<RequestContext, 'subject'>, create
 
 export function createSchedulesRouter<TTransaction>(deps: SchedulesRouterDeps<TTransaction>) {
   const listHandler: RouteHandler<typeof listSchedulesRoute> = async c => {
-    const { agent_names: agentNames, limit, page_token: pageToken } = c.req.valid('query');
+    const { agent_names: agentNames, limit, page_token: pageToken, created_by_me: createdByMe } = c.req.valid('query');
     const requestContext = deps.resolveRequestContext(c);
     try {
-      const managedAgentIds = await resolveManagedAgentIds({
-        store: deps.resolveAgentStore(c),
-        context: requestContext,
-        authorizer: deps.authorizer,
-      });
+      const managedAgentIds = createdByMe
+        ? []
+        : await resolveManagedAgentIds({
+            store: deps.resolveAgentStore(c),
+            context: requestContext,
+            authorizer: deps.authorizer,
+          });
       const { data, pagination } = await deps.scheduleStore.listSchedules({
         tenant_id: requestContext.tenant_id,
         limit,

--- a/packages/trueforge/src/apis/sessions.ts
+++ b/packages/trueforge/src/apis/sessions.ts
@@ -483,11 +483,13 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
     const query = c.req.valid('query');
     const requestContext = deps.resolveRequestContext(c);
     try {
-      const managedAgentIds = await resolveManagedAgentIds({
-        store: deps.resolveAgentStore(c),
-        context: requestContext,
-        authorizer: deps.authorizer,
-      });
+      const managedAgentIds = query.created_by_me
+        ? []
+        : await resolveManagedAgentIds({
+            store: deps.resolveAgentStore(c),
+            context: requestContext,
+            authorizer: deps.authorizer,
+          });
       const { data, pagination } = await deps.sessionStore.listSessions({
         agent_id: query.agent_id,
         created_by_or_agent_ids: {

--- a/packages/trueforge/src/routes/scheduleRoutes.ts
+++ b/packages/trueforge/src/routes/scheduleRoutes.ts
@@ -43,6 +43,11 @@ export const ListSchedulesQuerySchema = z
       })
       .transform(value => parseCommaSeparatedQuery(value))
       .pipe(z.array(NameSchema).min(1).optional()),
+    created_by_me: z
+      .stringbool()
+      .optional()
+      .describe('When true, only schedules created by the authenticated subject.')
+      .openapi({ type: 'boolean' }),
   })
   .openapi('ListSchedulesQuery');
 
@@ -51,7 +56,7 @@ export const listSchedulesRoute = createRoute({
   path: '/',
   tags: [OpenApiTag.SCHEDULES],
   summary: 'List schedules',
-  description: 'List schedules for the tenant, newest first. Optionally filter by `agent_names`.',
+  description: 'List schedules for the tenant, newest first.',
   'x-fern-sdk-group-name': ['schedules'],
   'x-fern-sdk-method-name': 'list',
   'x-fern-pagination': TOKEN_PAGINATION,

--- a/packages/trueforge/src/routes/sessionRoutes.ts
+++ b/packages/trueforge/src/routes/sessionRoutes.ts
@@ -202,8 +202,7 @@ export const listSessionsRoute = createRoute({
   path: '/',
   tags: [OpenApiTag.AGENT_SESSIONS],
   summary: 'List sessions',
-  description:
-    "List the caller's sessions (newest first by default), token-paginated. Results are scoped to the authenticated identity via the session store's `created_by_subject.subject_id` filter (not a client query param). Optional `agent_id` filters to sessions bound to that named agent. Pass `page_token` to fetch the next page, keeping the other query params constant.",
+  description: "List the caller's sessions (newest first by default).",
   'x-fern-sdk-group-name': ['sessions'],
   'x-fern-sdk-method-name': 'list',
   'x-fern-pagination': TOKEN_PAGINATION,

--- a/packages/trueforge/src/schemas/session.ts
+++ b/packages/trueforge/src/schemas/session.ts
@@ -92,7 +92,11 @@ export const ListSessionsRequestQuerySchema = z
       'Inclusive upper bound on `created_at` (ISO-8601 / RFC 3339).',
     ),
     agent_id: z.string().min(1).optional().describe('When set, only sessions bound to this agent id are returned.'),
-    created_by_me: z.stringbool().optional().describe('When true, only sessions created by the authenticated subject.'),
+    created_by_me: z
+      .stringbool()
+      .optional()
+      .describe('When true, only sessions created by the authenticated subject.')
+      .openapi({ type: 'boolean' }),
   })
   .openapi('ListSessionsRequestQuery');
 

--- a/packages/trueforge/src/schemas/session.ts
+++ b/packages/trueforge/src/schemas/session.ts
@@ -92,6 +92,7 @@ export const ListSessionsRequestQuerySchema = z
       'Inclusive upper bound on `created_at` (ISO-8601 / RFC 3339).',
     ),
     agent_id: z.string().min(1).optional().describe('When set, only sessions bound to this agent id are returned.'),
+    created_by_me: z.stringbool().optional().describe('When true, only sessions created by the authenticated subject.'),
   })
   .openapi('ListSessionsRequestQuery');
 

--- a/packages/trueforge/tests/unit/apis/schedules.test.ts
+++ b/packages/trueforge/tests/unit/apis/schedules.test.ts
@@ -192,10 +192,20 @@ describe('schedule RBAC', () => {
     asUser(BOB);
     expect((await app.request(`/${id}`)).status).toBe(200);
     expect(ListSchedulesResponseSchema.parse(await (await app.request('/')).json()).data).toHaveLength(1);
+    expect(
+      ListSchedulesResponseSchema.parse(await (await app.request('/?created_by_me=true')).json()).data,
+    ).toHaveLength(0);
     expect(ListScheduleRunsResponseSchema.parse(await (await app.request(`/${id}/runs`)).json()).data).toHaveLength(1);
     expect((await postJson(`/${id}`, 'PUT', { name: 'renamed', manifest: scheduleBody.manifest })).status).toBe(403);
     expect((await app.request(`/${id}`, { method: 'DELETE' })).status).toBe(403);
     expect((await postJson('/runs', 'POST', { schedule_id: id })).status).toBe(403);
+
+    asUser(ALICE);
+    expect(
+      ListSchedulesResponseSchema.parse(await (await app.request('/?created_by_me=true')).json()).data.map(
+        row => row.id,
+      ),
+    ).toEqual([id]);
   });
 });
 

--- a/packages/trueforge/tests/unit/apis/sessionHttp.test.ts
+++ b/packages/trueforge/tests/unit/apis/sessionHttp.test.ts
@@ -284,6 +284,21 @@ describe('sessions HTTP agent binding', () => {
     expect(ListSessionsResponseSchema.parse(await listed.json()).data.map(session => session.id)).toContain(
       'managed-session',
     );
+    const listedMine = await managerApp.request('/?created_by_me=true');
+    expect(listedMine.status).toBe(200);
+    expect(ListSessionsResponseSchema.parse(await listedMine.json()).data.map(session => session.id)).not.toContain(
+      'managed-session',
+    );
+    expect((await managerApp.request('/?created_by_me=maybe')).status).toBe(400);
+
+    const own = await app.request('/', jsonInit('POST', { agent: { spec: inlineSpec } }));
+    expect(own.status).toBe(201);
+    const ownId = ((await own.json()) as { data: { id: string } }).data.id;
+    expect(
+      ListSessionsResponseSchema.parse(await (await app.request('/?created_by_me=true')).json()).data.map(
+        session => session.id,
+      ),
+    ).toContain(ownId);
 
     const query = new URLSearchParams({
       agent_id: agent.id,


### PR DESCRIPTION
## Summary
Add an explicit bool filter for `created_by_me` for sessions and schedules.

## Changes

-

## How was this tested?
unit tests added.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization-scoped list behavior for sessions and schedules; incorrect handling could hide or expose the wrong resources across tenants/subjects.
> 
> **Overview**
> Adds optional **`created_by_me`** query parameter on **GET `/api/v1/sessions`** and **GET `/api/v1/schedules`**, plus matching SDK request fields (`createdByMe`).
> 
> When **`created_by_me=true`**, list handlers skip resolving managed-agent IDs and pass an empty agent list into the existing `created_by_or_agent_ids` filter, so results are limited to resources the authenticated subject created—not sessions/schedules visible only through agent-management permissions. Default list behavior is unchanged when the flag is omitted.
> 
> OpenAPI/route schemas, generated SDK clients, and reference docs are updated; list endpoint descriptions are shortened. Unit tests cover manager vs creator listing and invalid boolean query values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d5efb9b8352f785a01290d7e75cada50c3e518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->