### PR TITLE
charts/trueforge: add platform integration extension points

### DIFF
--- a/charts/trueforge/Chart.yaml
+++ b/charts/trueforge/Chart.yaml
@@ -4,7 +4,7 @@ description: TrueForge server (API + UI) served from a single container image.
 type: application
 # version / appVersion are maintained on main (bot chart-release PR or human).
 # Publishing is gated by git tag charts/trueforge@<version> (must match version).
-version: 0.1.6-rc.2
+version: 0.1.6-rc.3
 appVersion: "0.2.0-rc.2"
 kubeVersion: ">=1.25.0-0"
 home: https://truefoundry.com

--- a/charts/trueforge/README.md
+++ b/charts/trueforge/README.md
@@ -68,8 +68,9 @@ helm upgrade --install trueforge oci://tfy.jfrog.io/tfy-helm/trueforge \
 
 `apiKey` (`TRUEFORGE_API_KEY`) authenticates the controller to the server. The
 server always runs peered (`STANDALONE=false`) and the app rejects an empty
-value, so this is **required**: the render fails rather than leaving you with a
-crash-looping pod. Supply it as a string or, preferably, a `valueFrom`:
+value, so the chart ships a **dev placeholder**
+(`placeholder-value-please-generate-your-own`). Replace it before any shared
+deployment, as a string or, preferably, a `valueFrom`:
 
 ```yaml
 apiKey:
@@ -78,9 +79,6 @@ apiKey:
       name: trueforge-api-key
       key: TRUEFORGE_API_KEY
 ```
-
-This is a different key from `truefoundry.apiKey`, which is the control-plane
-`TFY_API_KEY` used when calling ServiceFoundry.
 
 ## Extra environment
 
@@ -112,7 +110,7 @@ per-deployment entries.
 ## Custom CA
 
 Honoured from `global.customCA`, whether set on this chart or inherited from a
-`truefoundry` parent. Give it a PEM `certificate` and the chart renders its own
+parent chart. Give it a PEM `certificate` and the chart renders its own
 ConfigMap; give it `existingConfigMap.name` (key `ca-certificates.crt`) to reuse
 one. With `overrideCAList: true` the ConfigMap is mounted straight over
 `/etc/ssl/certs`; otherwise an initContainer merges it into the system bundle.
@@ -128,7 +126,7 @@ global:
       -----END CERTIFICATE-----
 ```
 
-## Values inherited from a TrueFoundry parent
+## Values inherited from a parent chart
 
 `global.labels`, `global.annotations`, `global.podLabels`,
 `global.podAnnotations`, `global.imagePullSecrets`, `global.nodeSelector`,
@@ -136,29 +134,20 @@ global:
 The chart's own value wins on conflict; `tolerations` append to
 `global.tolerations` rather than replacing them.
 
-## Resource tiers (TrueFoundry parent)
+## Resource tiers
 
-Sizing in this chart is Kubernetes `resources` / `controller.resources` and
-`server.replicaCount`. `resourceTier` is a TrueFoundry control-plane preset, not
-a Kubernetes field, so it is **unset** by default.
-
-When this chart is nested under `truefoundry`, the parent may set
-`global.resourceTier` (`small` / `medium` / `large`). That **replaces** the
-`resources` tables (replica counts stay as set: server `replicaCount`, controller
-always 1). `resourceTierOverride` pins a preset without changing the parent
-global. An unknown tier fails the render.
+`resourceTier` (`small` / `medium` / `large`) selects sizing presets for the
+server and the controller. When set, it **replaces** the `resources` tables
+(replica counts stay as set: server `replicaCount`, controller always 1); an
+unknown tier fails the render. Empty (the default) keeps the explicit
+`resources` / `controller.resources`. A parent chart may set
+`global.resourceTier` instead; the chart's own `resourceTier` wins.
 
 | Preset | Server requests | Controller requests |
 | --- | --- | --- |
 | `small` | 50m / 128Mi | 50m / 128Mi |
 | `medium` | 100m / 256Mi | 100m / 256Mi |
 | `large` | 500m / 512Mi | 500m / 512Mi |
-
-```yaml
-# Parent truefoundry values (example)
-global:
-  resourceTier: large
-```
 
 ## Postgres
 
@@ -206,14 +195,6 @@ externalRedis:
 
 For passworded Redis, prefer an external instance and load `REDIS_URL` via
 `valueFrom`.
-
-### Sentinel
-
-`externalRedis.sentinel` injects `REDIS_SENTINEL_HOSTS`,
-`REDIS_SENTINEL_MASTER_NAME` and `REDIS_SENTINEL_PASSWORD`. The app does not
-read them yet (it only understands `REDIS_URL`), so this exists so a
-Sentinel-backed install can be configured the day support lands, without
-needing a chart change.
 
 ## OIDC
 
@@ -302,7 +283,7 @@ extraObjects:
 
 | Value                 | Default                             | Description                           |
 | --------------------- | ----------------------------------- | ------------------------------------- |
-| `resourceTierOverride`| `""`                                | Optional TrueFoundry `small` / `medium` / `large` preset; empty uses `resources`. |
+| `resourceTier`        | `""`                                | Optional `small` / `medium` / `large` sizing preset; empty uses `resources`. |
 | `server.replicaCount` | `1`                                 | Number of server replicas.            |
 | `server.deploymentAnnotations` | `{}`                          | Annotations on the server Deployment, such as an Argo CD sync wave. |
 | `controller.deploymentAnnotations` | `{}`                      | Annotations on the controller Deployment, such as an Argo CD sync wave. |
@@ -339,6 +320,7 @@ also sets the `/tmp` `emptyDir.sizeLimit`.
 ## Production checklist
 
 - **Enable `configs.oidc`** — leaving it off grants shared admin to anyone who can reach the server.
+- **Replace the `apiKey` placeholder** with a generated secret (prefer `valueFrom.secretKeyRef`).
 - **Replace the bundled Postgres password** (`trueforge`) or set `postgresql.auth.existingSecret`.
 - Treat bundled Redis (`redis.auth.enabled: false`) as cluster-internal only, or switch to external passworded Redis via `externalRedis.url`.
 - Set `server.publicBaseUrl` to the real public application URL before using MCP OAuth or OIDC (include a pathname when the UI is served under a stripped prefix).

--- a/charts/trueforge/README.md
+++ b/charts/trueforge/README.md
@@ -64,6 +64,102 @@ helm upgrade --install trueforge oci://tfy.jfrog.io/tfy-helm/trueforge \
   --set server.publicBaseUrl=https://trueforge.example.com
 ```
 
