### PR TITLE
Add use and delete agent actions

### DIFF
--- a/packages/trueforge/src/apis/agents.ts
+++ b/packages/trueforge/src/apis/agents.ts
@@ -158,7 +158,7 @@ export function createAgentsRouter<TTransaction>(deps: AgentsRouterDeps<TTransac
     const existing = await agentIfAccessible({
       authorizer: deps.authorizer,
       context: requestContext,
-      action: 'manage',
+      action: 'delete',
       agent: await deps.resolveAgentStore(c).getAgent({ tenant_id: requestContext.tenant_id, id: agentId }),
     });
     if (existing === undefined) {

--- a/packages/trueforge/src/apis/schedules.ts
+++ b/packages/trueforge/src/apis/schedules.ts
@@ -184,11 +184,11 @@ export function createSchedulesRouter<TTransaction>(deps: SchedulesRouterDeps<TT
       return c.json({ error: { message: FORBIDDEN_SCHEDULE_ACCESS } }, 403);
     }
 
-    // Schedule ownership alone must not invoke an agent the caller cannot read.
+    // Schedule ownership alone must not invoke an agent the caller cannot use.
     const agent = await agentIfAccessible({
       authorizer: deps.authorizer,
       context: requestContext,
-      action: 'read',
+      action: 'use',
       agent: await deps.resolveAgentStore(c).getAgent({
         tenant_id: requestContext.tenant_id,
         name: schedule.agent_name,
@@ -259,7 +259,7 @@ export function createSchedulesRouter<TTransaction>(deps: SchedulesRouterDeps<TT
     const agent = await agentIfAccessible({
       authorizer: deps.authorizer,
       context: requestContext,
-      action: 'read',
+      action: 'use',
       agent: await deps.resolveAgentStore(c).getAgent({ tenant_id: requestContext.tenant_id, name: body.agent_name }),
     });
     if (agent === undefined) {

--- a/packages/trueforge/src/apis/sessions.ts
+++ b/packages/trueforge/src/apis/sessions.ts
@@ -270,7 +270,7 @@ function createGetOrCreateSessionByExternalIdHandler(
       const named = await agentIfAccessible({
         authorizer: deps.authorizer,
         context: requestContext,
-        action: 'read',
+        action: 'use',
         agent: await deps.resolveAgentStore(c).getAgent({
           tenant_id: requestContext.tenant_id,
           name: body.agent.name,
@@ -332,7 +332,7 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
       const agent = await agentIfAccessible({
         authorizer: deps.authorizer,
         context: requestContext,
-        action: 'read',
+        action: 'use',
         agent: await deps.resolveAgentStore(c).getAgent({
           tenant_id: requestContext.tenant_id,
           name: body.agent.name,

--- a/packages/trueforge/src/apis/turns.ts
+++ b/packages/trueforge/src/apis/turns.ts
@@ -734,12 +734,12 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
       if (agent === undefined) {
         return c.json({ error: { message: `Agent not found: ${agentId}` } }, 422);
       }
-      const canReadAgent = await deps.authorizer.canAccessAgent({
+      const canUseAgent = await deps.authorizer.canAccessAgent({
         context: requestContext,
-        action: 'read',
+        action: 'use',
         agent,
       });
-      if (!canReadAgent) {
+      if (!canUseAgent) {
         return c.json({ error: { message: `Agent not found: ${agentId}` } }, 404);
       }
     }

--- a/packages/trueforge/src/auth/authorizer.ts
+++ b/packages/trueforge/src/auth/authorizer.ts
@@ -1,7 +1,7 @@
 import type { AgentRecord } from '../db/agentStore';
 import type { RequestContext } from './identity';
 
-export type AgentAction = 'read' | 'manage';
+export type AgentAction = 'read' | 'use' | 'manage' | 'delete';
 
 export type AgentListAccess = { kind: 'all' } | { kind: 'agent_external_ids'; agent_external_ids: readonly string[] };
 
@@ -10,14 +10,14 @@ export interface Authorizer {
   canAccessAgent(input: { context: RequestContext; action: AgentAction; agent: AgentRecord }): Promise<boolean>;
 }
 
-/** Standalone and OIDC: tenant-local agents. Read is unconstrained; manage is creator-only. */
+/** Standalone and OIDC: tenant-local agents. Read/use are unconstrained; manage/delete are creator-only. */
 export class TrueForgeAuthorizer implements Authorizer {
   listAgentAccess(): Promise<AgentListAccess> {
     return Promise.resolve({ kind: 'all' });
   }
 
   canAccessAgent(input: { context: RequestContext; action: AgentAction; agent: AgentRecord }): Promise<boolean> {
-    if (input.action === 'read') {
+    if (input.action === 'read' || input.action === 'use') {
       return Promise.resolve(true);
     }
     return Promise.resolve(input.agent.created_by_subject.subject_id === input.context.subject.id);

--- a/packages/trueforge/src/truefoundry/TrueFoundryAuthorizer.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryAuthorizer.ts
@@ -5,10 +5,15 @@ import type { RequestContext } from '../auth/identity';
 import type { AgentRecord } from '../db/agentStore';
 import type { AgentPermission, TrueFoundryServiceFoundryServerClient } from './TrueFoundryServiceFoundryServerClient';
 
+const permissionByAction: Record<AgentAction, AgentPermission> = {
+  read: 'READ_AGENT',
+  use: 'USE_AGENT',
+  manage: 'MANAGE_AGENT',
+  delete: 'DELETE_AGENT',
+};
+
 function allowsAction(permissions: readonly AgentPermission[], action: AgentAction): boolean {
-  return action === 'manage'
-    ? permissions.includes('MANAGE_AGENT')
-    : permissions.includes('READ_AGENT') || permissions.includes('MANAGE_AGENT');
+  return permissions.includes(permissionByAction[action]);
 }
 
 function requireUserCredential(context: RequestContext): string {

--- a/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
@@ -62,7 +62,7 @@ const PutRemoteAgentResponseSchema = z.object({
   agentId: z.string().min(1),
 });
 
-const AgentPermissionSchema = z.enum(['READ_AGENT', 'MANAGE_AGENT']);
+const AgentPermissionSchema = z.enum(['READ_AGENT', 'USE_AGENT', 'MANAGE_AGENT', 'DELETE_AGENT']);
 export type AgentPermission = z.infer<typeof AgentPermissionSchema>;
 
 /** ServiceFoundry may return grants we do not use; drop them instead of failing. */

--- a/packages/trueforge/tests/unit/apis/agents.test.ts
+++ b/packages/trueforge/tests/unit/apis/agents.test.ts
@@ -1,5 +1,5 @@
 import { createAgentsRouter } from '../../../src/apis/agents';
-import { TrueForgeAuthorizer, type Authorizer } from '../../../src/auth/authorizer';
+import { TrueForgeAuthorizer, type AgentListAccess, type Authorizer } from '../../../src/auth/authorizer';
 import { STANDALONE_REQUEST_CONTEXT } from '../../../src/auth/identity';
 import { migrateSqliteToLatest } from '../../../src/db/migrateSqlite';
 import { SqliteAgentStore } from '../../../src/db/sqlite/agent-store/SqliteAgentStore';
@@ -69,9 +69,14 @@ function jsonInit(method: string, body: unknown): RequestInit {
   };
 }
 
+const deniedListAgentAccess = jest.fn(
+  (_input: Parameters<Authorizer['listAgentAccess']>[0]): Promise<AgentListAccess> =>
+    Promise.resolve({ kind: 'agent_external_ids', agent_external_ids: [] }),
+);
+const deniedCanAccessAgent = jest.fn((_input: Parameters<Authorizer['canAccessAgent']>[0]) => Promise.resolve(false));
 const denyAllAuthorizer: Authorizer = {
-  listAgentAccess: () => Promise.resolve({ kind: 'agent_external_ids', agent_external_ids: [] }),
-  canAccessAgent: () => Promise.resolve(false),
+  listAgentAccess: deniedListAgentAccess,
+  canAccessAgent: deniedCanAccessAgent,
 };
 
 describe('agents router', () => {
@@ -209,6 +214,8 @@ describe('agents router', () => {
   });
 
   it('lists, gets, updates, and deletes as not found when the authorizer denies the agent', async () => {
+    deniedListAgentAccess.mockClear();
+    deniedCanAccessAgent.mockClear();
     const created = await router.request('/', jsonInit('POST', { ...writeBody, name: 'denied-agent' }));
     expect(created.status).toBe(201);
     const { data } = (await created.json()) as { data: { id: string } };
@@ -222,5 +229,12 @@ describe('agents router', () => {
     expect((await deniedRouter.request(`/${data.id}`, jsonInit('PUT', updateBody))).status).toBe(404);
     expect((await deniedRouter.request(`/${data.id}`, { method: 'DELETE' })).status).toBe(404);
     expect((await router.request(`/${data.id}`)).status).toBe(200);
+    expect(deniedListAgentAccess.mock.calls.map(([input]) => input.action)).toEqual(['read']);
+    expect(deniedCanAccessAgent.mock.calls.map(([input]) => input.action)).toEqual([
+      'read',
+      'read',
+      'manage',
+      'delete',
+    ]);
   });
 });

--- a/packages/trueforge/tests/unit/apis/schedules.test.ts
+++ b/packages/trueforge/tests/unit/apis/schedules.test.ts
@@ -345,15 +345,17 @@ describe('create schedule run', () => {
     expect(runNow?.status).toBe('failed');
   });
 
-  it('returns 404 when creating a schedule for an agent the caller cannot read', async () => {
+  it('returns 404 when creating a schedule for an agent the caller cannot use', async () => {
+    const canAccessAgent = jest.fn((_input: Parameters<Authorizer['canAccessAgent']>[0]) => Promise.resolve(false));
     const denyAll: Authorizer = {
       listAgentAccess: () => Promise.resolve({ kind: 'agent_external_ids', agent_external_ids: [] }),
-      canAccessAgent: () => Promise.resolve(false),
+      canAccessAgent,
     };
     const { postJson } = await setup(denyAll);
     const res = await postJson('/', 'POST', scheduleBody);
     expect(res.status).toBe(404);
     expect(((await res.json()) as { error: { message: string } }).error.message).toBe('Agent not found: reporter');
+    expect(canAccessAgent.mock.calls.map(([input]) => input.action)).toEqual(['use']);
   });
 
   it('returns 404 on run-now when the caller can access the schedule but not the agent', async () => {
@@ -363,9 +365,10 @@ describe('create schedule run', () => {
     const created = await postJson('/', 'POST', scheduleBody);
     const { id: scheduleId } = ((await created.json()) as { data: { id: string } }).data;
 
+    const canAccessAgent = jest.fn((_input: Parameters<Authorizer['canAccessAgent']>[0]) => Promise.resolve(false));
     setAuthorizer({
       listAgentAccess: () => Promise.resolve({ kind: 'agent_external_ids', agent_external_ids: [] }),
-      canAccessAgent: () => Promise.resolve(false),
+      canAccessAgent,
     });
 
     const res = await postJson('/runs', 'POST', { schedule_id: scheduleId });
@@ -375,5 +378,6 @@ describe('create schedule run', () => {
 
     const runs = await scheduleStore.listRuns({ tenant_id: 'default', schedule_id: scheduleId });
     expect(runs.some(r => r.name.startsWith('manual-'))).toBe(false);
+    expect(canAccessAgent.mock.calls.map(([input]) => input.action)).toEqual(['use']);
   });
 });

--- a/packages/trueforge/tests/unit/apis/sessionHttp.test.ts
+++ b/packages/trueforge/tests/unit/apis/sessionHttp.test.ts
@@ -41,9 +41,10 @@ function jsonInit(method: string, body: unknown): RequestInit {
   };
 }
 
+const deniedCanAccessAgent = jest.fn((_input: Parameters<Authorizer['canAccessAgent']>[0]) => Promise.resolve(false));
 const denyAllAuthorizer: Authorizer = {
   listAgentAccess: () => Promise.resolve({ kind: 'agent_external_ids', agent_external_ids: [] }),
-  canAccessAgent: () => Promise.resolve(false),
+  canAccessAgent: deniedCanAccessAgent,
 };
 
 describe('sessions HTTP agent binding', () => {
@@ -553,7 +554,8 @@ describe('sessions HTTP agent binding', () => {
     });
   });
 
-  it('returns 404 when creating a session for a named agent the caller cannot read', async () => {
+  it('returns 404 when creating a session for a named agent the caller cannot use', async () => {
+    deniedCanAccessAgent.mockClear();
     const agent = await agentStore.createAgent({
       tenant_id: 'default',
       created_by_subject: {
@@ -585,6 +587,7 @@ describe('sessions HTTP agent binding', () => {
     );
     expect(getOrCreate.status).toBe(404);
     expect(await getOrCreate.json()).toEqual({ error: { message: `Agent not found: ${agent.name}` } });
+    expect(deniedCanAccessAgent.mock.calls.map(([input]) => input.action)).toEqual(['use', 'use']);
   });
 
   it('rejects create bodies that mix name and AgentSpec fields', async () => {

--- a/packages/trueforge/tests/unit/apis/turns.test.ts
+++ b/packages/trueforge/tests/unit/apis/turns.test.ts
@@ -403,9 +403,12 @@ describe('turns', () => {
   });
 
   describe('create turn referenced agent', () => {
+    const deniedCanAccessAgent = jest.fn((_input: Parameters<Authorizer['canAccessAgent']>[0]) =>
+      Promise.resolve(false),
+    );
     const denyAllAuthorizer: Authorizer = {
       listAgentAccess: () => Promise.resolve({ kind: 'agent_external_ids', agent_external_ids: [] }),
-      canAccessAgent: () => Promise.resolve(false),
+      canAccessAgent: deniedCanAccessAgent,
     };
 
     async function referencedAgentHarness(authorizer: Authorizer) {
@@ -475,7 +478,8 @@ describe('turns', () => {
       expect(await response.json()).toEqual({ error: { message: `Agent not found: ${agent.id}` } });
     });
 
-    it('returns 404 when the caller cannot read the referenced agent', async () => {
+    it('returns 404 when the caller cannot use the referenced agent', async () => {
+      deniedCanAccessAgent.mockClear();
       const { app, agent } = await referencedAgentHarness(denyAllAuthorizer);
       const response = await app.request('/s1/turns', {
         method: 'POST',
@@ -484,6 +488,7 @@ describe('turns', () => {
       });
       expect(response.status).toBe(404);
       expect(await response.json()).toEqual({ error: { message: `Agent not found: ${agent.id}` } });
+      expect(deniedCanAccessAgent.mock.calls.map(([input]) => input.action)).toEqual(['use']);
     });
   });
 });


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization on agent execution and deletion across sessions, schedules, and turns; in TrueFoundry mode callers may lose access where they only had READ_AGENT, or gain/lose delete vs manage behavior.
> 
> **Overview**
> Introduces **`use`** and **`delete`** as first-class agent authorization actions, aligned with ServiceFoundry permissions **`USE_AGENT`** and **`DELETE_AGENT`**.
> 
> **Execution paths** (create session, get-or-create by external id, create schedule, schedule run-now, create turn on a referenced agent) now require **`use`** instead of **`read`**, so invoking an agent can be gated separately from viewing metadata. **Agent DELETE** checks **`delete`** rather than **`manage`**. Standalone/OIDC still treats read/use as open and manage/delete as creator-only; TrueFoundry maps each action to exactly one permission instead of treating manage as implying read.
> 
> Unit tests assert the authorizer is called with the expected action (`use`, `delete`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22db9cd8550d47d3080a5abbcddbd31c4e093fb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->