### PR TITLE
Chore: Show runtime config in drawer

### DIFF
--- a/.changeset/runtime-config-drawer.md
+++ b/.changeset/runtime-config-drawer.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge-ui": minor
+---
+
+Open Runtime Config in a right-side drawer and label scheduled sessions consistently.

--- a/packages/trueforge-ui/README.md
+++ b/packages/trueforge-ui/README.md
@@ -407,7 +407,7 @@ show the title text (see [Custom layouts](#custom-layouts)).
 
 In library modes, picking an agent from Agents switches to a named chat for that agent **and remounts the runtime** so the new agent starts from a clean conversation. Draft chats can be promoted via **Save agent** (`server.saveAgent` on the resolved `AgentUIServer`). **Clear Chat** (thread header) resets the current named or draft session.
 
-Mutable composers expose **Agent Config** for live model parameters, instructions, runtime behavior, per-connector MCP tools, and skills. The compact Tools picker contains only Connectors and Skills. The Save Agent dialog keeps a local editable copy of the same configuration and shares the same selector dialogs; cancelling it leaves the active draft unchanged. Model context and output limits render when the server supplies that optional catalog metadata.
+Mutable composers expose **Agent Config** for live model parameters, instructions, runtime behavior, per-connector MCP tools, and skills. Runtime Config opens in a second right-side drawer. The compact Tools picker contains only Connectors and Skills. The Save Agent dialog keeps a local editable copy of the same configuration and shares the same selector dialogs; cancelling it leaves the active draft unchanged. Model context and output limits render when the server supplies that optional catalog metadata.
 
 ```tsx
 {

--- a/packages/trueforge-ui/src/atoms/agent-details/AgentSessionListRow.tsx
+++ b/packages/trueforge-ui/src/atoms/agent-details/AgentSessionListRow.tsx
@@ -31,9 +31,9 @@ export function AgentSessionListRow({
       <span className="flex items-start justify-between gap-2">
         <span className="line-clamp-2 text-sm font-medium text-text-primary">{title}</span>
         {sourceType === 'schedule' ? (
-          <Tooltip content="Scheduled run">
+          <Tooltip content="Scheduled Session">
             <span aria-label="Scheduled run" className="mt-0.5 inline-flex shrink-0">
-              <Icon name="calendar" className="size-3.5" />
+              <Icon name="calendar" className="size-3.5 text-primary-button-bg" />
             </span>
           </Tooltip>
         ) : null}

--- a/packages/trueforge-ui/src/atoms/draft/AgentConfigEditors.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentConfigEditors.tsx
@@ -48,7 +48,7 @@ export function AgentConfigEditors({
 }: AgentConfigEditorsProps) {
   const AgentModelConfigModal = useSlot('AgentModelConfigModal');
   const AgentResourceConfigModal = useSlot('AgentResourceConfigModal');
-  const AgentRuntimeConfigModal = useSlot('AgentRuntimeConfigModal');
+  const AgentRuntimeConfigDrawer = useSlot('AgentRuntimeConfigDrawer');
   const AgentInstructionsDrawer = useSlot('AgentInstructionsDrawer');
   const [query, setQuery] = useState('');
   const [activeConnectorId, setActiveConnectorId] = useState<string | null>(null);
@@ -141,7 +141,7 @@ export function AgentConfigEditors({
         />
       ) : null}
       {editor === 'runtime' ? (
-        <AgentRuntimeConfigModal
+        <AgentRuntimeConfigDrawer
           open
           spec={spec}
           sandboxAvailable={sandboxAvailable}

--- a/packages/trueforge-ui/src/atoms/draft/AgentRuntimeConfigDrawer.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentRuntimeConfigDrawer.tsx
@@ -2,9 +2,9 @@
 
 import type { AgentSpec } from '../../server/types.js';
 import { useSlot } from '../../theme/SlotsProvider.js';
-import { CenteredModal } from '../primitives/CenteredModal.js';
+import { SideDrawer } from '../primitives/SideDrawer.js';
 
-export type AgentRuntimeConfigModalProps = {
+export type AgentRuntimeConfigDrawerProps = {
   open: boolean;
   spec: AgentSpec;
   sandboxAvailable: boolean;
@@ -12,31 +12,32 @@ export type AgentRuntimeConfigModalProps = {
   onClose: () => void;
 };
 
-export function AgentRuntimeConfigModal({
+export function AgentRuntimeConfigDrawer({
   open,
   spec,
   sandboxAvailable,
   onChange,
   onClose,
-}: AgentRuntimeConfigModalProps) {
+}: AgentRuntimeConfigDrawerProps) {
   const AgentRuntimeEditorContent = useSlot('AgentRuntimeEditorContent');
 
   return (
-    <CenteredModal
+    <SideDrawer
       open={open}
       onOpenChange={nextOpen => !nextOpen && onClose()}
       title="Runtime Config"
-      className="md:w-[min(56rem,calc(100%-3rem))] md:max-w-4xl"
-      contentSized
+      description="Control execution, sandbox, and context behavior."
+      anchor="right"
+      size="lg"
       aria-label="Edit Runtime Config"
     >
       <AgentRuntimeEditorContent spec={spec} sandboxAvailable={sandboxAvailable} onChange={onChange} />
-    </CenteredModal>
+    </SideDrawer>
   );
 }
 
 declare module '../../theme/SlotsProvider.js' {
   interface AtomSlots {
-    AgentRuntimeConfigModal: typeof AgentRuntimeConfigModal;
+    AgentRuntimeConfigDrawer: typeof AgentRuntimeConfigDrawer;
   }
 }

--- a/packages/trueforge-ui/src/atoms/draft/AgentRuntimeConfigDrawer.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentRuntimeConfigDrawer.tsx
@@ -28,7 +28,8 @@ export function AgentRuntimeConfigDrawer({
       title="Runtime Config"
       description="Control execution, sandbox, and context behavior."
       anchor="right"
-      size="lg"
+      size="xl"
+      className="md:w-3xl"
       aria-label="Edit Runtime Config"
     >
       <AgentRuntimeEditorContent spec={spec} sandboxAvailable={sandboxAvailable} onChange={onChange} />

--- a/packages/trueforge-ui/src/atoms/draft/AgentRuntimeConfigFields.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentRuntimeConfigFields.tsx
@@ -160,17 +160,13 @@ export function AgentRuntimeConfigFields({
     return (
       <div className="space-y-5">
         {showCapabilities ? (
-          // Stacked below `md` so the bottom-sheet modal does not cram three labeled switches into one row.
-          <div className="flex flex-col gap-3 md:flex-row">
+          // Stack drawer capabilities so labeled switches retain usable width.
+          <div className="flex flex-col gap-3">
             {capabilityFields.map((field, index) =>
               switchField({
                 field,
                 className: 'items-start justify-between gap-3',
-                wrapperClassName: cn(
-                  'flex-1',
-                  index < capabilityFields.length - 1 &&
-                    'border-b border-border pb-3 md:border-b-0 md:border-r md:pb-0 md:pr-3',
-                ),
+                wrapperClassName: cn('flex-1', index < capabilityFields.length - 1 && 'border-b border-border pb-3'),
               }),
             )}
           </div>

--- a/packages/trueforge-ui/src/atoms/draft/AgentRuntimeConfigFields.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentRuntimeConfigFields.tsx
@@ -161,7 +161,7 @@ export function AgentRuntimeConfigFields({
       <div className="space-y-5">
         {showCapabilities ? (
           // Stack below `md` so narrow bottom sheets retain usable control widths.
-          <div className="flex flex-col gap-3 md:flex-row">
+          <div className="flex flex-col gap-3 border-b border-border pb-5 md:flex-row">
             {capabilityFields.map((field, index) =>
               switchField({
                 field,

--- a/packages/trueforge-ui/src/atoms/draft/AgentRuntimeConfigFields.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentRuntimeConfigFields.tsx
@@ -160,13 +160,17 @@ export function AgentRuntimeConfigFields({
     return (
       <div className="space-y-5">
         {showCapabilities ? (
-          // Stack drawer capabilities so labeled switches retain usable width.
-          <div className="flex flex-col gap-3">
+          // Stack below `md` so narrow bottom sheets retain usable control widths.
+          <div className="flex flex-col gap-3 md:flex-row">
             {capabilityFields.map((field, index) =>
               switchField({
                 field,
                 className: 'items-start justify-between gap-3',
-                wrapperClassName: cn('flex-1', index < capabilityFields.length - 1 && 'border-b border-border pb-3'),
+                wrapperClassName: cn(
+                  'flex-1',
+                  index < capabilityFields.length - 1 &&
+                    'border-b border-border pb-3 md:border-b-0 md:border-r md:pb-0 md:pr-3',
+                ),
               }),
             )}
           </div>

--- a/packages/trueforge-ui/src/atoms/draft/AgentRuntimeEditorContent.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentRuntimeEditorContent.tsx
@@ -13,7 +13,7 @@ export function AgentRuntimeEditorContent({ spec, sandboxAvailable, onChange }: 
   const AgentRuntimeConfigFields = useSlot('AgentRuntimeConfigFields');
 
   return (
-    <div className="h-[min(38rem,calc(100dvh-8rem))] w-full overflow-y-auto p-5">
+    <div className="w-full p-5">
       <AgentRuntimeConfigFields
         value={spec.config ?? {}}
         sandboxAvailable={sandboxAvailable}

--- a/packages/trueforge-ui/src/index.ts
+++ b/packages/trueforge-ui/src/index.ts
@@ -479,10 +479,10 @@ export { AgentResourceConfigModal } from './atoms/draft/AgentResourceConfigModal
 export type { AgentResourceConfigModalProps } from './atoms/draft/AgentResourceConfigModal.js';
 export { AgentResourceEditorContent } from './atoms/draft/AgentResourceEditorContent.js';
 export type { AgentResourceEditorContentProps } from './atoms/draft/AgentResourceEditorContent.js';
+export { AgentRuntimeConfigDrawer } from './atoms/draft/AgentRuntimeConfigDrawer.js';
+export type { AgentRuntimeConfigDrawerProps } from './atoms/draft/AgentRuntimeConfigDrawer.js';
 export { AgentRuntimeConfigFields } from './atoms/draft/AgentRuntimeConfigFields.js';
 export type { AgentRuntimeConfigFieldsProps } from './atoms/draft/AgentRuntimeConfigFields.js';
-export { AgentRuntimeConfigModal } from './atoms/draft/AgentRuntimeConfigModal.js';
-export type { AgentRuntimeConfigModalProps } from './atoms/draft/AgentRuntimeConfigModal.js';
 export { AgentRuntimeEditorContent } from './atoms/draft/AgentRuntimeEditorContent.js';
 export type { AgentRuntimeEditorContentProps } from './atoms/draft/AgentRuntimeEditorContent.js';
 export { AgentSkillsEditorContent } from './atoms/draft/AgentSkillsEditorContent.js';

--- a/packages/trueforge-ui/src/theme/defaultSlots.ts
+++ b/packages/trueforge-ui/src/theme/defaultSlots.ts
@@ -50,8 +50,8 @@ import { AgentModelEditorContent } from '../atoms/draft/AgentModelEditorContent.
 import { AgentModelSettingsContent } from '../atoms/draft/AgentModelSettingsContent.js';
 import { AgentResourceConfigModal } from '../atoms/draft/AgentResourceConfigModal.js';
 import { AgentResourceEditorContent } from '../atoms/draft/AgentResourceEditorContent.js';
+import { AgentRuntimeConfigDrawer } from '../atoms/draft/AgentRuntimeConfigDrawer.js';
 import { AgentRuntimeConfigFields } from '../atoms/draft/AgentRuntimeConfigFields.js';
-import { AgentRuntimeConfigModal } from '../atoms/draft/AgentRuntimeConfigModal.js';
 import { AgentRuntimeEditorContent } from '../atoms/draft/AgentRuntimeEditorContent.js';
 import { AgentSkillsEditorContent } from '../atoms/draft/AgentSkillsEditorContent.js';
 import { DraftAgentConfigTrigger } from '../atoms/draft/DraftAgentConfigTrigger.js';
@@ -157,7 +157,7 @@ export const defaultSlots = {
   AgentConfigPanel,
   AgentConfigSection,
   AgentRuntimeConfigFields,
-  AgentRuntimeConfigModal,
+  AgentRuntimeConfigDrawer,
   AgentRuntimeEditorContent,
   DraftCompositeSelector,
   CatalogRow,

--- a/packages/trueforge-ui/test/atoms/SessionsPage.test.tsx
+++ b/packages/trueforge-ui/test/atoms/SessionsPage.test.tsx
@@ -115,7 +115,7 @@ describe('SessionsPage', () => {
 
     const indicator = await screen.findByLabelText('Scheduled run');
     fireEvent.mouseEnter(indicator);
-    expect(await screen.findByRole('tooltip')).toHaveTextContent('Scheduled run');
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Scheduled Session');
   });
 
   it('shows a single empty screen when there are no sessions', async () => {

--- a/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
@@ -232,7 +232,7 @@ describe('AgentConfigEditors', () => {
     });
   });
 
-  it('opens runtime configuration in a dedicated modal', () => {
+  it('opens runtime configuration in a right-side drawer', () => {
     const spec: AgentSpec = { model: { name: 'openai/gpt' } };
     render(
       <SlotsProvider>
@@ -251,7 +251,7 @@ describe('AgentConfigEditors', () => {
       </SlotsProvider>,
     );
 
-    expect(screen.getByRole('dialog', { name: 'Runtime Config' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Runtime Config' })).toHaveClass('md:ml-auto', 'md:mr-0', 'md:h-dvh');
     expect(screen.getByRole('switch', { name: 'Context compaction' })).toBeInTheDocument();
   });
 

--- a/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
@@ -251,7 +251,11 @@ describe('AgentConfigEditors', () => {
       </SlotsProvider>,
     );
 
-    expect(screen.getByRole('dialog', { name: 'Runtime Config' })).toHaveClass('md:ml-auto', 'md:mr-0', 'md:h-dvh');
+    expect(screen.getByRole('dialog', { name: 'Runtime Config' })).toHaveClass(
+      'md:ml-auto',
+      'md:mr-0',
+      'md:h-dvh',
+    );
     expect(screen.getByRole('switch', { name: 'Context compaction' })).toBeInTheDocument();
   });
 

--- a/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
@@ -251,11 +251,7 @@ describe('AgentConfigEditors', () => {
       </SlotsProvider>,
     );
 
-    expect(screen.getByRole('dialog', { name: 'Runtime Config' })).toHaveClass(
-      'md:ml-auto',
-      'md:mr-0',
-      'md:h-dvh',
-    );
+    expect(screen.getByRole('dialog', { name: 'Runtime Config' })).toHaveClass('md:ml-auto', 'md:mr-0', 'md:h-dvh');
     expect(screen.getByRole('switch', { name: 'Context compaction' })).toBeInTheDocument();
   });
 

--- a/packages/trueforge-ui/test/containers/AgentConfigDrawerContainer.test.tsx
+++ b/packages/trueforge-ui/test/containers/AgentConfigDrawerContainer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SaveAgentButton } from '@/atoms/SaveAgentButton.js';
@@ -101,6 +101,33 @@ describe('AgentConfigDrawerContainer', () => {
 
     expect(screen.getByTestId('config-open')).toHaveTextContent('true');
     expect(screen.queryByRole('button', { name: 'Close agent config' })).not.toBeInTheDocument();
+  });
+
+  it('opens Runtime Config in a second right-side drawer', async () => {
+    render(
+      <SlotsProvider>
+        <ServerProvider server={createMockAgentUIServer()}>
+          <ShellModeProvider agentConfig={{ mode: 'AgentComposer' }}>
+            <AgentConfigInstructionsProvider>
+              <TestView compact={false} />
+            </AgentConfigInstructionsProvider>
+          </ShellModeProvider>
+        </ServerProvider>
+      </SlotsProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open config' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Runtime Config' }));
+
+    const runtimeDrawer = await screen.findByRole('dialog', { name: 'Runtime Config' });
+    expect(runtimeDrawer).toHaveClass('md:ml-auto', 'md:mr-0', 'md:h-dvh');
+    fireEvent.click(within(runtimeDrawer).getByRole('switch', { name: 'Generative UI' }));
+
+    expect(updateAgentSpec).toHaveBeenCalledWith({
+      model: { name: 'openai/gpt-4.1' },
+      config: { generativeUi: { enabled: false } },
+      instructions: undefined,
+    });
   });
 
   it('commits drawer instructions and messages in one spec update', () => {

--- a/packages/trueforge-ui/test/publicUiExports.test.ts
+++ b/packages/trueforge-ui/test/publicUiExports.test.ts
@@ -25,7 +25,7 @@ const expectedRuntimeExports: Array<keyof typeof sdk> = [
   'AgentResourceEditorContent',
   'AgentResourceConfigModal',
   'AgentRuntimeConfigFields',
-  'AgentRuntimeConfigModal',
+  'AgentRuntimeConfigDrawer',
   'AgentRuntimeEditorContent',
   'AgentSkillsEditorContent',
   'AgentSessionsFilters',


### PR DESCRIPTION
## Summary

<img width="1920" height="941" alt="image" src="https://github.com/user-attachments/assets/77c5794d-6239-40f3-8945-2f2acdfbe184" />


## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and export rename only; runtime spec updates behave as before with added test coverage.
> 
> **Overview**
> **Runtime Config** no longer opens in a centered modal. It uses a **right-side `SideDrawer`** (with description and xl width) layered on top of Agent Config, and the detailed runtime editor drops the fixed viewport-height scroll shell in favor of drawer-native scrolling. Capability toggles in the detailed layout get clearer section dividers.
> 
> The public slot/export **`AgentRuntimeConfigModal` is replaced by `AgentRuntimeConfigDrawer`** (default slots, package exports, and docs updated). Tests assert right-drawer chrome and that toggling runtime options still updates the live agent spec.
> 
> Scheduled sessions in the session list show tooltip copy **"Scheduled Session"** (was "Scheduled run") and a primary-colored calendar icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e2fa428c5e3aabae4313e00612d323e4379cea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->