### PR TITLE
Use agent name for ServiceFoundry remote agent description

### DIFF
--- a/.changeset/remote-agent-description-name.md
+++ b/.changeset/remote-agent-description-name.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": patch
+---
+
+Use agent name for ServiceFoundry remote agent description so save succeeds when instructions are empty.

--- a/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
@@ -29,7 +29,7 @@ function toPutRemoteAgentPayload({
 }): Omit<PutRemoteAgentInput, 'accessToken'> {
   return {
     name,
-    description: manifest.instructions ?? name,
+    description: name,
     model: manifest.model.name,
     mcp_servers: (manifest.mcp_servers ?? []).map(server => server.name),
   };

--- a/packages/trueforge/tests/unit/truefoundry/TrueFoundryAgentStore.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/TrueFoundryAgentStore.test.ts
@@ -153,7 +153,7 @@ describe('TrueFoundryAgentStore', () => {
       expect(input).toEqual({
         accessToken: TOKEN,
         name: 'research',
-        description: 'Be helpful.',
+        description: 'research',
         model: 'openai-gateway/gpt-5',
         mcp_servers: ['slack'],
       });
@@ -220,7 +220,7 @@ describe('TrueFoundryAgentStore', () => {
     expect(deleteRemoteAgent).not.toHaveBeenCalled();
   });
 
-  it('createAgent uses agent name as description when instructions are omitted', async () => {
+  it('createAgent uses agent name as description even when instructions are empty', async () => {
     const putRemoteAgent = jest.fn(async (input: PutRemoteAgentInput) => {
       expect(input.description).toBe('research');
       expect(input.mcp_servers).toEqual([]);
@@ -238,7 +238,7 @@ describe('TrueFoundryAgentStore', () => {
         tenant_id: TENANT,
         created_by_subject: CREATED_BY_SUBJECT,
         name: 'research',
-        manifest: AgentSpecSchema.parse({ model: { name: 'openai-gateway/gpt-5' } }),
+        manifest: AgentSpecSchema.parse({ model: { name: 'openai-gateway/gpt-5' }, instructions: '' }),
         external_id: null,
       },
       TXN,
@@ -518,7 +518,7 @@ describe('TrueFoundryAgentStore', () => {
       expect.objectContaining({
         accessToken: TOKEN,
         name: previous.name,
-        description: previous.manifest.instructions ?? previous.name,
+        description: previous.name,
         model: previous.manifest.model.name,
       }),
     );


### PR DESCRIPTION
## Summary
Use agent name for ServiceFoundry remote agent description instead of instructions

Closes AGE-2114

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to the ServiceFoundry sync payload with matching unit tests; no auth or data-model changes.
> 
> **Overview**
> ServiceFoundry remote agent sync no longer sends manifest **instructions** as the remote **description**. **`toPutRemoteAgentPayload`** always sets **`description`** to the agent **name**, including on create, manifest updates, and the restore **`putRemoteAgent`** after a failed DB write.
> 
> This avoids failed saves when instructions are empty (previously an empty string could be sent as the description). Unit expectations were updated to match, including an explicit empty-instructions case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9726af54c60292548fda0c8befd5a61ba1b56e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->