### PR TITLE
Refactor: Remove preload tools functionality and enhance error handling

### DIFF
--- a/.changeset/remove-modal-preload-tools.md
+++ b/.changeset/remove-modal-preload-tools.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge-ui": patch
+---
+
+Polish the MCP tool selector controls, loading state, and API error messages.

--- a/packages/trueforge-ui/src/atoms/draft/AgentConfigEditors.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentConfigEditors.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import type { AgentSkill, AgentSpec, ConnectorState, McpToolSelection, ModelSelection } from '../../server/types.js';
 import { useSlot } from '../../theme/SlotsProvider.js';
+import { getErrorMessage } from '../../utils/getErrorMessage.js';
 import type { AgentInstructionsDraft } from './AgentInstructionsDrawer.js';
 import { initialUserMessagesFromSpec, withInitialUserMessages } from './agentConfigMessages.js';
 import { editableMountsFromSpec } from './agentConfigMounts.js';
@@ -83,7 +84,7 @@ export function AgentConfigEditors({
         if (!cancelled) setTools(nextTools);
       })
       .catch((reason: unknown) => {
-        if (!cancelled) setToolsError(reason instanceof Error ? reason.message : 'Failed to load tools.');
+        if (!cancelled) setToolsError(getErrorMessage(reason, 'Failed to load tools.'));
       })
       .finally(() => {
         if (!cancelled) setToolsLoading(false);

--- a/packages/trueforge-ui/src/atoms/draft/AgentMcpEditorContent.tsx
+++ b/packages/trueforge-ui/src/atoms/draft/AgentMcpEditorContent.tsx
@@ -14,13 +14,7 @@ import { CatalogLogo } from '../primitives/CatalogLogo.js';
 import { Spinner } from '../primitives/Spinner.js';
 import { Switch } from '../primitives/Switch.js';
 import { Tooltip } from '../primitives/Tooltip.js';
-import {
-  editableMountsFromSpec,
-  enabledToolsFromMount,
-  preloadFromMount,
-  withEnabledTools,
-  withPreload,
-} from './agentConfigMounts.js';
+import { editableMountsFromSpec, enabledToolsFromMount, withEnabledTools } from './agentConfigMounts.js';
 import { useDraftCatalog } from './DraftCatalogProvider.js';
 import { connectorsWithSelectedStubs } from './mcpConnectorStubs.js';
 
@@ -241,7 +235,7 @@ export function AgentMcpEditorContent({
                   Retry loading connectors
                 </button>
               ) : connectorsLoadingMore ? (
-                <span className="text-text-secondary text-[0.625rem]">Loading…</span>
+                <Spinner size={16} className="text-text-secondary" aria-label="Loading more MCP servers" />
               ) : null}
             </div>
           ) : null}
@@ -352,17 +346,6 @@ export function AgentMcpEditorContent({
                     })
                   : null}
               </div>
-              <label className="text-text-secondary flex shrink-0 cursor-pointer items-center justify-end gap-2 border-t border-border p-3 text-xs has-[:disabled]:cursor-not-allowed">
-                Preload tools
-                <Switch
-                  checked={activeMount !== undefined && preloadFromMount(activeMount.value)}
-                  disabled={activeMount === undefined}
-                  onCheckedChange={preload => {
-                    if (activeMount) updateMount(activeMount.id, withPreload(activeMount.value, preload));
-                  }}
-                  aria-label="Preload tools"
-                />
-              </label>
             </>
           )
         ) : (

--- a/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/AgentConfigEditors.test.tsx
@@ -510,6 +510,33 @@ describe('AgentConfigEditors', () => {
     expect(screen.getByRole('button', { name: 'GitHub' })).toHaveAttribute('aria-current', 'true');
   });
 
+  it('shows the API error message when loading MCP tools fails', async () => {
+    const error = Object.assign(new Error('BadGatewayError Status code: 502 Body: <html>…</html>'), {
+      statusCode: 502,
+      body: { error: { message: 'Failed to connect to remote MCP server' } },
+    });
+
+    render(
+      <SlotsProvider>
+        <AgentConfigEditors
+          editor="mcp"
+          spec={{ model: { name: 'openai/gpt' } }}
+          models={[]}
+          connectors={[{ id: 'broken', name: 'Broken MCP', authenticated: true }]}
+          skills={[]}
+          loading={false}
+          error={null}
+          loadMcpTools={async () => Promise.reject(error)}
+          onChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </SlotsProvider>,
+    );
+
+    expect(await screen.findByText('Failed to connect to remote MCP server')).toBeInTheDocument();
+    expect(screen.queryByText(/BadGatewayError/)).not.toBeInTheDocument();
+  });
+
   it('keeps an off-page selected MCP active via catalog stubs', async () => {
     const loadMcpTools = vi.fn(async (connectorId: string) => [
       { id: `${connectorId}.tool`, name: `${connectorId}.tool` },

--- a/packages/trueforge-ui/test/atoms/draft/AgentMcpEditorContent.search.test.tsx
+++ b/packages/trueforge-ui/test/atoms/draft/AgentMcpEditorContent.search.test.tsx
@@ -33,6 +33,7 @@ describe('AgentMcpEditorContent tool search', () => {
 
     expect(screen.getByRole('menuitemcheckbox', { name: 'web_search' })).toBeInTheDocument();
     expect(screen.getByRole('menuitemcheckbox', { name: 'web_fetch' })).toBeInTheDocument();
+    expect(screen.queryByRole('switch', { name: 'Preload tools' })).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByPlaceholderText('Search Tools'), { target: { value: 'fetch' } });
 


### PR DESCRIPTION
…ng in MCP tool selector

- Removed the preload tools switch from the AgentMcpEditorContent component.
- Updated error handling in AgentConfigEditors to use a utility function for better error message display.
- Added a test case to verify the correct display of API error messages when loading MCP tools fails.

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only MCP editor changes plus safer error copy; preload can no longer be toggled in the UI but other tool selection behavior is unchanged.
> 
> **Overview**
> Removes the **Preload tools** switch from the MCP tool picker so agents are configured only via enable/disable and “Enable all tools,” without exposing preload in the modal.
> 
> When listing tools for a connector fails, the editor now surfaces user-facing API text through **`getErrorMessage`** (e.g. `Failed to connect to remote MCP server`) instead of raw transport errors like `BadGatewayError…`. Infinite scroll for MCP servers shows a **Spinner** with an accessible label rather than plain “Loading…” text.
> 
> Tests assert the preload control is gone and that structured error bodies render correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3530a204343a3873722294bcd62f2d05c11bdbf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->