### PR TITLE
Resolve AgentSpec skills by version FQN on save and turn

### DIFF
--- a/.changeset/20260908173000-age-2128-fqn-skills.md
+++ b/.changeset/20260908173000-age-2128-fqn-skills.md
@@ -1,0 +1,6 @@
+---
+"@truefoundry/trueforge": patch
+"@truefoundry/trueforge-core": patch
+---
+
+AgentSpec skills: TrueFoundry save/turn resolve via SFY; standalone git validate/resolve on the skill store.

--- a/packages/trueforge/src/apis/turns.ts
+++ b/packages/trueforge/src/apis/turns.ts
@@ -53,7 +53,6 @@ import {
   buildTurnSandbox,
   getMcpConnection,
   getModelDetails,
-  resolveGitSkills,
   resolveSandboxProvider,
 } from '../runtime/sessionResources';
 import { checkSnapshotStatus } from '../sandbox/providerUtils';
@@ -221,15 +220,18 @@ function createTurnResolver(deps: {
           });
         }
       }
-      const gitSkills = await resolveGitSkills({
-        tenant_id,
-        skills: spec.skills ?? [],
-        store: skillStore,
-      });
+      const skills = spec.skills ?? [];
+      const mountSkills =
+        skills.length === 0
+          ? []
+          : await skillStore.resolveTurnSkills({
+              tenant_id,
+              skills,
+            });
       return buildTurnSandbox({
         provider,
         logger,
-        skills: gitSkills,
+        skills: mountSkills,
         fileDownloadEnabled: spec.config.sandbox.file_downloads,
         existingSandboxId: carriedSandboxId,
         tracing,

--- a/packages/trueforge/src/db/gitSkillMounts.ts
+++ b/packages/trueforge/src/db/gitSkillMounts.ts
@@ -1,4 +1,6 @@
+import type { Skill as SkillMount } from '@truefoundry/trueforge-core/core';
 import { HTTPException } from 'hono/http-exception';
+import { parseGitSkill } from '../schemas/skill';
 import type { AgentSkillsInput, ISkillStore } from './skillStore';
 
 /** Admit configured git skills; reject preload. */
@@ -32,4 +34,42 @@ export async function validateGitAgentSkills(
       });
     }
   }
+}
+
+/** Expand configured git skills to sandbox mounts. */
+export async function resolveGitTurnSkills(
+  store: Pick<ISkillStore, 'listSkills'>,
+  input: AgentSkillsInput,
+): Promise<SkillMount[]> {
+  const { tenant_id, skills } = input;
+  if (skills.length === 0) {
+    return [];
+  }
+  const names = skills.map(skill => skill.name);
+  const records = await store.listSkills({ tenant_id, names });
+  const byName = new Map(records.map(record => [record.name, record]));
+  const resolved: SkillMount[] = [];
+  for (const skill of skills) {
+    const record = byName.get(skill.name);
+    if (record === undefined) {
+      throw new HTTPException(422, {
+        message: `Unknown skill "${skill.name}" — not configured`,
+      });
+    }
+    const git = parseGitSkill(record.manifest);
+    if (git === undefined) {
+      throw new HTTPException(422, {
+        message: `Skill "${skill.name}" is not a git skill`,
+      });
+    }
+    resolved.push({
+      type: 'git',
+      name: git.name,
+      description: git.description,
+      url: git.url,
+      path: git.path ?? '',
+      ref: git.ref,
+    });
+  }
+  return resolved;
 }

--- a/packages/trueforge/src/db/postgres/skill-store/PostgresSkillStore.ts
+++ b/packages/trueforge/src/db/postgres/skill-store/PostgresSkillStore.ts
@@ -1,6 +1,7 @@
+import type { Skill as SkillMount } from '@truefoundry/trueforge-core/core';
 import type { Kysely, Selectable, Transaction } from 'kysely';
 import type { SkillVersion } from '../../../schemas/skill';
