### PR TITLE
chore: Namespace all Redis keys and pub/sub channels under tfg:

### DIFF
--- a/.changeset/redis-tfg-key-prefix.md
+++ b/.changeset/redis-tfg-key-prefix.md
@@ -1,0 +1,6 @@
+---
+"@truefoundry/trueforge-core": patch
+"@truefoundry/trueforge": patch
+---
+
+Namespace all Redis keys and pub/sub channels under `tfg:` so TrueForge can share a Redis instance without colliding with other apps.

--- a/packages/trueforge-core/src/core/index.ts
+++ b/packages/trueforge-core/src/core/index.ts
@@ -133,6 +133,7 @@ export type {
 
 // Errors / utils
 export { AgentHarnessError, McpConnectionError, McpDcrConfigurationError } from './errors';
+export { REDIS_KEY_NAMESPACE, redisKey } from './redisKeys';
 export { describeUnknownError, extractErrorLogFields } from './util/errorLogFields';
 export { PromiseTimeoutError, withTimeout } from './util/promiseUtils';
 

--- a/packages/trueforge-core/src/core/redisKeys.ts
+++ b/packages/trueforge-core/src/core/redisKeys.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared Redis key/channel namespace for TrueForge.
+ * Every Redis key and pub/sub channel MUST start with this segment.
+ */
+export const REDIS_KEY_NAMESPACE = 'tfg' as const;
+
+export function redisKey(...parts: readonly string[]): string {
+  return [REDIS_KEY_NAMESPACE, ...parts].join(':');
+}

--- a/packages/trueforge-core/src/request-reply/executor.ts
+++ b/packages/trueforge-core/src/request-reply/executor.ts
@@ -42,7 +42,7 @@ export type RequestReplyErrorHandler = (err: Error, context: { executorId: strin
  */
 export class RequestReplyExecutor {
   readonly executorId: string;
-  /** `rr:req:<executorId>` — the channel this executor subscribes to. */
+  /** `tfg:rr:req:<executorId>` — the channel this executor subscribes to. */
   readonly channel: string;
   private readonly redis: RedisClientType;
   private readonly subscriberClient: RedisClientType;

--- a/packages/trueforge-core/src/request-reply/utils.ts
+++ b/packages/trueforge-core/src/request-reply/utils.ts
@@ -1,20 +1,20 @@
+import { redisKey } from '../core/redisKeys';
+
 export function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export const KEY_PREFIX = 'rr';
-
 /** Liveness key an executor refreshes; callers check it before publishing. */
 export function heartbeatKey(executorId: string): string {
-  return `${KEY_PREFIX}:hb:${executorId}`;
+  return redisKey('rr', 'hb', executorId);
 }
 
 /** Pub/sub channel: executors subscribe; callers publish the JSON request (see publishedRequestSchema). */
 export function requestChannel(executorId: string): string {
-  return `${KEY_PREFIX}:req:${executorId}`;
+  return redisKey('rr', 'req', executorId);
 }
 
 /** Per-request key the executor SETs the JSONReply to; the caller polls it with GETDEL. */
 export function replyKey(requestId: string): string {
-  return `${KEY_PREFIX}:reply:${requestId}`;
+  return redisKey('rr', 'reply', requestId);
 }

--- a/packages/trueforge-core/tests/core/redisKeys.test.ts
+++ b/packages/trueforge-core/tests/core/redisKeys.test.ts
@@ -1,0 +1,15 @@
+import { REDIS_KEY_NAMESPACE, redisKey } from '../../src/core/redisKeys';
+import { heartbeatKey, replyKey, requestChannel } from '../../src/request-reply/utils';
+
+describe('redisKeys', () => {
+  it('namespaces every key under tfg', () => {
+    expect(REDIS_KEY_NAMESPACE).toBe('tfg');
+    expect(redisKey('agent', 'turn', 'ten', 'sess', 'turn1', 'stream')).toBe('tfg:agent:turn:ten:sess:turn1:stream');
+  });
+
+  it('prefixes request-reply keys and channels', () => {
+    expect(heartbeatKey('exec-1')).toBe('tfg:rr:hb:exec-1');
+    expect(requestChannel('exec-1')).toBe('tfg:rr:req:exec-1');
+    expect(replyKey('req-1')).toBe('tfg:rr:reply:req-1');
+  });
+});

--- a/packages/trueforge/src/apis/turns.ts
+++ b/packages/trueforge/src/apis/turns.ts
@@ -22,6 +22,7 @@ import {
   isFileContentPart,
   McpConnectionError,
   rawSandboxId,
+  redisKey,
   SandboxError,
   VercelAILLM,
 } from '@truefoundry/trueforge-core/core';
@@ -304,7 +305,7 @@ export function streamTTLSecondsFor(event: TurnStreamingEvent): number | undefin
 
 /** Redis/in-memory key for one turn's resumable event stream. */
 export function turnStreamId(tenantId: string, sessionId: string, turnId: string): string {
-  return `agent:turn:${tenantId}:${sessionId}:${turnId}:stream`;
+  return redisKey('agent', 'turn', tenantId, sessionId, turnId, 'stream');
 }
 
 /**

--- a/packages/trueforge/tests/unit/apis/turns.test.ts
+++ b/packages/trueforge/tests/unit/apis/turns.test.ts
@@ -33,6 +33,10 @@ function mcpServerStoreWithAuth(db: Kysely<Database>, tokenStore: SqliteOAuthTok
 }
 
 describe('turns', () => {
+  it('namespaces turn stream ids under tfg', () => {
+    expect(turnStreamId('ten', 'sess', 'turn1')).toBe('tfg:agent:turn:ten:sess:turn1:stream');
+  });
+
   describe('turn ownership', () => {
     it('returns 403 for all turn routes when the caller is not the session creator', async () => {
       const db = createSqliteDb(':memory:');


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All Redis keys and channels rename on deploy, so mixed-version or rolling upgrades can miss in-flight turn streams and request-reply traffic until clients and executors align.
> 
> **Overview**
> Introduces a shared **`tfg:`** Redis namespace via `REDIS_KEY_NAMESPACE` and **`redisKey()`** in trueforge-core, exported for callers that build Redis keys or pub/sub channel names.
> 
> **Request-reply** heartbeat keys, request channels, and reply keys now use **`tfg:rr:…`** instead of bare **`rr:…`**. **Turn resumable event streams** use **`tfg:agent:turn:…:stream`** instead of **`agent:turn:…:stream`**.
> 
> Unit tests lock in the new shapes for request-reply helpers and **`turnStreamId`**. Patch changesets cover **`@truefoundry/trueforge-core`** and **`@truefoundry/trueforge`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe728d2eede19c0a91dc0284cd226f0d47451e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->