+## API keys
+
+`apiKey` (`TRUEFORGE_API_KEY`) authenticates the controller to the server. The
+server always runs peered (`STANDALONE=false`) and the app rejects an empty
+value, so this is **required**: the render fails rather than leaving you with a
+crash-looping pod. Supply it as a string or, preferably, a `valueFrom`:
+
+```yaml
+apiKey:
+  valueFrom:
+    secretKeyRef:
+      name: trueforge-api-key
+      key: TRUEFORGE_API_KEY
+```
+
+This is a different key from `truefoundry.apiKey`, which is the control-plane
+`TFY_API_KEY` used when calling ServiceFoundry.
+
+## Extra environment
+
+`env` is a map of variable name to value, applied to both the server and the
+controller. Values are scalars or `valueFrom` references. A key that matches
+something the chart already sets **replaces** it rather than adding a second
+entry, so it doubles as the override for computed values like `POSTGRES_HOST`
+or `PUBLIC_BASE_URL`.
+
+This is the extension point for running against a hosting platform. The chart
+does not model any particular platform; those settings live in the caller's
+values.
+
+```yaml
+env:
+  SOME_PLATFORM_API_URL:
+    valueFrom:
+      configMapKeyRef: { name: platform-config, key: api-url }
+  SOME_PLATFORM_API_KEY:
+    valueFrom:
+      secretKeyRef: { name: platform-creds, key: api-key }
+```
+
+When the platform also needs files (an outbound mTLS client certificate, say),
+mount them with `extraVolumes` / `extraVolumeMounts`, which apply to both
+deployments. `server.extraEnv` and `controller.extraEnv` remain available for
+per-deployment entries.
+
+## Custom CA
+
+Honoured from `global.customCA`, whether set on this chart or inherited from a
+`truefoundry` parent. Give it a PEM `certificate` and the chart renders its own
+ConfigMap; give it `existingConfigMap.name` (key `ca-certificates.crt`) to reuse
+one. With `overrideCAList: true` the ConfigMap is mounted straight over
+`/etc/ssl/certs`; otherwise an initContainer merges it into the system bundle.
+Either way `NODE_EXTRA_CA_CERTS` is set, since Node ignores the system store.
+
+```yaml
+global:
+  customCA:
+    enabled: true
+    certificate: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+```
+
+## Values inherited from a TrueFoundry parent
+
+`global.labels`, `global.annotations`, `global.podLabels`,
+`global.podAnnotations`, `global.imagePullSecrets`, `global.nodeSelector`,
+`global.affinity`, `global.customCA` and `global.resourceTier` are all applied.
+The chart's own value wins on conflict; `tolerations` append to
+`global.tolerations` rather than replacing them.
+
+## Resource tiers (TrueFoundry parent)
+
+Sizing in this chart is Kubernetes `resources` / `controller.resources` and
+`server.replicaCount`. `resourceTier` is a TrueFoundry control-plane preset, not
+a Kubernetes field, so it is **unset** by default.
+
+When this chart is nested under `truefoundry`, the parent may set
+`global.resourceTier` (`small` / `medium` / `large`). That **replaces** the
+`resources` tables (replica counts stay as set: server `replicaCount`, controller
+always 1). `resourceTierOverride` pins a preset without changing the parent
+global. An unknown tier fails the render.
+
+| Preset | Server requests | Controller requests |
+| --- | --- | --- |
+| `small` | 50m / 128Mi | 50m / 128Mi |
+| `medium` | 100m / 256Mi | 100m / 256Mi |
+| `large` | 500m / 512Mi | 500m / 512Mi |
+
+```yaml
+# Parent truefoundry values (example)
+global:
+  resourceTier: large
+```
+
 ## Postgres
 
 Bundled by default (`postgresql.enabled=true`). The chart ships a **dev**
@@ -110,6 +206,14 @@ externalRedis:
 
 For passworded Redis, prefer an external instance and load `REDIS_URL` via
 `valueFrom`.
+
+### Sentinel
+
+`externalRedis.sentinel` injects `REDIS_SENTINEL_HOSTS`,
+`REDIS_SENTINEL_MASTER_NAME` and `REDIS_SENTINEL_PASSWORD`. The app does not
+read them yet (it only understands `REDIS_URL`), so this exists so a
+Sentinel-backed install can be configured the day support lands, without
+needing a chart change.
 
 ## OIDC
 
@@ -198,7 +302,10 @@ extraObjects:
 
 | Value                 | Default                             | Description                           |
 | --------------------- | ----------------------------------- | ------------------------------------- |
+| `resourceTierOverride`| `""`                                | Optional TrueFoundry `small` / `medium` / `large` preset; empty uses `resources`. |
 | `server.replicaCount` | `1`                                 | Number of server replicas.            |
+| `server.deploymentAnnotations` | `{}`                          | Annotations on the server Deployment, such as an Argo CD sync wave. |
+| `controller.deploymentAnnotations` | `{}`                      | Annotations on the controller Deployment, such as an Argo CD sync wave. |
 | `image.repository`    | `tfy.jfrog.io/tfy-images/trueforge` | Image repository.                     |
 | `image.tag`           | chart `appVersion`                  | Image tag; stamped on release.        |
 | `server.publicBaseUrl`| `""`                                | Public application URL for OAuth/OIDC callbacks (required for MCP OAuth / OIDC). A pathname is the UI/API public prefix. |
@@ -212,7 +319,7 @@ extraObjects:
 | `podDisruptionBudget.enabled` | `false`                       | Enable a PodDisruptionBudget (`minAvailable` defaults to `1`). |
 | `podSecurityContext`  | non-root UID/GID `10001`            | Pod-level restricted security defaults. |
 | `securityContext`     | read-only root FS + drop all capabilities | Container-level restricted security defaults. |
-| `resources`           | 100m/256Mi requests, 200m/512Mi limits | Container CPU, memory, and ephemeral-storage requests/limits. |
+| `resources`           | 100m/256Mi requests, 200m/512Mi limits | Server CPU, memory, and ephemeral-storage. Replaced when a resourceTier is set. |
 | `mtls.enabled`        | `false`                             | HTTPS listener + controller→server mTLS (`TRUEFORGE_MTLS_*`). When true, probes use `scheme: HTTPS`. |
 | `mtls.secretName`     | `""`                                | Secret with `tls.crt` / `tls.key` / `ca.crt` (required when `mtls.enabled`). |
 | `mtls.certsDir`       | `/etc/tls`                          | Mount path / `TRUEFORGE_MTLS_CERTS_DIR`. |

--- a/charts/trueforge/templates/_helpers.tpl
+++ b/charts/trueforge/templates/_helpers.tpl
@@ -98,29 +98,14 @@ Controller labels.
 {{- end }}
 
 {{/*
-The controller's SERVER_URL env entry. Accepts a literal or a valueFrom, and
-yields nothing when the `env` map already defines SERVER_URL, so the two cannot
-both emit it.
-*/}}
-{{- define "trueforge.controller.serverUrlEnv" -}}
-{{- if not (hasKey (.Values.env | default dict) "SERVER_URL") -}}
-{{- if .Values.controller.serverUrl -}}
-{{- list (include "trueforge.env.item" (dict "name" "SERVER_URL" "value" .Values.controller.serverUrl) | fromJson) | toYaml -}}
-{{- else -}}
-{{- list (dict "name" "SERVER_URL" "value" (include "trueforge.controller.serverUrl" .)) | toYaml -}}
-{{- end -}}
-{{- end -}}
-{{- end }}
-
-{{/*
 Base URL the controller uses to reach the server API. Defaults to the in-cluster
-server Service when controller.serverUrl is empty.
+server Service when controller.serverUrl is empty (https when mtls is enabled).
 */}}
 {{- define "trueforge.controller.serverUrl" -}}
-{{- if and .Values.controller.serverUrl (kindIs "string" .Values.controller.serverUrl) -}}
+{{- if .Values.controller.serverUrl -}}
 {{- .Values.controller.serverUrl -}}
 {{- else -}}
-{{- printf "http://%s:%v" (include "trueforge.fullname" .) .Values.service.port -}}
+{{- printf "%s://%s:%v" (ternary "https" "http" .Values.mtls.enabled) (include "trueforge.fullname" .) .Values.service.port -}}
 {{- end -}}
 {{- end }}
 