-import { validateGitAgentSkills } from '../../gitSkillMounts';
+import { resolveGitTurnSkills, validateGitAgentSkills } from '../../gitSkillMounts';
 import {
   SkillNameConflictError,
   type AgentSkillsInput,
@@ -97,5 +98,9 @@ export class PostgresSkillStore implements ISkillStore<Transaction<Database>> {
   validateAgentSkills(input: AgentSkillsInput, transaction?: Transaction<Database>): Promise<void> {
     void transaction;
     return validateGitAgentSkills(this, input);
+  }
+
+  resolveTurnSkills(input: AgentSkillsInput): Promise<SkillMount[]> {
+    return resolveGitTurnSkills(this, input);
   }
 }

--- a/packages/trueforge/src/db/skillStore.ts
+++ b/packages/trueforge/src/db/skillStore.ts
@@ -4,6 +4,7 @@
  * Implementations: PostgresSkillStore and SqliteSkillStore.
  */
 import type { Skill as AgentSkillRef } from '@truefoundry/trueforge-core/agent-session';
+import type { Skill as SkillMount } from '@truefoundry/trueforge-core/core';
 import type { SkillManifest, SkillVersion } from '../schemas/skill';
 
 export interface SkillRecord {
@@ -35,7 +36,7 @@ export interface CreateSkillInput {
 /** Same shape as create for now; kept as a distinct name for the upsert path. */
 export type UpsertSkillInput = CreateSkillInput;
 
-/** AgentSpec `skills` refs for save validate. */
+/** AgentSpec `skills` refs for validate and resolve. */
 export interface AgentSkillsInput {
   tenant_id: string;
   skills: readonly AgentSkillRef[];
@@ -63,4 +64,6 @@ export interface ISkillStore<TTransaction = never> {
   listSkillVersions(input: { name: string }): Promise<SkillVersion[]>;
   /** Admit AgentSpec skill refs (git store or TrueFoundry SFY resolve with caller token). */
   validateAgentSkills(input: AgentSkillsInput, transaction?: TTransaction): Promise<void>;
+  /** Expand AgentSpec skill refs to sandbox mounts (git store or TrueFoundry SFY resolve with API key). */
+  resolveTurnSkills(input: AgentSkillsInput): Promise<SkillMount[]>;
 }

--- a/packages/trueforge/src/db/sqlite/skill-store/SqliteSkillStore.ts
+++ b/packages/trueforge/src/db/sqlite/skill-store/SqliteSkillStore.ts
@@ -1,6 +1,7 @@
+import type { Skill as SkillMount } from '@truefoundry/trueforge-core/core';
 import type { ExpressionBuilder, Kysely, Transaction } from 'kysely';
 import type { SkillManifest, SkillVersion } from '../../../schemas/skill';
-import { validateGitAgentSkills } from '../../gitSkillMounts';
+import { resolveGitTurnSkills, validateGitAgentSkills } from '../../gitSkillMounts';
 import {
   SkillNameConflictError,
   type AgentSkillsInput,
@@ -97,5 +98,9 @@ export class SqliteSkillStore implements ISkillStore<Transaction<Database>> {
   validateAgentSkills(input: AgentSkillsInput, transaction?: Transaction<Database>): Promise<void> {
     void transaction;
     return validateGitAgentSkills(this, input);
+  }
+
+  resolveTurnSkills(input: AgentSkillsInput): Promise<SkillMount[]> {
+    return resolveGitTurnSkills(this, input);
   }
 }

--- a/packages/trueforge/src/runtime/sessionResources.ts
+++ b/packages/trueforge/src/runtime/sessionResources.ts
@@ -4,7 +4,6 @@ import {
   SkillMounter,
   type AgentDefinition,
   type AgentTracing,
-  type GitSkill,
   type ModelParams,
   type RemoteMcpHeaders,
   type SandboxProvider,
@@ -23,7 +22,6 @@ import { LocalSandboxProvider } from '../sandbox/local/provider/LocalSandboxProv
 import { getCachedLocalSandboxSupport, isLocalSandboxFallbackEnabled } from '../sandbox/localRuntime';
 import { toSandboxProviderFromRecord } from '../sandbox/providerUtils';
 import type { ReasoningEffort } from '../schemas/modelProvider';
-import { parseGitSkill } from '../schemas/skill';
 
 export interface McpConnection {
   url: string;
@@ -125,52 +123,6 @@ export async function getMcpConnection({
     url: record.manifest.url,
     headers: store.resolveInvokeHeaders({ record, userRef }),
   };
-}
-
-/**
- * Expand agent_spec skill names into git mounts from the skill store.
- * Wire url/path/ref/description on the request are ignored — the store row wins.
- * Throws HTTPException(422) if any name is missing or not a git skill.
- */
-export async function resolveGitSkills({
-  tenant_id,
-  skills,
-  store,
-}: {
-  tenant_id: string;
-  skills: readonly { name: string }[];
-  store: ISkillStore;
-}): Promise<GitSkill[]> {
-  if (skills.length === 0) {
-    return [];
-  }
-  const names = skills.map(skill => skill.name);
-  const records = await store.listSkills({ tenant_id, names });
-  const byName = new Map(records.map(record => [record.name, record]));
-  const resolved: GitSkill[] = [];
-  for (const skill of skills) {
-    const record = byName.get(skill.name);
-    if (record === undefined) {
-      throw new HTTPException(422, {
-        message: `Unknown skill "${skill.name}" — not configured`,
-      });
-    }
-    const git = parseGitSkill(record.manifest);
-    if (git === undefined) {
-      throw new HTTPException(422, {
-        message: `Skill "${skill.name}" is not a git skill`,
-      });
-    }
-    resolved.push({
-      type: 'git',
-      name: git.name,
-      description: git.description,
-      url: git.url,
-      path: git.path ?? '',
-      ref: git.ref,
-    });
-  }
-  return resolved;
 }
 
 /**

--- a/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
@@ -151,6 +151,11 @@ export class TrueFoundryServiceFoundryServerClient {
     this.#apiKey = input.apiKey;
   }
 
+  /** Service API key (`TRUEFOUNDRY_API_KEY`); callers pass it explicitly when needed. */
+  get apiKey(): string {
+    return this.#apiKey;
+  }
+
   /**
    * Model integrations. No limit/offset → full match set in one response.
    * Pass `filter` (account + model name together) for a point lookup.
@@ -270,42 +275,6 @@ export class TrueFoundryServiceFoundryServerClient {
     });
   }
 
-  /**
-   * `POST /internal/tfg/agent-skill-versions/resolve`. Chunks to 50 FQNs.
-   * Caller supplies the token (caller JWT on save validate).
-   * Failures: SFY HTTP errors from `#requestJson` (401/403/424/500); unexpected body → 500.
-   */
-  async resolveAgentSkillVersions(input: {
-    accessToken: string;
-    skills: readonly { fqn: string }[];
-  }): Promise<ResolvedAgentSkillVersion[]> {
-    if (input.skills.length === 0) {
-      return [];
-    }
-    const resolved: ResolvedAgentSkillVersion[] = [];
-    for (let i = 0; i < input.skills.length; i += AGENT_SKILL_RESOLVE_CHUNK_SIZE) {
-      const chunk = input.skills.slice(i, i + AGENT_SKILL_RESOLVE_CHUNK_SIZE);
-      const payload = await this.#requestJson({
-        url: this.#url(TFG_AGENT_SKILL_VERSIONS_RESOLVE_PATH),
-        accessToken: input.accessToken,
-        method: 'POST',
-        body: { skills: chunk.map(({ fqn }) => ({ fqn })) },
-      });
-      try {
-        resolved.push(...mapResolvedAgentSkillVersions(payload));
-      } catch (error) {
-        this.#logger.error('TrueFoundry ServiceFoundry resolve agent-skill-versions returned an unexpected response', {
-          ...extractErrorLogFields(error),
-        });
-        throw new HTTPException(500, {
-          message: 'TrueFoundry ServiceFoundry resolve agent-skill-versions returned an unexpected response',
-          cause: error,
-        });
-      }
-    }
-    return resolved;
-  }
-
   /** `GET /v1/agent-skill-versions?fqn=` (one row) or `?agent_skill_id=` (all versions). */
   async listAgentSkillVersions(input: {
     accessToken: string;
@@ -325,6 +294,52 @@ export class TrueFoundryServiceFoundryServerClient {
       query,
       limit: AGENT_SKILLS_PAGE_SIZE,
     });
+  }
+
+  /**
+   * `POST /internal/tfg/agent-skill-versions/resolve`. Chunks to 50 FQNs.
+   * Caller supplies the token (caller JWT on save validate; service API key on turns).
+   * Failures: SFY HTTP errors from `#requestJson` (401/403/424/500); unexpected body → 500.
+   */
+  async resolveAgentSkillVersions(input: {
+    accessToken: string;
+    skills: readonly {
+      fqn: string;
+      include_skill_md_content?: boolean;
+      include_presigned_url?: boolean;
+    }[];
+  }): Promise<ResolvedAgentSkillVersion[]> {
+    if (input.skills.length === 0) {
+      return [];
+    }
+    const resolved: ResolvedAgentSkillVersion[] = [];
+    for (let i = 0; i < input.skills.length; i += AGENT_SKILL_RESOLVE_CHUNK_SIZE) {
+      const chunk = input.skills.slice(i, i + AGENT_SKILL_RESOLVE_CHUNK_SIZE);
+      const payload = await this.#requestJson({
+        url: this.#url(TFG_AGENT_SKILL_VERSIONS_RESOLVE_PATH),
+        accessToken: input.accessToken,
+        method: 'POST',
+        body: {
+          skills: chunk.map(({ fqn, include_skill_md_content = false, include_presigned_url = false }) => ({
+            fqn,
+            include_skill_md_content,
+            include_presigned_url,
+          })),
+        },
+      });
+      try {
+        resolved.push(...mapResolvedAgentSkillVersions(payload));
+      } catch (error) {
+        this.#logger.error('TrueFoundry ServiceFoundry resolve agent-skill-versions returned an unexpected response', {
+          ...extractErrorLogFields(error),
+        });
+        throw new HTTPException(500, {
+          message: 'TrueFoundry ServiceFoundry resolve agent-skill-versions returned an unexpected response',
+          cause: error,
+        });
+      }
+    }
+    return resolved;
   }
 
   /** Offset/limit list until empty page or `pagination.total`. */

