### PR TITLE
fix: add compatible and ephemeral cache control options for truefoundry provider

### DIFF
--- a/.changeset/truefoundry-cache-control-ephemeral.md
+++ b/.changeset/truefoundry-cache-control-ephemeral.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-core': patch
+---
+
+Default `cache_control` to `{ type: 'ephemeral' }` for `truefoundry` provider model calls (overridable via request body).

--- a/packages/trueforge-core/src/core/llm/VercelAILLM.ts
+++ b/packages/trueforge-core/src/core/llm/VercelAILLM.ts
@@ -544,6 +544,11 @@ export function buildProviderOptions({
   } else if (config.provider.type === 'alibaba') {
     const alibaba = alibabaProviderOptions(rawBody);
     return alibaba !== undefined ? { alibaba } : {};
+  } else if (config.provider.type === 'truefoundry') {
+    // Prompt caching defaults on for the TFY gateway. Callers can override.
+    const cache_control = readBodyField({ rawBody, key: 'cache_control' }) ?? { type: 'ephemeral' };
+    const compatible = compatibleProviderOptions({ strictJsonSchema, reasoningEffort, rawBody }) ?? {};
+    return { truefoundry: { ...compatible, cache_control } };
   } else {
     // The remaining providers all share the compatible adapter, which reads its options from a key
     // matching the `name` it was built with — the provider type itself.

--- a/packages/trueforge-core/tests/core/llm/VercelAILLM.output.test.ts
+++ b/packages/trueforge-core/tests/core/llm/VercelAILLM.output.test.ts
@@ -370,6 +370,30 @@ describe('buildProviderOptions', () => {
     });
   });
 
+  describe('truefoundry provider', () => {
+    const config = makeConfig({ provider: 'truefoundry', baseUrl: 'https://gateway.example/v1' });
+
+    it('defaults cache_control to ephemeral when omitted', () => {
+      const opts = buildProviderOptions({
+        config,
+        reasoningEffort: undefined,
+        structuredOutputSpec: textSpec,
+        rawBody: {},
+      });
+      expect(opts).toEqual({ truefoundry: { cache_control: { type: 'ephemeral' } } });
+    });
+
+    it('forwards a caller-supplied cache_control', () => {
+      const opts = buildProviderOptions({
+        config,
+        reasoningEffort: undefined,
+        structuredOutputSpec: textSpec,
+        rawBody: { cache_control: { type: 'ephemeral', ttl: '1h' } },
+      });
+      expect(opts).toEqual({ truefoundry: { cache_control: { type: 'ephemeral', ttl: '1h' } } });
+    });
+  });
+
   describe('moonshot provider', () => {
     const config = makeConfig({ provider: 'moonshot' });
 


### PR DESCRIPTION

## Summary

add compatible and ephemeral cache control options for truefoundry provider
## Changes


## How was this tested?

unit tests added

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, provider-scoped default for gateway prompt caching with override preserved; behavior change only affects truefoundry model calls.
> 
> **Overview**
> **Truefoundry** LLM calls now get a dedicated path in `buildProviderOptions` instead of the generic OpenAI-compatible branch.
> 
> When the request body omits `cache_control`, the adapter sends **`{ type: 'ephemeral' }`** to the Truefoundry gateway (callers can still override via `cache_control` in the body). The same **compatible** options as other gateway-style providers—reasoning effort, `strictJsonSchema`, and forwarded snake_case body fields—are merged into the `truefoundry` provider-options bucket alongside that default.
> 
> Unit tests cover the default and explicit override behavior; a patch changeset documents the `@truefoundry/trueforge-core` release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d429abb027ef3bb12626e392ff95e7a07d19d6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->