### PR TITLE
Fix: Keep composer catalogs cached when starting a new chat

### DIFF
--- a/.changeset/cache-composer-catalogs.md
+++ b/.changeset/cache-composer-catalogs.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Keep composer catalogs cached when starting a new chat.

--- a/packages/trueforge-ui/src/containers/TrueForgeUIShell.tsx
+++ b/packages/trueforge-ui/src/containers/TrueForgeUIShell.tsx
@@ -220,22 +220,22 @@ function ChatProviderFromShell({
   }, [mode, draftDefaultAgentSpec, pendingSessionId]);
 
   return (
-    <TrueFoundryChatProvider
-      key={runtimeKey}
-      {...providerRest}
-      server={serverWithCreateIntent}
-      agent={agent}
-      listSessionsAgentId={listSessionsAgentId}
-      initialSessionId={pendingSessionId ?? hostInitialSessionId}
-    >
-      <DraftCatalogProvider>
+    <DraftCatalogProvider>
+      <TrueFoundryChatProvider
+        key={runtimeKey}
+        {...providerRest}
+        server={serverWithCreateIntent}
+        agent={agent}
+        listSessionsAgentId={listSessionsAgentId}
+        initialSessionId={pendingSessionId ?? hostInitialSessionId}
+      >
         <AgentConfigInstructionsProvider>
           <DraftSpecPreferenceBridge />
           {onRemoteIdChange != null ? <RemoteIdRouteBridge onRemoteIdChange={onRemoteIdChange} /> : null}
           {children}
         </AgentConfigInstructionsProvider>
-      </DraftCatalogProvider>
-    </TrueFoundryChatProvider>
+      </TrueFoundryChatProvider>
+    </DraftCatalogProvider>
   );
 }
 

--- a/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
+++ b/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
@@ -176,7 +176,7 @@ describe('TrueForgeUI', () => {
     });
   });
 
-  it('refetches composer data when starting a new chat', async () => {
+  it('keeps composer catalogs cached when starting a new chat', async () => {
     const getCapabilities = vi
       .fn()
       .mockResolvedValueOnce({ data: { sandbox: { enabled: true }, skill: { enabled: true } } })
@@ -209,9 +209,9 @@ describe('TrueForgeUI', () => {
 
     await waitFor(() => {
       expect(getCapabilities).toHaveBeenCalledTimes(2);
-      expect(getModels).toHaveBeenCalledTimes(2);
-      expect(getSkills).toHaveBeenCalledTimes(2);
-      expect(getMcp).toHaveBeenCalledTimes(2);
+      expect(getModels).toHaveBeenCalledTimes(1);
+      expect(getSkills).toHaveBeenCalledTimes(1);
+      expect(getMcp).toHaveBeenCalledTimes(1);
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Tools (0)' }));


### PR DESCRIPTION
## Summary

Before: 
[Screencast from 2026-09-09 14-12-34.webm](https://github.com/user-attachments/assets/72cdbac7-f0cd-4ca6-b7d4-38969727dcaa)

After:
[Screencast from 2026-09-09 14-12-22.webm](https://github.com/user-attachments/assets/f44cb775-ebdf-4c6d-8af2-2a7005f2f27d)

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small provider tree reorder with no auth or data-persistence changes; behavior is covered by an updated integration test.
> 
> **Overview**
> Starting a new chat remounts the chat runtime via `runtimeKey`, which previously tore down **DraftCatalogProvider** and refetched models, skills, and MCP lists—causing visible flicker in the composer.
> 
> **DraftCatalogProvider** now wraps **TrueFoundryChatProvider** in `ChatProviderFromShell` so catalog state survives runtime remounts while the chat session still resets. Capabilities can still refresh on new chat; catalog fetch mocks (`getModels`, `getSkills`, `getMcp`) are expected to run only once per shell session.
> 
> Includes a patch changeset for `@truefoundry/trueforge-ui` and updates the container test to assert cached catalogs instead of a full refetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c32c508f869762a3d3808157bcf85d69e111fa86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->