--- a/packages/trueforge/src/truefoundry/TrueFoundrySkillStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundrySkillStore.ts
@@ -1,3 +1,4 @@
+import type { Skill as SkillMount } from '@truefoundry/trueforge-core/core';
 import { HTTPException } from 'hono/http-exception';
 import type { Logger } from 'winston';
 import type { RequestContext } from '../auth/identity';
@@ -23,7 +24,7 @@ import type { TrueFoundryServiceFoundryServerClient } from './TrueFoundryService
 
 export type TrueFoundrySkillApiClient = Pick<
   TrueFoundryServiceFoundryServerClient,
-  'listAgentSkills' | 'listAgentSkillVersions' | 'vendToken' | 'resolveAgentSkillVersions'
+  'listAgentSkills' | 'listAgentSkillVersions' | 'vendToken' | 'resolveAgentSkillVersions' | 'apiKey'
 >;
 
 function toRegistryRecord(tenant_id: string, skill: SfyRegistrySkill): SkillRecord {
@@ -47,6 +48,7 @@ function toRegistryRecord(tenant_id: string, skill: SfyRegistrySkill): SkillReco
 
 /** Read-only TrueFoundry registry skill catalog; writes are managed by TrueFoundry.
  * Pass `agent` on turn/cron paths so catalog reads use the same vend token as models and MCP.
+ * Save validate uses the caller JWT; turn mounts pass the service API key.
  */
 export class TrueFoundrySkillStore<TTransaction = never> implements ISkillStore<TTransaction> {
   readonly #client: TrueFoundrySkillApiClient;
@@ -151,5 +153,52 @@ export class TrueFoundrySkillStore<TTransaction = never> implements ISkillStore<
       }
       seenNames.add(row.name);
     }