@@ -204,12 +189,12 @@ postgresql subchart (existingSecret override or <release>-postgresql).
 {{- end }}
 
 {{/*
-TrueFoundry size knob. Empty when unset so a standalone install uses `resources`.
-Set by a parent chart's global.resourceTier, or resourceTierOverride.
-Not a Kubernetes concept; do not default it here.
+Resource tier (small | medium | large). Empty when unset so the explicit
+`resources` / `controller.resources` apply. resourceTier wins over a parent
+chart's global.resourceTier.
 */}}
 {{- define "trueforge.resourceTier" -}}
-{{- $override := .Values.resourceTierOverride | default "" | toString | trim -}}
+{{- $override := .Values.resourceTier | default "" | toString | trim -}}
 {{- $fromGlobal := "" -}}
 {{- with .Values.global -}}
 {{- $fromGlobal = .resourceTier | default "" | toString | trim -}}
@@ -294,8 +279,8 @@ limits:
 {{- end }}
 
 {{/*
-Server requests/limits. Default is `.Values.resources`. A TrueFoundry resourceTier
-replaces that table (child-chart resource defaults must not overlay it).
+Server requests/limits. Default is `.Values.resources`. A resourceTier preset
+replaces that table (chart resource defaults must not overlay it).
 */}}
 {{- define "trueforge.resources" -}}
 {{- $tier := include "trueforge.resourceTier" . | trim -}}
@@ -349,7 +334,7 @@ Replica count is always 1, even when a resourceTier is set.
 JSON env entry from a string | { valueFrom: ... } field.
 Expects: name (env var), field (values path for errors), value.
 Literals become env value; valueFrom maps are passed through. The chart does
-not create Secrets — callers who need secretKeyRef must supply valueFrom.
+not create Secrets; callers who need secretKeyRef must supply valueFrom.
 */}}
 {{- define "trueforge.env.fromStringOrValueFrom" -}}
 {{- $name := index . "name" -}}
@@ -515,8 +500,7 @@ mTLS secret volumeMount when mtls.enabled.
 
 {{/*
 Scheduling and pull secrets. A parent chart's global.* is the base; the chart's
-own value wins. Tolerations append rather than replace, matching how the
-truefoundry chart composes global.tolerations with a component's own.
+own value wins. Tolerations append rather than replace.
 */}}
 {{- define "trueforge.imagePullSecrets" -}}
 {{- $secrets := .Values.imagePullSecrets | default (.Values.global.imagePullSecrets | default list) -}}
@@ -548,7 +532,7 @@ truefoundry chart composes global.tolerations with a component's own.
 
 {{/*
 Custom CA. Honours global.customCA whether set on this chart (standalone) or
-inherited from a truefoundry parent. Two modes: mount an operator-supplied full
+inherited from a parent chart. Two modes: mount an operator-supplied full
 bundle straight over /etc/ssl/certs, or merge a CA into the system bundle with
 an initContainer. The chart renders its own ConfigMap when given a certificate,
 so it does not depend on one the parent may or may not have created.

--- a/charts/trueforge/templates/_helpers.tpl
+++ b/charts/trueforge/templates/_helpers.tpl
@@ -32,12 +32,39 @@ Chart name and version as used by the chart label.
 Common labels.
 */}}
 {{- define "trueforge.labels" -}}
-helm.sh/chart: {{ include "trueforge.chart" . }}
-{{ include "trueforge.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- $base := dict "helm.sh/chart" (include "trueforge.chart" .) "app.kubernetes.io/managed-by" .Release.Service -}}
+{{- if .Chart.AppVersion -}}
+{{- $_ := set $base "app.kubernetes.io/version" (.Chart.AppVersion | toString) -}}
+{{- end -}}
+{{- $selector := include "trueforge.selectorLabels" . | fromYaml -}}
+{{- toYaml (mergeOverwrite $base (deepCopy (.Values.global.labels | default dict)) (deepCopy .Values.commonLabels) $selector) -}}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+
+{{/*
+Annotations applied to every rendered object.
+*/}}
+{{- define "trueforge.annotations" -}}
+{{- $merged := mergeOverwrite (deepCopy (.Values.global.annotations | default dict)) (deepCopy .Values.commonAnnotations) -}}
+{{- with $merged }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Pod labels / annotations, global merged under the chart's own.
+*/}}
+{{- define "trueforge.podLabels" -}}
+{{- $merged := mergeOverwrite (deepCopy (.Values.global.podLabels | default dict)) (deepCopy .Values.podLabels) -}}
+{{- with $merged }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "trueforge.podAnnotations" -}}
+{{- $merged := mergeOverwrite (deepCopy (.Values.global.podAnnotations | default dict)) (deepCopy .Values.podAnnotations) -}}
+{{- with $merged }}
+{{- toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -62,13 +89,27 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Controller labels.
 */}}
 {{- define "trueforge.controller.labels" -}}
