### PR TITLE
chore: lookup sfy model integration by provider account and name

### DIFF
--- a/.changeset/sfy-model-point-lookup.md
+++ b/.changeset/sfy-model-point-lookup.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": patch
+---
+
+Point-lookup ServiceFoundry model integrations by provider account and model name, and fetch the full catalog in one unpaginated request.

--- a/packages/trueforge/src/db/modelProviderStore.ts
+++ b/packages/trueforge/src/db/modelProviderStore.ts
@@ -20,14 +20,12 @@ export interface ListModelProvidersInput {
   tenant_id: string;
 }
 
-/** Resolve one catalog model (`provider/model`) for turn / validation. */
 export interface GetModelProviderInput {
   tenant_id: string;
   name: string;
   model_name: string;
 }
 
-/** Lock one provider row by account name (settings secret keep/rotate). */
 export interface GetModelProviderForUpdateInput {
   tenant_id: string;
   name: string;

--- a/packages/trueforge/src/db/modelProviderStore.ts
+++ b/packages/trueforge/src/db/modelProviderStore.ts
@@ -20,7 +20,15 @@ export interface ListModelProvidersInput {
   tenant_id: string;
 }
 
+/** Resolve one catalog model (`provider/model`) for turn / validation. */
 export interface GetModelProviderInput {
+  tenant_id: string;
+  name: string;
+  model_name: string;
+}
+
+/** Lock one provider row by account name (settings secret keep/rotate). */
+export interface GetModelProviderForUpdateInput {
   tenant_id: string;
   name: string;
 }
@@ -57,7 +65,7 @@ export interface IModelProviderStore<TTransaction = never> {
    * Required before read-modify-write of secrets so concurrent keep/rotate cannot interleave.
    */
   getProviderForUpdate(
-    input: GetModelProviderInput,
+    input: GetModelProviderForUpdateInput,
     transaction: TTransaction,
   ): Promise<ModelProviderRecord | undefined>;
   /** Inserts a new provider. Throws ModelProviderNameConflictError on name clash. */

--- a/packages/trueforge/src/db/postgres/model-provider-store/PostgresModelProviderStore.ts
+++ b/packages/trueforge/src/db/postgres/model-provider-store/PostgresModelProviderStore.ts
@@ -4,6 +4,7 @@ import {
   flattenProviderModels,
   ModelProviderNameConflictError,
   type CreateModelProviderInput,
+  type GetModelProviderForUpdateInput,
   type GetModelProviderInput,
   type IModelProviderStore,
   type ListModelProvidersInput,
@@ -49,6 +50,7 @@ export class PostgresModelProviderStore implements IModelProviderStore<Transacti
     input: GetModelProviderInput,
     transaction?: Transaction<Database>,
   ): Promise<ModelProviderRecord | undefined> {
+    void input.model_name;
     const db = transaction ?? this.#db;
     const row = await db
       .selectFrom('model_provider')
@@ -60,7 +62,7 @@ export class PostgresModelProviderStore implements IModelProviderStore<Transacti
   }
 
   async getProviderForUpdate(
-    input: GetModelProviderInput,
+    input: GetModelProviderForUpdateInput,
     transaction: Transaction<Database>,
   ): Promise<ModelProviderRecord | undefined> {
     const row = await transaction

--- a/packages/trueforge/src/db/sqlite/model-provider-store/SqliteModelProviderStore.ts
+++ b/packages/trueforge/src/db/sqlite/model-provider-store/SqliteModelProviderStore.ts
@@ -4,6 +4,7 @@ import {
   flattenProviderModels,
   ModelProviderNameConflictError,
   type CreateModelProviderInput,
+  type GetModelProviderForUpdateInput,
   type GetModelProviderInput,
   type IModelProviderStore,
   type ListModelProvidersInput,
@@ -49,6 +50,7 @@ export class SqliteModelProviderStore implements IModelProviderStore<Transaction
     input: GetModelProviderInput,
     transaction?: Transaction<Database>,
   ): Promise<ModelProviderRecord | undefined> {
+    void input.model_name;
     const db = transaction ?? this.#db;
     return await db
       .selectFrom('model_provider')
@@ -63,7 +65,7 @@ export class SqliteModelProviderStore implements IModelProviderStore<Transaction
    * serializes concurrent writers so RMW of secrets stays consistent.
    */
   async getProviderForUpdate(
-    input: GetModelProviderInput,
+    input: GetModelProviderForUpdateInput,
     transaction: Transaction<Database>,
   ): Promise<ModelProviderRecord | undefined> {
     return await transaction

--- a/packages/trueforge/src/runtime/sessionResources.ts
+++ b/packages/trueforge/src/runtime/sessionResources.ts
@@ -65,7 +65,11 @@ export async function getModelDetails({
       message: `Model name must be a fully qualified "provider/model": ${name}`,
     });
   }
-  const provider = await store.getProvider({ tenant_id, name: parsed.providerName });
+  const provider = await store.getProvider({
+    tenant_id,
+    name: parsed.providerName,
+    model_name: parsed.modelName,
+  });
   if (provider === undefined) {
     throw new HTTPException(422, {
       message: `Unknown model "${name}" — provider not configured`,

--- a/packages/trueforge/src/truefoundry/TrueFoundryModelProviderStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryModelProviderStore.ts
@@ -4,6 +4,7 @@ import type { AgentRecord } from '../db/agentStore';
 import {
   flattenProviderModels,
   type CreateModelProviderInput,
+  type GetModelProviderForUpdateInput,
   type GetModelProviderInput,
   type IModelProviderStore,
   type ListModelProvidersInput,
@@ -45,12 +46,15 @@ export class TrueFoundryModelProviderStore<TTransaction = never> implements IMod
     transaction?: TTransaction,
   ): Promise<ModelProviderRecord | undefined> {
     void transaction;
-    const records = await this.#records(input);
+    const records = await this.#records({
+      tenant_id: input.tenant_id,
+      filter: { provider_account_name: input.name, name: input.model_name },
+    });
     return records.find(record => record.name === input.name);
   }
 
   getProviderForUpdate(
-    input: GetModelProviderInput,
+    input: GetModelProviderForUpdateInput,
     transaction: TTransaction,
   ): Promise<ModelProviderRecord | undefined> {
     void input;
@@ -74,10 +78,16 @@ export class TrueFoundryModelProviderStore<TTransaction = never> implements IMod
     return flattenProviderModels(await this.listProviders(input, transaction));
   }
 
-  async #records(input: { tenant_id: string }): Promise<ModelProviderRecord[]> {
+  async #records(input: {
+    tenant_id: string;
+    filter?: { provider_account_name: string; name: string };
+  }): Promise<ModelProviderRecord[]> {
     const accessToken = await this.#resolveAccessToken();
     const [integrations, installations] = await Promise.all([
-      this.#client.listProviderIntegrations(accessToken),
+      this.#client.listProviderIntegrations({
+        accessToken,
+        ...(input.filter !== undefined ? { filter: input.filter } : {}),
+      }),
       this.#client.listGatewayInstallations(accessToken),
     ]);
     const gatewayUrl = resolveDefaultGatewayUrl(installations);

--- a/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
@@ -148,11 +148,14 @@ export class TrueFoundryServiceFoundryServerClient {
     accessToken: string;
     filter?: { provider_account_name: string; name: string };
   }): Promise<unknown[]> {
-    const query: Record<string, string> = { type: 'model' };
-    if (input.filter !== undefined) {
-      query.provider_account_name = input.filter.provider_account_name;
-      query.name = input.filter.name;
-    }
+    const filterQuery =
+      input.filter === undefined
+        ? {}
+        : {
+            provider_account_name: input.filter.provider_account_name,
+            name: input.filter.name,
+          };
+    const query: Record<string, string> = { type: 'model', ...filterQuery };
     const payload = await this.#requestJson({
       url: this.#url(INTEGRATIONS_PATH, query),
       accessToken: input.accessToken,

--- a/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
@@ -15,7 +15,6 @@ const TFG_AGENTS_PATH = 'internal/tfg/agents';
 const SESSION_PATH = 'v1/session';
 const AGENT_PERMISSIONS_PATH = 'v1/authorize/permissions';
 const VEND_TOKEN_PATH = 'internal/vend-token';
-const INTEGRATIONS_PAGE_SIZE = 1000;
 
 /**
  * Fields required to build RequestContext from ServiceFoundry `GET /v1/session`.
@@ -112,10 +111,6 @@ function listPage(response: ListResponse): unknown[] {
   return Array.isArray(response) ? response : response.data;
 }
 
-function listPaginationTotal(response: ListResponse): number | undefined {
-  return Array.isArray(response) ? undefined : response.pagination?.total;
-}
-
 export class TrueFoundryServiceFoundryServerClient {
   readonly #baseUrl: string;
   readonly #logger: Logger;
@@ -145,29 +140,25 @@ export class TrueFoundryServiceFoundryServerClient {
     this.#apiKey = input.apiKey;
   }
 
-  async listProviderIntegrations(accessToken: string): Promise<unknown[]> {
-    const items: unknown[] = [];
-    let offset = 0;
-    for (;;) {
-      const payload = await this.#requestJson({
-        url: this.#url(INTEGRATIONS_PATH, {
-          type: 'model',
-          offset: String(offset),
-          limit: String(INTEGRATIONS_PAGE_SIZE),
-        }),
-        accessToken,
-        method: 'GET',
-      });
-      const response = this.#parseListResponse(payload);
-      const page = listPage(response);
-      const total = listPaginationTotal(response);
-      items.push(...page);
-      if (total === undefined || items.length >= total || page.length === 0) {
-        break;
-      }
-      offset = items.length;
+  /**
+   * Model integrations. No limit/offset → full match set in one response.
+   * Pass `filter` (account + model name together) for a point lookup.
+   */
+  async listProviderIntegrations(input: {
+    accessToken: string;
+    filter?: { provider_account_name: string; name: string };
+  }): Promise<unknown[]> {
+    const query: Record<string, string> = { type: 'model' };
+    if (input.filter !== undefined) {
+      query.provider_account_name = input.filter.provider_account_name;
+      query.name = input.filter.name;
     }
-    return items;
+    const payload = await this.#requestJson({
+      url: this.#url(INTEGRATIONS_PATH, query),
+      accessToken: input.accessToken,
+      method: 'GET',
+    });
+    return listPage(this.#parseListResponse(payload));
   }
 
   listGatewayInstallations(accessToken: string): Promise<unknown> {

--- a/packages/trueforge/tests/db/modelProviderStoreContractSuite.ts
+++ b/packages/trueforge/tests/db/modelProviderStoreContractSuite.ts
@@ -51,7 +51,11 @@ export function runModelProviderStoreContractSuite(getStore: () => IModelProvide
     expect(created.created_at).toMatch(ISO_UTC);
     expect(created.updated_at).toBe(created.created_at);
 
-    const fetched = await store.getProvider({ tenant_id: TENANT, name: 'anthropic' });
+    const fetched = await store.getProvider({
+      tenant_id: TENANT,
+      name: 'anthropic',
+      model_name: 'claude-sonnet-4-6',
+    });
     expect(fetched).toEqual(created);
   });
 
@@ -67,7 +71,7 @@ export function runModelProviderStoreContractSuite(getStore: () => IModelProvide
 
   it('getProvider returns undefined for unknown providers', async () => {
     const store = getStore();
-    expect(await store.getProvider({ tenant_id: TENANT, name: 'missing' })).toBeUndefined();
+    expect(await store.getProvider({ tenant_id: TENANT, name: 'missing', model_name: 'any' })).toBeUndefined();
   });
 
   it('upsert replaces the whole document and preserves created_at', async () => {

--- a/packages/trueforge/tests/unit/apis/modelProviders.test.ts
+++ b/packages/trueforge/tests/unit/apis/modelProviders.test.ts
@@ -389,7 +389,11 @@ describe('model-provider secret redaction and strict PUT', () => {
     expect(updateBody.data.manifest.auth.api_key).toBe(toRedactedSecretValue(anthropicBody.auth.api_key));
     expect(updateBody.data.manifest.models).toHaveLength(2);
 
-    const stored = await modelProviderStore.getProvider({ tenant_id: 'default', name: 'anthropic' });
+    const stored = await modelProviderStore.getProvider({
+      tenant_id: 'default',
+      name: 'anthropic',
+      model_name: 'claude-sonnet-4-6',
+    });
     if (!stored || !('auth' in stored.manifest)) {
       throw new Error('expected stored anthropic provider with auth');
     }
@@ -408,7 +412,11 @@ describe('model-provider secret redaction and strict PUT', () => {
       data: configured('anthropic', withRedactedApiKey({ ...anthropicProvider, auth: { api_key: rotatedKey } })),
     });
 
-    const stored = await modelProviderStore.getProvider({ tenant_id: 'default', name: 'anthropic' });
+    const stored = await modelProviderStore.getProvider({
+      tenant_id: 'default',
+      name: 'anthropic',
+      model_name: 'claude-sonnet-4-6',
+    });
     if (!stored || !('auth' in stored.manifest)) {
       throw new Error('expected stored anthropic provider with auth');
     }


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the TrueFoundry ServiceFoundry HTTP contract (unpaginated list + optional filters) used when resolving models for agent turns; misaligned API behavior could break model lookup in managed mode.
> 
> **Overview**
> **ServiceFoundry model integration loading** no longer pages through `GET v1/provider-integrations` with offset/limit. The client now requests the full model catalog in **one call** (no pagination), and can pass **`provider_account_name` + model `name`** query filters for a targeted lookup.
> 
> **TrueFoundry `getProvider`** uses that filter when resolving a configured `provider/model` FQN, so session/model resolution does not need to pull every integration first. **`getModelDetails`** in session resources now passes **`model_name`** into `getProvider` alongside the provider account name.
> 
> The **`IModelProviderStore` contract** adds required **`model_name`** on `GetModelProviderInput` and introduces **`GetModelProviderForUpdateInput`** (provider name only) for locked read-modify-write paths like secret rotation. Postgres/SQLite **`getProvider`** still keys only on tenant + provider name (`model_name` is ignored); **`getProviderForUpdate`** call sites use the new input type. Tests and contract suites were updated for the new **`getProvider`** shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec8a06855f8fb1e2c18e6c45c531e17d7d022eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->