+  }
+
+  async resolveTurnSkills(input: AgentSkillsInput): Promise<SkillMount[]> {
+    const { skills } = input;
+    if (skills.length === 0) {
+      return [];
+    }
+
+    // Runtime resolve uses the service API key, not the caller token.
+    const resolved = await this.#client.resolveAgentSkillVersions({
+      accessToken: this.#client.apiKey,
+      skills: skills.map(skill => ({
+        fqn: skill.name,
+        include_skill_md_content: skill.preload,
+        include_presigned_url: true,
+      })),
+    });
+
+    const byFqn = new Map(resolved.map(row => [row.fqn, row]));
+    return skills.map(skill => {
+      const row = byFqn.get(skill.name);
+      if (row === undefined) {
+        throw new HTTPException(422, {
+          message: `Unknown skill "${skill.name}" — not configured`,
+        });
+      }
+      if (row.presigned_url === undefined) {
+        throw new HTTPException(422, {
+          message: `Skill "${skill.name}" did not return a presigned URL`,
+        });
+      }
+      const skillMdContent = skill.preload ? (row.skill_md_content ?? null) : null;
+      if (skill.preload && (skillMdContent === null || skillMdContent.length === 0)) {
+        throw new HTTPException(422, {
+          message: `Skill "${skill.name}" did not return SKILL.md for preload`,
+        });
+      }
+      return {
+        type: 'registry' as const,
+        name: row.name,
+        description: row.description,
+        fqn: row.fqn,
+        preload: skill.preload,
+        skillMdContent,
+        presignedUrl: row.presigned_url,
+      };
+    });
   }
 }

