### PR TITLE
Enhance Dockerfile.dev by adding root scripts for package build steps

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -34,6 +34,8 @@ RUN pnpm fetch
 # ---------------------------------------------------------------------------
 FROM store AS workspace
 COPY package.json .npmrc tsconfig.base.json ./
+# Root scripts used by package build steps (rm-path.mjs, chmod-path.mjs).
+COPY scripts scripts
 COPY packages/trueforge-core/package.json packages/trueforge-core/package.json
 COPY packages/trueforge/package.json packages/trueforge/package.json
 COPY packages/trueforge-sdk/package.json packages/trueforge-sdk/package.json


### PR DESCRIPTION
…. This includes copying necessary scripts to the workspace for improved build process.

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects the dev Docker build context; no runtime, auth, or application logic changes.
> 
> **Overview**
> **Dockerfile.dev** now copies the repo root **`scripts/`** directory into the **`workspace`** build stage, alongside the manifests and other install inputs.
> 
> Package builds for **`@truefoundry/trueforge`** and the UI invoke **`../../scripts/rm-path.mjs`** and **`../../scripts/chmod-path.mjs`** during **`pnpm build`**. Without this copy, those steps fail inside the dev image build even though local workspace builds work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d7e9b40d2c78cc956b0e3701251d1f651c04f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->