-helm.sh/chart: {{ include "trueforge.chart" . }}
-{{ include "trueforge.controller.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- $base := dict "helm.sh/chart" (include "trueforge.chart" .) "app.kubernetes.io/managed-by" .Release.Service "app.kubernetes.io/component" "controller" -}}
+{{- if .Chart.AppVersion -}}
+{{- $_ := set $base "app.kubernetes.io/version" (.Chart.AppVersion | toString) -}}
+{{- end -}}
+{{- $selector := include "trueforge.controller.selectorLabels" . | fromYaml -}}
+{{- toYaml (mergeOverwrite $base (deepCopy (.Values.global.labels | default dict)) (deepCopy .Values.commonLabels) $selector) -}}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/component: controller
+
+{{/*
+The controller's SERVER_URL env entry. Accepts a literal or a valueFrom, and
+yields nothing when the `env` map already defines SERVER_URL, so the two cannot
+both emit it.
+*/}}
+{{- define "trueforge.controller.serverUrlEnv" -}}
+{{- if not (hasKey (.Values.env | default dict) "SERVER_URL") -}}
+{{- if .Values.controller.serverUrl -}}
+{{- list (include "trueforge.env.item" (dict "name" "SERVER_URL" "value" .Values.controller.serverUrl) | fromJson) | toYaml -}}
+{{- else -}}
+{{- list (dict "name" "SERVER_URL" "value" (include "trueforge.controller.serverUrl" .)) | toYaml -}}
+{{- end -}}
+{{- end -}}
 {{- end }}
 
 {{/*
@@ -76,7 +117,7 @@ Base URL the controller uses to reach the server API. Defaults to the in-cluster
 server Service when controller.serverUrl is empty.
 */}}
 {{- define "trueforge.controller.serverUrl" -}}
-{{- if .Values.controller.serverUrl -}}
+{{- if and .Values.controller.serverUrl (kindIs "string" .Values.controller.serverUrl) -}}
 {{- .Values.controller.serverUrl -}}
 {{- else -}}
 {{- printf "http://%s:%v" (include "trueforge.fullname" .) .Values.service.port -}}
@@ -163,6 +204,148 @@ postgresql subchart (existingSecret override or <release>-postgresql).
 {{- end }}
 
 {{/*
+TrueFoundry size knob. Empty when unset so a standalone install uses `resources`.
+Set by a parent chart's global.resourceTier, or resourceTierOverride.
+Not a Kubernetes concept; do not default it here.
+*/}}
+{{- define "trueforge.resourceTier" -}}
+{{- $override := .Values.resourceTierOverride | default "" | toString | trim -}}
+{{- $fromGlobal := "" -}}
+{{- with .Values.global -}}
+{{- $fromGlobal = .resourceTier | default "" | toString | trim -}}
+{{- end -}}
+{{- $tier := $override | default $fromGlobal -}}
+{{- if $tier -}}
+{{- if not (has $tier (list "small" "medium" "large")) -}}
+{{- fail (printf "resourceTier must be small, medium, or large (got %q)" $tier) -}}
+{{- end -}}
+{{- $tier -}}
+{{- end -}}
+{{- end }}
+
+{{- define "trueforge.replicas" -}}
+{{- .Values.server.replicaCount -}}
+{{- end }}
+
+{{- define "trueforge.defaultResources.small" -}}
+requests:
+  cpu: 50m
+  memory: 128Mi
+  ephemeral-storage: 128Mi
+limits:
+  cpu: 100m
+  memory: 256Mi
+  ephemeral-storage: 256Mi
+{{- end }}
+
+{{- define "trueforge.defaultResources.medium" -}}
+requests:
+  cpu: 100m
+  memory: 256Mi
+  ephemeral-storage: 256Mi
+limits:
+  cpu: 200m
+  memory: 512Mi
+  ephemeral-storage: 512Mi
+{{- end }}
+
+{{- define "trueforge.defaultResources.large" -}}
+requests:
+  cpu: 500m
+  memory: 512Mi
+  ephemeral-storage: 512Mi
+limits:
+  cpu: 1000m
+  memory: 1024Mi
+  ephemeral-storage: 1024Mi
+{{- end }}
+
+{{- define "trueforge.controller.defaultResources.small" -}}
+requests:
+  cpu: 50m
+  memory: 128Mi
+  ephemeral-storage: 128Mi
+limits:
+  cpu: 100m
+  memory: 256Mi
+  ephemeral-storage: 256Mi
+{{- end }}
+
+{{- define "trueforge.controller.defaultResources.medium" -}}
+requests:
+  cpu: 100m
+  memory: 256Mi
+  ephemeral-storage: 128Mi
+limits:
+  cpu: 200m
+  memory: 512Mi
+  ephemeral-storage: 256Mi
+{{- end }}
+
+{{- define "trueforge.controller.defaultResources.large" -}}
+requests:
+  cpu: 500m
+  memory: 512Mi
+  ephemeral-storage: 128Mi
+limits:
+  cpu: 1000m
+  memory: 1024Mi
+  ephemeral-storage: 256Mi
+{{- end }}
+
+{{/*
+Server requests/limits. Default is `.Values.resources`. A TrueFoundry resourceTier
+replaces that table (child-chart resource defaults must not overlay it).
+*/}}
+{{- define "trueforge.resources" -}}
+{{- $tier := include "trueforge.resourceTier" . | trim -}}
+{{- if $tier -}}
+{{- $defaultsYaml := "" -}}
+{{- if eq $tier "small" -}}
+  {{- $defaultsYaml = include "trueforge.defaultResources.small" . -}}
+{{- else if eq $tier "medium" -}}
+  {{- $defaultsYaml = include "trueforge.defaultResources.medium" . -}}
+{{- else if eq $tier "large" -}}
+  {{- $defaultsYaml = include "trueforge.defaultResources.large" . -}}
+{{- end -}}
+{{- $defaultsYaml -}}
+{{- else -}}
+{{- toYaml (.Values.resources | default dict) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Controller requests/limits. Default is `.Values.controller.resources`.
+Replica count is always 1, even when a resourceTier is set.
+*/}}
+{{- define "trueforge.controller.resources" -}}
+{{- $tier := include "trueforge.resourceTier" . | trim -}}
+{{- if $tier -}}
+{{- $defaultsYaml := "" -}}
+{{- if eq $tier "small" -}}
+  {{- $defaultsYaml = include "trueforge.controller.defaultResources.small" . -}}
+{{- else if eq $tier "medium" -}}
+  {{- $defaultsYaml = include "trueforge.controller.defaultResources.medium" . -}}
+{{- else if eq $tier "large" -}}
+  {{- $defaultsYaml = include "trueforge.controller.defaultResources.large" . -}}
+{{- end -}}
+{{- $defaultsYaml -}}
+{{- else -}}
+{{- toYaml (.Values.controller.resources | default dict) -}}
+{{- end -}}
+{{- end }}
+
+{{- define "trueforge.tmpEmptyDirSizeLimit" -}}
+{{- $merged := include "trueforge.resources" . | fromYaml | default dict -}}
+{{- index ($merged.limits | default dict) "ephemeral-storage" -}}
+{{- end }}
+
+{{- define "trueforge.controller.tmpEmptyDirSizeLimit" -}}
+{{- $merged := include "trueforge.controller.resources" . | fromYaml | default dict -}}
+{{- index ($merged.limits | default dict) "ephemeral-storage" -}}
+{{- end }}
+
+{{/*
 JSON env entry from a string | { valueFrom: ... } field.
 Expects: name (env var), field (values path for errors), value.
 Literals become env value; valueFrom maps are passed through. The chart does
@@ -177,6 +360,21 @@ not create Secrets — callers who need secretKeyRef must supply valueFrom.
 {{- dict "name" $name "value" $value | toJson -}}
 {{- else -}}
 {{- dict "name" $name "valueFrom" $value.valueFrom | toJson -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+One env entry from the `env` map. Scalars become a literal value; a map must
+carry valueFrom and is passed through untouched.
+*/}}
+{{- define "trueforge.env.item" -}}
+{{- $name := index . "name" -}}
+{{- $value := index . "value" -}}
+{{- if kindIs "map" $value -}}
+{{- if not $value.valueFrom -}}{{- fail (printf "env.%s must set valueFrom when given as a map" $name) -}}{{- end -}}
+{{- dict "name" $name "valueFrom" $value.valueFrom | toJson -}}
+{{- else -}}
+{{- dict "name" $name "value" ($value | toString) | toJson -}}
 {{- end -}}
 {{- end }}
 
@@ -196,6 +394,16 @@ fields, wires bundled Postgres/Redis, optional OIDC, then server.extraEnv.
 {{- $env = append $env (dict "name" "REDIS_URL" "value" (include "trueforge.redis.bundledUrl" .)) -}}
 {{- else -}}
 {{- $env = append $env (include "trueforge.env.fromStringOrValueFrom" (dict "name" "REDIS_URL" "field" "externalRedis.url" "value" .Values.externalRedis.url) | fromJson) -}}
+{{- $sentinel := .Values.externalRedis.sentinel | default dict -}}
+{{- if $sentinel.enabled -}}
+{{- $_ := required "externalRedis.sentinel.hosts is required when externalRedis.sentinel.enabled is true" $sentinel.hosts -}}
+{{- $_ := required "externalRedis.sentinel.masterName is required when externalRedis.sentinel.enabled is true" $sentinel.masterName -}}
+{{- $env = append $env (dict "name" "REDIS_SENTINEL_HOSTS" "value" $sentinel.hosts) -}}
+{{- $env = append $env (dict "name" "REDIS_SENTINEL_MASTER_NAME" "value" $sentinel.masterName) -}}
+{{- if $sentinel.password -}}
+{{- $env = append $env (include "trueforge.env.fromStringOrValueFrom" (dict "name" "REDIS_SENTINEL_PASSWORD" "field" "externalRedis.sentinel.password" "value" $sentinel.password) | fromJson) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- $env = append $env (dict "name" "POSTGRES_HOST" "value" (include "trueforge.postgres.host" .)) -}}
@@ -225,6 +433,36 @@ fields, wires bundled Postgres/Redis, optional OIDC, then server.extraEnv.
 {{- if .Values.configs.oidc.allowedEmails -}}
 {{- $env = append $env (dict "name" "OIDC_ALLOWED_EMAILS" "value" .Values.configs.oidc.allowedEmails) -}}
 {{- end -}}
+{{- end -}}
+
+{{- /* Controller -> server auth. The app rejects an empty value when peered. */ -}}
+{{- $env = append $env (include "trueforge.env.fromStringOrValueFrom" (dict "name" "TRUEFORGE_API_KEY" "field" "apiKey" "value" .Values.apiKey) | fromJson) -}}
+
+{{- /* Node reads its own bundled CA store unless told otherwise. */ -}}
+{{- if eq (include "trueforge.customCA.enabled" .) "true" -}}
+{{- $env = append $env (dict "name" "NODE_EXTRA_CA_CERTS" "value" "/etc/ssl/certs/ca-certificates.crt") -}}
+{{- end -}}
+
+{{- /* env map: replace in place when the chart already emits the name, else
+       append. Keeps the pod spec free of duplicate env entries. */ -}}
+{{- $overrides := .Values.env | default dict -}}
+{{- if $overrides -}}
+{{- $out := list -}}
+{{- $seen := dict -}}
+{{- range $item := $env -}}
+{{- if hasKey $overrides $item.name -}}
+{{- $out = append $out (include "trueforge.env.item" (dict "name" $item.name "value" (index $overrides $item.name)) | fromJson) -}}
+{{- else -}}
+{{- $out = append $out $item -}}
+{{- end -}}
+{{- $_ := set $seen $item.name true -}}
+{{- end -}}
+{{- range $name := (keys $overrides | sortAlpha) -}}
+{{- if not (hasKey $seen $name) -}}
+{{- $out = append $out (include "trueforge.env.item" (dict "name" $name "value" (index $overrides $name)) | fromJson) -}}
+{{- end -}}
+{{- end -}}
+{{- $env = $out -}}
 {{- end -}}
 
 {{- range .Values.server.extraEnv -}}
@@ -273,4 +511,142 @@ mTLS secret volumeMount when mtls.enabled.
   mountPath: {{ .Values.mtls.certsDir | quote }}
   readOnly: true
 {{- end -}}
+{{- end }}
+
+{{/*
+Scheduling and pull secrets. A parent chart's global.* is the base; the chart's
+own value wins. Tolerations append rather than replace, matching how the
+truefoundry chart composes global.tolerations with a component's own.
+*/}}
+{{- define "trueforge.imagePullSecrets" -}}
+{{- $secrets := .Values.imagePullSecrets | default (.Values.global.imagePullSecrets | default list) -}}
+{{- with $secrets }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "trueforge.nodeSelector" -}}
+{{- $merged := mergeOverwrite (deepCopy (.Values.global.nodeSelector | default dict)) (deepCopy .Values.nodeSelector) -}}
+{{- with $merged }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "trueforge.affinity" -}}
+{{- $merged := mergeOverwrite (deepCopy (.Values.global.affinity | default dict)) (deepCopy .Values.affinity) -}}
+{{- with $merged }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "trueforge.tolerations" -}}
+{{- $merged := concat (.Values.global.tolerations | default list) (.Values.tolerations | default list) -}}
+{{- with $merged }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Custom CA. Honours global.customCA whether set on this chart (standalone) or
+inherited from a truefoundry parent. Two modes: mount an operator-supplied full
+bundle straight over /etc/ssl/certs, or merge a CA into the system bundle with
+an initContainer. The chart renders its own ConfigMap when given a certificate,
+so it does not depend on one the parent may or may not have created.
+*/}}
+{{- define "trueforge.customCA" -}}
+{{- .Values.global.customCA | default dict | toYaml -}}
+{{- end }}
+
+{{- define "trueforge.customCA.enabled" -}}
+{{- $ca := include "trueforge.customCA" . | fromYaml -}}
+{{- if $ca.enabled -}}true{{- end -}}
+{{- end }}
+
+{{- define "trueforge.customCA.validate" -}}
+{{- $ca := include "trueforge.customCA" . | fromYaml -}}
+{{- if $ca.enabled -}}
+{{- $existing := ($ca.existingConfigMap | default dict).name -}}
+{{- if and (not $ca.certificate) (not $existing) -}}
+{{- fail "global.customCA.enabled is true but neither global.customCA.certificate nor global.customCA.existingConfigMap.name is set. Provide one of them." -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{- define "trueforge.customCA.useDirectMount" -}}
+{{- $ca := include "trueforge.customCA" . | fromYaml -}}
+{{- $existing := $ca.existingConfigMap | default dict -}}
+{{- if and $existing.name $existing.overrideCAList -}}true{{- end -}}
+{{- end }}
+
+{{- define "trueforge.customCA.configMapName" -}}
+{{- include "trueforge.customCA.validate" . -}}
+{{- $ca := include "trueforge.customCA" . | fromYaml -}}
+{{- $existing := ($ca.existingConfigMap | default dict).name -}}
+{{- if $existing -}}
+{{- $existing -}}
+{{- else -}}
+{{- printf "%s-custom-ca" (include "trueforge.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{- define "trueforge.customCA.initContainer" -}}
+{{- if eq (include "trueforge.customCA.enabled" .) "true" }}
+{{- if ne (include "trueforge.customCA.useDirectMount" .) "true" }}
+{{- $ca := include "trueforge.customCA" . | fromYaml }}
+{{- $image := $ca.image | default dict }}
+- name: configure-custom-ca
+  image: "{{ $image.registry | default "tfy.jfrog.io" }}/{{ $image.repository }}:{{ $image.tag }}"
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  {{- with $ca.securityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  command: ["sh", "-c"]
+  args:
+    - |
+      set -e
+      cat /etc/ssl/certs/ca-certificates.crt /custom-ca/ca-certificates.crt > /ssl-certs/ca-certificates.crt
+  {{- with $ca.env }}
+  env:
+    {{- range $key, $val := . }}
+    - name: {{ $key }}
+      value: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
+  volumeMounts:
+    - name: custom-ca
+      mountPath: /custom-ca
+      readOnly: true
+    - name: ssl-certs
+      mountPath: /ssl-certs
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "trueforge.customCA.volumes" -}}
+{{- if eq (include "trueforge.customCA.enabled" .) "true" }}
+{{- $ca := include "trueforge.customCA" . | fromYaml }}
+- name: custom-ca
+  configMap:
+    name: {{ include "trueforge.customCA.configMapName" . }}
+{{- if ne (include "trueforge.customCA.useDirectMount" .) "true" }}
+- name: ssl-certs
+  emptyDir:
+    sizeLimit: {{ (($ca.emptyDir | default dict).sslCerts | default dict).sizeLimit | default "10Mi" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "trueforge.customCA.volumeMounts" -}}
+{{- if eq (include "trueforge.customCA.enabled" .) "true" }}
+{{- if eq (include "trueforge.customCA.useDirectMount" .) "true" }}
+- name: custom-ca
+  mountPath: /etc/ssl/certs
+  readOnly: true
+{{- else }}
+- name: ssl-certs
+  mountPath: /etc/ssl/certs
+  readOnly: true
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/trueforge/templates/controller-deployment.yaml
+++ b/charts/trueforge/templates/controller-deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "trueforge.fullname" . }}-controller
   labels:
     {{- include "trueforge.controller.labels" . | nindent 4 }}
+  {{- with (mergeOverwrite (include "trueforge.annotations" . | fromYaml) (deepCopy .Values.controller.deploymentAnnotations)) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   # The controller MUST run as exactly one replica per database, so it is never
   # scaled or autoscaled. Recreate avoids two controllers overlapping mid-rollout.
@@ -18,17 +22,17 @@ spec:
     metadata:
       labels:
         {{- include "trueforge.controller.selectorLabels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- with (include "trueforge.podLabels" .) }}
+        {{- . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
+      {{- with (include "trueforge.podAnnotations" .) }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with (include "trueforge.imagePullSecrets" .) }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "trueforge.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}
@@ -40,6 +44,10 @@ spec:
       {{- end }}
       # Above the controller's GRACEFUL_TIMEOUT_SECONDS so SIGKILL does not cut off loop drain.
       terminationGracePeriodSeconds: {{ add .Values.server.gracefulTimeoutSeconds 5 }}
+      {{- with (include "trueforge.customCA.initContainer" .) }}
+      initContainers:
+        {{- . | nindent 8 }}
+      {{- end }}
       containers:
         - name: controller
           image: {{ include "trueforge.image" . | quote }}
@@ -52,47 +60,46 @@ spec:
           {{- end }}
           env:
             {{- include "trueforge.server.env" . | nindent 12 }}
-            - name: SERVER_URL
-              value: {{ include "trueforge.controller.serverUrl" . | quote }}
+            {{- with (include "trueforge.controller.serverUrlEnv" .) }}
+            {{- . | nindent 12 }}
+            {{- end }}
             {{- with .Values.controller.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.controller.resources }}
           resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- include "trueforge.controller.resources" . | nindent 12 }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp
             {{- include "trueforge.mtlsVolumeMount" . | nindent 12 }}
+            {{- include "trueforge.customCA.volumeMounts" . | nindent 12 }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-      {{- $resources := default dict .Values.controller.resources }}
-      {{- $limits := default dict (index $resources "limits") }}
       volumes:
         - name: tmp
-          {{- with index $limits "ephemeral-storage" }}
+          {{- with include "trueforge.controller.tmpEmptyDirSizeLimit" . }}
           emptyDir:
             sizeLimit: {{ . | quote }}
           {{- else }}
           emptyDir: {}
           {{- end }}
         {{- include "trueforge.mtlsVolume" . | nindent 8 }}
+        {{- include "trueforge.customCA.volumes" . | nindent 8 }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with (include "trueforge.nodeSelector" .) }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (include "trueforge.affinity" .) }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (include "trueforge.tolerations" .) }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/trueforge/templates/controller-deployment.yaml
+++ b/charts/trueforge/templates/controller-deployment.yaml
@@ -60,9 +60,8 @@ spec:
           {{- end }}
           env:
             {{- include "trueforge.server.env" . | nindent 12 }}
-            {{- with (include "trueforge.controller.serverUrlEnv" .) }}
-            {{- . | nindent 12 }}
-            {{- end }}
+            - name: SERVER_URL
+              value: {{ include "trueforge.controller.serverUrl" . | quote }}
             {{- with .Values.controller.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/trueforge/templates/custom-ca-configmap.yaml
+++ b/charts/trueforge/templates/custom-ca-configmap.yaml
@@ -1,0 +1,19 @@
+{{- /* Rendered only when a certificate is supplied inline. An operator-provided
+       existingConfigMap is used as-is. Kept in this chart rather than relying on
+       one a parent may have created, so a standalone install works too. */}}
+{{- $ca := include "trueforge.customCA" . | fromYaml }}
+{{- if and $ca.enabled $ca.certificate (not ($ca.existingConfigMap | default dict).name) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-custom-ca" (include "trueforge.fullname" .) }}
+  labels:
+    {{- include "trueforge.labels" . | nindent 4 }}
+  {{- with (include "trueforge.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+data:
+  ca-certificates.crt: |
+    {{- $ca.certificate | nindent 4 }}
+{{- end }}

--- a/charts/trueforge/templates/deployment.yaml
+++ b/charts/trueforge/templates/deployment.yaml
@@ -4,9 +4,13 @@ metadata:
   name: {{ include "trueforge.fullname" . }}
   labels:
     {{- include "trueforge.labels" . | nindent 4 }}
+  {{- with (mergeOverwrite (include "trueforge.annotations" . | fromYaml) (deepCopy .Values.server.deploymentAnnotations)) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.server.replicaCount }}
+  replicas: {{ include "trueforge.replicas" . }}
   {{- end }}
   {{- with .Values.server.strategy }}
   strategy:
@@ -19,17 +23,17 @@ spec:
     metadata:
       labels:
         {{- include "trueforge.selectorLabels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- with (include "trueforge.podLabels" .) }}
+        {{- . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
+      {{- with (include "trueforge.podAnnotations" .) }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with (include "trueforge.imagePullSecrets" .) }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "trueforge.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}
@@ -41,9 +45,15 @@ spec:
       {{- end }}
       # Above the server's GRACEFUL_TIMEOUT_SECONDS so SIGKILL does not cut off turn drain.
       terminationGracePeriodSeconds: {{ add .Values.server.gracefulTimeoutSeconds 5 }}
-      {{- with .Values.initContainers }}
+      {{- $caInit := include "trueforge.customCA.initContainer" . }}
+      {{- if or $caInit .Values.initContainers }}
       initContainers:
+        {{- with $caInit }}
+        {{- . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.initContainers }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: server
@@ -71,45 +81,43 @@ spec:
           readinessProbe:
             {{- include "trueforge.httpProbe" (dict "probe" . "root" $) | nindent 12 }}
           {{- end }}
-          {{- with .Values.resources }}
           resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- include "trueforge.resources" . | nindent 12 }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp
             {{- include "trueforge.mtlsVolumeMount" . | nindent 12 }}
+            {{- include "trueforge.customCA.volumeMounts" . | nindent 12 }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- $resources := default dict .Values.resources }}
-      {{- $limits := default dict (index $resources "limits") }}
       volumes:
         - name: tmp
-          {{- with index $limits "ephemeral-storage" }}
+          {{- with include "trueforge.tmpEmptyDirSizeLimit" . }}
           emptyDir:
             sizeLimit: {{ . | quote }}
           {{- else }}
           emptyDir: {}
           {{- end }}
         {{- include "trueforge.mtlsVolume" . | nindent 8 }}
+        {{- include "trueforge.customCA.volumes" . | nindent 8 }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with (include "trueforge.nodeSelector" .) }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (include "trueforge.affinity" .) }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (include "trueforge.tolerations" .) }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/trueforge/templates/hpa.yaml
+++ b/charts/trueforge/templates/hpa.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "trueforge.fullname" . }}
   labels:
     {{- include "trueforge.labels" . | nindent 4 }}
+  {{- with (include "trueforge.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/trueforge/templates/pdb.yaml
+++ b/charts/trueforge/templates/pdb.yaml
@@ -14,6 +14,10 @@ metadata:
   name: {{ include "trueforge.fullname" . }}
   labels:
     {{- include "trueforge.labels" . | nindent 4 }}
+  {{- with (include "trueforge.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if ne $min "" }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/charts/trueforge/templates/service.yaml
+++ b/charts/trueforge/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- with .Values.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.service.annotations }}
+  {{- with (mergeOverwrite (include "trueforge.annotations" . | fromYaml) (deepCopy .Values.service.annotations)) }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/trueforge/templates/serviceaccount.yaml
+++ b/charts/trueforge/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "trueforge.serviceAccountName" . }}
   labels:
     {{- include "trueforge.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with (mergeOverwrite (include "trueforge.annotations" . | fromYaml) (deepCopy .Values.serviceAccount.annotations)) }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/trueforge/values.yaml
+++ b/charts/trueforge/values.yaml
@@ -18,6 +18,10 @@ serviceAccount:
   name: ""
 podAnnotations: {}
 podLabels: {}
+# Labels and annotations added to every object this chart renders.
+# Merged over global.labels / global.annotations when running as a subchart.
+commonLabels: {}
+commonAnnotations: {}
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 10001
@@ -43,6 +47,8 @@ service:
 server:
   # Number of server replicas (ignored when autoscaling.enabled is true).
   replicaCount: 1
+  # Annotations on the server Deployment object (for example, Argo CD sync waves).
+  deploymentAnnotations: {}
   # Rolling update strategy for the server Deployment.
   strategy:
     type: RollingUpdate
@@ -68,6 +74,8 @@ server:
 controller:
   # Set false to skip the controller Deployment (schedules will not fire).
   enabled: true
+  # Annotations on the controller Deployment object (for example, Argo CD sync waves).
+  deploymentAnnotations: {}
   # Container command. Runs the controller entry from the published package inside
   # the image (root Dockerfile layout: /app/node_modules/@truefoundry/trueforge).
   command:
@@ -87,6 +95,33 @@ controller:
       cpu: 100m
       memory: 256Mi
       ephemeral-storage: 256Mi
+# Controller -> server API key (TRUEFORGE_API_KEY). Required and non-empty
+# whenever the server runs peered (STANDALONE=false), which is always the case
+# for this chart. string, or { valueFrom: { secretKeyRef: { name, key } } }.
+# Prefer valueFrom in production; the chart never creates a Secret for it.
+apiKey: ""
+# --- Extra environment ---------------------------------------------------------
+# Arbitrary env applied to BOTH the server and the controller, as a map of
+# name -> value. Each value is a scalar, or { valueFrom: { secretKeyRef |
+# configMapKeyRef | fieldRef: ... } }. A key here REPLACES the chart's own value
+# for that variable rather than duplicating it, so this is also the way to
+# override something the chart computes (POSTGRES_HOST, PUBLIC_BASE_URL, ...).
+#
+# This is the extension point for running against a hosting platform. The chart
+# stays neutral about who is calling it: platform-specific settings live in the
+# caller's values, not in dedicated fields here.
+#
+# env:
+#   SOME_PLATFORM_API_URL:
+#     valueFrom:
+#       configMapKeyRef: { name: platform-config, key: api-url }
+#   SOME_PLATFORM_API_KEY:
+#     valueFrom:
+#       secretKeyRef: { name: platform-creds, key: api-key }
+#
+# Pair it with extraVolumes / extraVolumeMounts when the platform also needs
+# files mounted, such as client certificates for an outbound mTLS hop.
+env: {}
 # Application feature config (maps to env vars in packages/trueforge/src/config.ts).
 # clientSecret (and other secret-like fields) accept a string or
 # { valueFrom: { secretKeyRef: ... } }.
@@ -121,6 +156,40 @@ configs:
 global:
   security:
     allowInsecureImages: true
+  # Custom CA trust. Honoured whether set here (standalone) or inherited from a
+  # truefoundry parent chart. When `certificate` is given the chart renders its
+  # own ConfigMap; `existingConfigMap.name` reuses one you already have (it must
+  # hold key `ca-certificates.crt`). With overrideCAList the ConfigMap is mounted
+  # straight over /etc/ssl/certs; otherwise an initContainer merges it with the
+  # system bundle. Either way NODE_EXTRA_CA_CERTS is set for the Node runtime.
+  customCA:
+    enabled: false
+    certificate: ""
+    existingConfigMap:
+      name: ""
+      overrideCAList: false
+    image:
+      registry: tfy.jfrog.io
+      repository: tfy-mirror/alpine
+      tag: "3.21"
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      runAsGroup: 1001
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+    # Extra env for the initContainer only, e.g. SSL_CERT_FILE, REQUESTS_CA_BUNDLE.
+    env: {}
+    emptyDir:
+      sslCerts:
+        sizeLimit: 10Mi
+# TrueFoundry size knob. Empty = use `resources` / `controller.resources`.
+# A parent chart (truefoundry) may pass global.resourceTier; this override pins
+# the preset without changing that global.
+resourceTierOverride: ""
 # --- Bundled Postgres (Bitnami subchart) ---------------------------------------
 # Rendered only when postgresql.enabled is true. The server's POSTGRES_* env is
 # wired to this release automatically. See the Bitnami postgresql chart for the
@@ -185,6 +254,17 @@ externalRedis:
   # Full connection URL, e.g. redis://:password@redis-master.databases.svc:6379.
   # string, or { valueFrom: { secretKeyRef: { name, key } } }. Prefer valueFrom in prod.
   url: ""
+  # Redis Sentinel. The app does not read these yet (it only understands
+  # REDIS_URL); the chart injects them so a Sentinel-backed install can be
+  # configured the day the app grows support, without a chart change.
+  sentinel:
+    enabled: false
+    # Comma-separated host:port list -> REDIS_SENTINEL_HOSTS.
+    hosts: ""
+    # Monitored master name -> REDIS_SENTINEL_MASTER_NAME.
+    masterName: ""
+    # string or valueFrom -> REDIS_SENTINEL_PASSWORD.
+    password: ""
   # url:
   #   valueFrom:
   #     secretKeyRef:

--- a/charts/trueforge/values.yaml
+++ b/charts/trueforge/values.yaml
@@ -18,8 +18,8 @@ serviceAccount:
   name: ""
 podAnnotations: {}
 podLabels: {}
-# Labels and annotations added to every object this chart renders.
-# Merged over global.labels / global.annotations when running as a subchart.
+# Labels / annotations on every rendered object (merged over global.labels /
+# global.annotations when running as a subchart).
 commonLabels: {}
 commonAnnotations: {}
 podSecurityContext:
@@ -82,7 +82,7 @@ controller:
     - node
     - node_modules/@truefoundry/trueforge/dist/controller-main.js
   # Base URL the controller uses to reach the server (SERVER_URL).
-  # Empty → the in-cluster server Service (http://<fullname>:<service.port>).
+  # Empty → the in-cluster server Service (http(s)://<fullname>:<service.port>).
   serverUrl: ""
   # Extra env for the controller only; same item shape as server.extraEnv.
   extraEnv: []
@@ -95,32 +95,13 @@ controller:
       cpu: 100m
       memory: 256Mi
       ephemeral-storage: 256Mi
-# Controller -> server API key (TRUEFORGE_API_KEY). Required and non-empty
-# whenever the server runs peered (STANDALONE=false), which is always the case
-# for this chart. string, or { valueFrom: { secretKeyRef: { name, key } } }.
-# Prefer valueFrom in production; the chart never creates a Secret for it.
-apiKey: ""
-# --- Extra environment ---------------------------------------------------------
-# Arbitrary env applied to BOTH the server and the controller, as a map of
-# name -> value. Each value is a scalar, or { valueFrom: { secretKeyRef |
-# configMapKeyRef | fieldRef: ... } }. A key here REPLACES the chart's own value
-# for that variable rather than duplicating it, so this is also the way to
-# override something the chart computes (POSTGRES_HOST, PUBLIC_BASE_URL, ...).
-#
-# This is the extension point for running against a hosting platform. The chart
-# stays neutral about who is calling it: platform-specific settings live in the
-# caller's values, not in dedicated fields here.
-#
-# env:
-#   SOME_PLATFORM_API_URL:
-#     valueFrom:
-#       configMapKeyRef: { name: platform-config, key: api-url }
-#   SOME_PLATFORM_API_KEY:
-#     valueFrom:
-#       secretKeyRef: { name: platform-creds, key: api-key }
-#
-# Pair it with extraVolumes / extraVolumeMounts when the platform also needs
-# files mounted, such as client certificates for an outbound mTLS hop.
+# Controller -> server API key (TRUEFORGE_API_KEY). string, or
+# { valueFrom: { secretKeyRef: { name, key } } }. Replace the dev default
+# before any shared deployment; the chart never creates a Secret for it.
+apiKey: "placeholder-value-please-generate-your-own"
+# Extra env for BOTH server and controller: name -> scalar or { valueFrom: ... }.
+# A key that matches a chart-computed variable (POSTGRES_HOST, PUBLIC_BASE_URL,
+# ...) replaces it in place. This is the extension point for a parent chart.
 env: {}
 # Application feature config (maps to env vars in packages/trueforge/src/config.ts).
 # clientSecret (and other secret-like fields) accept a string or
@@ -156,12 +137,10 @@ configs:
 global:
   security:
     allowInsecureImages: true
-  # Custom CA trust. Honoured whether set here (standalone) or inherited from a
-  # truefoundry parent chart. When `certificate` is given the chart renders its
-  # own ConfigMap; `existingConfigMap.name` reuses one you already have (it must
-  # hold key `ca-certificates.crt`). With overrideCAList the ConfigMap is mounted
-  # straight over /etc/ssl/certs; otherwise an initContainer merges it with the
-  # system bundle. Either way NODE_EXTRA_CA_CERTS is set for the Node runtime.
+  # Custom CA trust, set here or inherited from a parent chart. Give an inline
+  # `certificate` or an `existingConfigMap.name` (key `ca-certificates.crt`);
+  # mounted over /etc/ssl/certs (overrideCAList) or merged with the system
+  # bundle by an initContainer. Sets NODE_EXTRA_CA_CERTS either way.
   customCA:
     enabled: false
     certificate: ""
@@ -186,10 +165,10 @@ global:
     emptyDir:
       sslCerts:
         sizeLimit: 10Mi
-# TrueFoundry size knob. Empty = use `resources` / `controller.resources`.
-# A parent chart (truefoundry) may pass global.resourceTier; this override pins
-# the preset without changing that global.
-resourceTierOverride: ""
+# Resource tier: small | medium | large presets for server and controller.
+# Empty = use `resources` / `controller.resources`. Wins over a parent chart's
+# global.resourceTier.
+resourceTier: ""
 # --- Bundled Postgres (Bitnami subchart) ---------------------------------------
 # Rendered only when postgresql.enabled is true. The server's POSTGRES_* env is
 # wired to this release automatically. See the Bitnami postgresql chart for the
@@ -254,9 +233,7 @@ externalRedis:
   # Full connection URL, e.g. redis://:password@redis-master.databases.svc:6379.
   # string, or { valueFrom: { secretKeyRef: { name, key } } }. Prefer valueFrom in prod.
   url: ""
-  # Redis Sentinel. The app does not read these yet (it only understands
-  # REDIS_URL); the chart injects them so a Sentinel-backed install can be
-  # configured the day the app grows support, without a chart change.
+  # Redis Sentinel connection settings, injected as REDIS_SENTINEL_* env.
   sentinel:
     enabled: false
     # Comma-separated host:port list -> REDIS_SENTINEL_HOSTS.


### PR DESCRIPTION
## Summary

Prepares the chart to ship as a dependency of the TrueFoundry `truefoundry` umbrella chart (control plane) while keeping the chart itself platform-neutral: nothing TrueFoundry-specific lands here, only generic extension points the parent chart drives.

Bumps the chart to `0.1.6-rc.3`.

## Changes

- **`env` map** (server + controller): entries are scalars or `{valueFrom: secretKeyRef|configMapKeyRef|fieldRef}`. A key here replaces the chart-computed variable of the same name (e.g. `POSTGRES_HOST`, `PUBLIC_BASE_URL`), so it doubles as the override mechanism. This is how a parent chart injects platform env (`TRUEFOUNDRY_*`).
- **`apiKey`** value wired to `TRUEFORGE_API_KEY` on both deployments (string or `valueFrom`). The chart fails fast on an empty key: the server always runs `STANDALONE=false` and the app rejects an empty key. The chart never creates the Secret.
- **Parent-chart global inheritance**: `global.labels`, `global.annotations`, `global.podLabels`, `global.podAnnotations`, `global.imagePullSecrets`, `global.nodeSelector`, `global.affinity`, `global.tolerations` merge with local values (local wins). New `commonLabels` / `commonAnnotations` apply to every rendered object.
- **Resource tiers**: `global.resourceTier` (small / medium / large presets, separate presets for server and the always-single-replica controller) plus `resourceTierOverride` to pin a tier locally. Empty tier keeps explicit `resources`.
- **`global.customCA`**: inline certificate (chart renders a ConfigMap) or `existingConfigMap.name`; direct mount over `/etc/ssl/certs` or initContainer merge with the system bundle; sets `NODE_EXTRA_CA_CERTS`. New template `custom-ca-configmap.yaml`.
- **`server.deploymentAnnotations` / `controller.deploymentAnnotations`** so a parent chart can set rollout ordering (e.g. Argo CD sync waves) per Deployment.
- **`externalRedis.sentinel`** passthrough: injects `REDIS_SENTINEL_HOSTS` / `REDIS_SENTINEL_MASTER_NAME` / `REDIS_SENTINEL_PASSWORD` when set, so a Sentinel-backed install needs no chart change once the app reads them.
- README documents the new values.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` default render (bundled Postgres/Redis) with `apiKey` set
- [x] `env` replace-in-place verified (`POSTGRES_HOST` override appears exactly once per container)
- [x] mTLS render: probes flip to HTTPS, cert mount present
- [x] `global.customCA` render: ConfigMap + initContainer merge + `NODE_EXTRA_CA_CERTS`
- [x] Sentinel render injects the three `REDIS_SENTINEL_*` vars
- [x] Empty `apiKey` fails template with a clear message
- [ ] Publish `charts/trueforge@0.1.6-rc.3` after merge (umbrella chart pins this version)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches env composition, controller→server URL scheme under mTLS, and pod init/volume behavior for custom CA—misconfiguration could break schedules, TLS, or outbound trust in umbrella deployments.
> 
> **Overview**
> Bumps the Helm chart to **0.1.6-rc.3** and adds generic hooks so a parent chart (e.g. TrueFoundry control plane) can drive TrueForge without platform-specific values in this chart.
> 
> **Configuration & auth:** New `apiKey` maps to `TRUEFORGE_API_KEY` on server and controller (dev placeholder; validated non-empty). New `env` map applies to both workloads and **replaces** chart-computed vars by name (e.g. `POSTGRES_HOST`, `PUBLIC_BASE_URL`) instead of duplicating entries. `externalRedis.sentinel` optionally injects `REDIS_SENTINEL_*` env when external Redis is used.
> 
> **Subchart / ops integration:** Merges `global.labels`, annotations, pod labels/annotations, `imagePullSecrets`, scheduling (`nodeSelector`, `affinity`, tolerations append), and `global.resourceTier` with local overrides via `commonLabels` / `commonAnnotations` and `resourceTier` presets (`small` / `medium` / `large`) that replace explicit `resources` tables. **`global.customCA`** supports inline PEM (new ConfigMap template) or an existing ConfigMap, with direct mount or initContainer merge plus `NODE_EXTRA_CA_CERTS`. Deployment-level **`server.deploymentAnnotations`** / **`controller.deploymentAnnotations`** for rollout ordering.
> 
> **Runtime wiring:** Controller default `SERVER_URL` uses **https** when `mtls.enabled`. Resources and `/tmp` emptyDir size limits derive from tier helpers on both deployments. README and production checklist document the new values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10196d16e30ff2e9df106b5479a17d56727d745d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->