--- a/packages/trueforge/src/truefoundry/mapSfyAgentSkills.ts
+++ b/packages/trueforge/src/truefoundry/mapSfyAgentSkills.ts
@@ -44,6 +44,8 @@ export const ResolvedAgentSkillVersionSchema = z.object({
   fqn: z.string().min(1),
   name: z.string().min(1),
   description: z.string().min(1),
+  skill_md_content: z.string().nullable().optional(),
+  presigned_url: z.string().min(1).optional(),
 });
 
 export type ResolvedAgentSkillVersion = z.infer<typeof ResolvedAgentSkillVersionSchema>;

--- a/packages/trueforge/tests/db/skillStoreContractSuite.ts
+++ b/packages/trueforge/tests/db/skillStoreContractSuite.ts
@@ -140,20 +140,6 @@ export function runSkillStoreContractSuite(getStore: () => ISkillStore): void {
     });
   });
 
-  it('validateAgentSkills rejects preload on git skills', async () => {
-    const store = getStore();
-    await store.upsertSkill({ tenant_id: TENANT, name: 'algorithmic-art', manifest: manifest() });
-    await expect(
-      store.validateAgentSkills({
-        tenant_id: TENANT,
-        skills: [{ name: 'algorithmic-art', preload: true }],
-      }),
-    ).rejects.toMatchObject({
-      status: 422,
-      message: 'Skill "algorithmic-art": preload is not supported for git skills',
-    });
-  });
-
   it('listSkills filters by names and returns empty for an empty name list', async () => {
     const store = getStore();
     await store.upsertSkill({ tenant_id: TENANT, name: 'algorithmic-art', manifest: manifest() });
@@ -185,5 +171,36 @@ export function runSkillStoreContractSuite(getStore: () => ISkillStore): void {
     const store = getStore();
     await store.upsertSkill({ tenant_id: TENANT, name: 'algorithmic-art', manifest: manifest() });
     await expect(store.listSkillVersions({ name: 'algorithmic-art' })).resolves.toEqual([]);
+  });
+
+  it('validateAgentSkills and resolveTurnSkills round-trip git skills', async () => {
+    const store = getStore();
+    await store.upsertSkill({ tenant_id: TENANT, name: 'algorithmic-art', manifest: manifest() });
+    const skills = [{ name: 'algorithmic-art', preload: false }];
+    await expect(store.validateAgentSkills({ tenant_id: TENANT, skills })).resolves.toBeUndefined();
+    await expect(store.resolveTurnSkills({ tenant_id: TENANT, skills })).resolves.toEqual([
+      {
+        type: 'git',
+        name: 'algorithmic-art',
+        description: 'Creating algorithmic art using p5.js with seeded randomness.',
+        url: 'https://github.com/anthropics/skills',
+        path: 'skills/algorithmic-art',
+        ref: 'main',
+      },
+    ]);
+  });
+
+  it('validateAgentSkills rejects preload on git skills', async () => {
+    const store = getStore();
+    await store.upsertSkill({ tenant_id: TENANT, name: 'algorithmic-art', manifest: manifest() });
+    await expect(
+      store.validateAgentSkills({
+        tenant_id: TENANT,
+        skills: [{ name: 'algorithmic-art', preload: true }],
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: 'Skill "algorithmic-art": preload is not supported for git skills',
+    });
   });
 }

--- a/packages/trueforge/tests/unit/apis/skills.test.ts
+++ b/packages/trueforge/tests/unit/apis/skills.test.ts
@@ -143,6 +143,7 @@ describe('skills routers', () => {
       upsertSkill: jest.fn(),
       listSkillVersions: jest.fn(),
       validateAgentSkills: jest.fn(),
+      resolveTurnSkills: jest.fn(),
     };
     const router = createAvailableSkillsRouter({
       resolveSkillStore: () => skillStore,
@@ -189,6 +190,7 @@ describe('skills routers', () => {
       upsertSkill: jest.fn().mockResolvedValue(record),
       listSkillVersions: jest.fn(),
       validateAgentSkills: jest.fn(),
+      resolveTurnSkills: jest.fn(),
     };
     const router = createSkillsRouter({
       resolveSkillStore: () => managedStore,
@@ -227,6 +229,7 @@ describe('skills routers', () => {
       upsertSkill: jest.fn(() => trueFoundryManaged()),
       listSkillVersions: jest.fn(),
       validateAgentSkills: jest.fn(),
+      resolveTurnSkills: jest.fn(),
     };
     const router = createSkillsRouter({
       resolveSkillStore: () => managedStore,

--- a/packages/trueforge/tests/unit/runtime/sessionResources.test.ts
+++ b/packages/trueforge/tests/unit/runtime/sessionResources.test.ts
@@ -1,6 +1,8 @@
 import { AgentSpecSchema } from '@truefoundry/trueforge-core/agent-session';
 import { HTTPException } from 'hono/http-exception';
+import { validateGitAgentSkills } from '../../../src/db/gitSkillMounts';
 import { migrateSqliteToLatest } from '../../../src/db/migrateSqlite';
+import type { ISkillStore } from '../../../src/db/skillStore';
 import { createSqliteDb } from '../../../src/db/sqlite/client';
 import { SqliteMcpServerStore } from '../../../src/db/sqlite/mcp-server-store/SqliteMcpServerStore';
 import { SqliteModelProviderStore } from '../../../src/db/sqlite/model-provider-store/SqliteModelProviderStore';
@@ -284,7 +286,7 @@ describe('validateAgentSpec', () => {
     expect(await stores.sandboxProviderStore.getSandboxProvider('default')).toBeUndefined();
   });
 
-  it('allows registry skills referenced by version FQN', async () => {
+  it('rejects registry catalog rows as git mounts (standalone)', async () => {
     const stores = await setup();
     setCachedLocalSandboxSupport({
       supported: true,
@@ -294,7 +296,7 @@ describe('validateAgentSpec', () => {
     });
     const fqn = 'agent-skill:acme/team-a/echo:1';
     const now = '2026-01-01T00:00:00.000Z';
-    const skillStore = {
+    const skillStore: ISkillStore = {
       listSkills: async () => [
         {
           tenant_id: 'default',
@@ -311,7 +313,6 @@ describe('validateAgentSpec', () => {
           updated_at: now,
         },
       ],
-      validateAgentSkills: async () => undefined,
       createSkill: async () => {
         throw new Error('unused');
       },
@@ -319,6 +320,12 @@ describe('validateAgentSpec', () => {
         throw new Error('unused');
       },
       listSkillVersions: async () => [],
+      async validateAgentSkills(input) {
+        return validateGitAgentSkills(this, input);
+      },
+      resolveTurnSkills: async () => {
+        throw new Error('unused');
+      },
     };
     await expect(
       validateAgentSpec({
@@ -331,6 +338,70 @@ describe('validateAgentSpec', () => {
         ...stores,
         skillStore,
       }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: `Skill "${fqn}" is not a git skill`,
+    });
+  });
+
+  it('validates skills via skillStore.validateAgentSkills', async () => {
+    const stores = await setup();
+    setCachedLocalSandboxSupport({
+      supported: true,
+      platform: 'darwin',
+      shell: '/bin/bash',
+      python: '/usr/bin/python3',
+    });
+    const validateAgentSkills = jest.spyOn(stores.skillStore, 'validateAgentSkills').mockResolvedValue(undefined);
+    await expect(
+      validateAgentSpec({
+        spec: AgentSpecSchema.parse({
+          model: { name: 'test-provider/test-model' },
+          instructions: 'test',
+          skills: [{ name: 'agent-skill:acme/team-a/echo:3', preload: false }],
+        }),
+        tenant_id: 'default',
+        ...stores,
+      }),
     ).resolves.toBeUndefined();
+    expect(validateAgentSkills).toHaveBeenCalledWith({
+      tenant_id: 'default',
+      skills: [{ name: 'agent-skill:acme/team-a/echo:3', preload: false }],
+    });
+  });
+
+  it('rejects preload on git skills', async () => {
+    const stores = await setup();
+    setCachedLocalSandboxSupport({
+      supported: true,
+      platform: 'darwin',
+      shell: '/bin/bash',
+      python: '/usr/bin/python3',
+    });
+    await stores.skillStore.upsertSkill({
+      tenant_id: 'default',
+      name: 'echo',
+      manifest: {
+        type: 'git',
+        name: 'echo',
+        description: 'Echo',
+        url: 'https://github.com/acme/skills',
+        ref: 'main',
+      },
+    });
+    await expect(
+      validateAgentSpec({
+        spec: AgentSpecSchema.parse({
+          model: { name: 'test-provider/test-model' },
+          instructions: 'test',
+          skills: [{ name: 'echo', preload: true }],
+        }),
+        tenant_id: 'default',
+        ...stores,
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: 'Skill "echo": preload is not supported for git skills',
+    });
   });
 });

--- a/packages/trueforge/tests/unit/truefoundry/TrueFoundrySkillStore.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/TrueFoundrySkillStore.test.ts
@@ -68,6 +68,7 @@ function createStore(
       },
     ]),
     vendToken: jest.fn().mockResolvedValue(AGENT_TOKEN),
+    apiKey: 'tfy-api-key',
   };
   const store = new TrueFoundrySkillStore({
     client,
@@ -315,6 +316,45 @@ describe('TrueFoundrySkillStore', () => {
     expect(client.resolveAgentSkillVersions).toHaveBeenCalledWith({
       accessToken: ACCESS_TOKEN,
       skills: [{ fqn: 'agent-skill:acme/team-a/echo:3' }],
+    });
+  });
+
+  it('resolveTurnSkills passes the service API key', async () => {
+    const { store, client } = createStore();
+    client.resolveAgentSkillVersions.mockResolvedValue([
+      {
+        fqn: 'agent-skill:acme/team-a/echo:3',
+        name: 'echo',
+        description: 'Echo skill',
+        skill_md_content: '# Echo',
+        presigned_url: 'https://example.com/echo.tgz',
+      },
+    ]);
+    await expect(
+      store.resolveTurnSkills({
+        tenant_id: TENANT,
+        skills: [{ name: 'agent-skill:acme/team-a/echo:3', preload: true }],
+      }),
+    ).resolves.toEqual([
+      {
+        type: 'registry',
+        name: 'echo',
+        description: 'Echo skill',
+        fqn: 'agent-skill:acme/team-a/echo:3',
+        preload: true,
+        skillMdContent: '# Echo',
+        presignedUrl: 'https://example.com/echo.tgz',
+      },
+    ]);
+    expect(client.resolveAgentSkillVersions).toHaveBeenCalledWith({
+      accessToken: 'tfy-api-key',
+      skills: [
+        {
+          fqn: 'agent-skill:acme/team-a/echo:3',
+          include_skill_md_content: true,
+          include_presigned_url: true,
+        },
+      ],
     });
   });
 });

--- a/packages/trueforge/tests/unit/truefoundry/mapSfyAgentSkills.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/mapSfyAgentSkills.test.ts
@@ -92,6 +92,7 @@ describe('mapSfyRegistrySkills', () => {
             fqn: 'agent-skill:acme/team-a/echo:3',
             name: 'echo',
             description: 'Echo skill',
+            skill_md_content: null,
           },
         ],
       }),
@@ -100,6 +101,7 @@ describe('mapSfyRegistrySkills', () => {
         fqn: 'agent-skill:acme/team-a/echo:3',
         name: 'echo',
         description: 'Echo skill',
+        skill_md_content: null,
       },
     ]);
   });


### PR DESCRIPTION
## Summary

Resolve AgentSpec skills by version FQN on save and turn

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turn-time skill mounting now depends on ServiceFoundry resolve with the service API key and presigned URLs; misconfiguration or SFY failures would break sandbox skill loads at runtime.
> 
> **Overview**
> Moves **AgentSpec skill resolution** onto `ISkillStore`: **`validateAgentSkills`** on save and the new **`resolveTurnSkills`** when building a turn sandbox, instead of inlining git expansion in `sessionResources`.
> 
> **Standalone** git skills validate and expand through `gitSkillMounts` (`resolveGitTurnSkills`); **TrueFoundry** registry version FQNs still validate via ServiceFoundry resolve with the **caller token**, but **turn mounts** call resolve with the **service API key**, requesting **presigned URLs** and optional **SKILL.md** when `preload` is set. Turn execution in `turns.ts` passes the resulting mounts into `buildTurnSandbox`.
> 
> The SFY client gains an **`apiKey` getter**, richer resolve payload flags, and parsing for `skill_md_content` / `presigned_url` on resolved versions. Contract and unit tests cover git round-trip, token vs API-key resolve, and standalone rejection of registry rows as git mounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ff777f93914728f243b957f755eb4f1546b4c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->