### PR TITLE
Fix: Stop vend tokens for TrueFoundry skill catalog; use caller JWT and API key mounts

### DIFF
--- a/.changeset/skills-no-agent-vend-token.md
+++ b/.changeset/skills-no-agent-vend-token.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": patch
+---
+
+TrueFoundry skills: use caller JWT for catalog/validate; never agent vend tokens.

--- a/packages/trueforge/src/apis/skills.ts
+++ b/packages/trueforge/src/apis/skills.ts
@@ -1,7 +1,6 @@
 import { OpenAPIHono, type RouteHandler } from '@hono/zod-openapi';
 import type { Context } from 'hono';
 import type { ResolveRequestContext } from '../auth/identity';
-import type { AgentRecord } from '../db/agentStore';
 import { SkillNameConflictError, type ISkillStore, type SkillRecord } from '../db/skillStore';
 import type { WithTransaction } from '../db/transaction';
 import {
@@ -14,10 +13,7 @@ import {
 import type { AvailableSkill, ConfiguredSkill, CreateSkillRequest, UpdateSkillRequest } from '../schemas/skill';
 import { parseTrueFoundryRegistrySkill } from '../schemas/skill';
 
-export type ResolveSkillStore<TTransaction = never> = (
-  c: Context,
-  runAsAgent?: AgentRecord,
-) => ISkillStore<TTransaction>;
+export type ResolveSkillStore<TTransaction = never> = (c: Context) => ISkillStore<TTransaction>;
 
 export interface SkillsRouterDeps<TTransaction> {
   resolveSkillStore: ResolveSkillStore<TTransaction>;

--- a/packages/trueforge/src/apis/turns.ts
+++ b/packages/trueforge/src/apis/turns.ts
@@ -107,7 +107,7 @@ export interface TurnsRouterDeps {
   activeTurns: ActiveTurnRegistry;
   resolveModelProviderStore: (c: Context, runAsAgent?: AgentRecord) => IModelProviderStore;
   resolveMcpServerStore: (c: Context, runAsAgent?: AgentRecord) => IMcpServerWithAuthStore;
-  resolveSkillStore: (c: Context, runAsAgent?: AgentRecord) => ISkillStore;
+  resolveSkillStore: (c: Context) => ISkillStore;
   resolveAgentStore: (c: Context) => IAgentStore;
   /** Resumable live turn-event transport: create-turn writes, subscribe polls. */
   eventSubscriptions: EventSubscriptionRegistry<TurnStreamingEvent>;
@@ -757,7 +757,7 @@ export function createTurnsRouter(deps: TurnsRouterDeps) {
         ...deps,
         modelProviderStore: deps.resolveModelProviderStore(c, referencedAgent),
         mcpServerStore: deps.resolveMcpServerStore(c, referencedAgent),
-        skillStore: deps.resolveSkillStore(c, referencedAgent),
+        skillStore: deps.resolveSkillStore(c),
         agentStore: deps.resolveAgentStore(c),
         sandboxProviderStore: deps.resolveSandboxProviderStore(c),
       },

--- a/packages/trueforge/src/app.ts
+++ b/packages/trueforge/src/app.ts
@@ -328,7 +328,7 @@ export function createServerApp<TTransaction>(deps: ServerDeps<TTransaction>) {
           eventSubscriptions: deps.eventSubscriptions,
           modelProviderStore: deps.resolveModelProviderStore(c, runAsAgent),
           mcpServerStore: deps.resolveMcpServerStore(c, runAsAgent),
-          skillStore: deps.resolveSkillStore(c, runAsAgent),
+          skillStore: deps.resolveSkillStore(c),
           agentStore: deps.resolveAgentStore(c),
           sandboxProviderStore: deps.resolveSandboxProviderStore(c),
           logger: deps.logger,

--- a/packages/trueforge/src/main.ts
+++ b/packages/trueforge/src/main.ts
@@ -137,24 +137,19 @@ function createServiceFoundryServerClient(logger: Logger): TrueFoundryServiceFou
   });
 }
 
-/** Per-request SFY skill catalog; otherwise {@link persistenceStore}.
- * `runAsAgent` is set only when a turn should use a saved agent's token.
- */
+/** Per-request SFY skill catalog; otherwise {@link persistenceStore}. Caller JWT for list/validate. */
 function buildResolveSkillStore<TTransaction>(options: {
   persistenceStore: ISkillStore<TTransaction>;
   client: TrueFoundryServiceFoundryServerClient | undefined;
-  logger: Logger;
 }): ResolveSkillStore<TTransaction> {
-  const { persistenceStore, client, logger } = options;
+  const { persistenceStore, client } = options;
   if (client === undefined) {
     return () => persistenceStore;
   }
-  return (c, runAsAgent) =>
+  return c =>
     new TrueFoundrySkillStore<TTransaction>({
       client,
       context: resolveRequestContext(c),
-      agent: runAsAgent,
-      logger,
     });
 }
 
@@ -409,7 +404,6 @@ async function createDistributedPersistence(options: {
     resolveSkillStore: buildResolveSkillStore({
       persistenceStore: skillStore,
       client: serviceFoundryClient,
-      logger,
     }),
   };
 }

--- a/packages/trueforge/src/truefoundry/TrueFoundrySkillStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundrySkillStore.ts
@@ -1,8 +1,6 @@
 import type { Skill as SkillMount } from '@truefoundry/trueforge-core/core';
 import { HTTPException } from 'hono/http-exception';
-import type { Logger } from 'winston';
 import type { RequestContext } from '../auth/identity';
-import type { AgentRecord } from '../db/agentStore';
 import type {
   AgentSkillsInput,
   CreateSkillInput,
@@ -12,7 +10,7 @@ import type {
   UpsertSkillInput,
 } from '../db/skillStore';
 import type { SkillVersion, TrueFoundryRegistrySkill } from '../schemas/skill';
-import { accessTokenForRequest, asTrueFoundryRequestContext, type ResolveAccessToken } from './accessToken';
+import { callerAccessToken, type ResolveAccessToken } from './accessToken';
 import { trueFoundryManaged } from './errors';
 import {
   mapSfyRegistrySkills,
@@ -24,7 +22,7 @@ import type { TrueFoundryServiceFoundryServerClient } from './TrueFoundryService
 
 export type TrueFoundrySkillApiClient = Pick<
   TrueFoundryServiceFoundryServerClient,
-  'listAgentSkills' | 'listAgentSkillVersions' | 'vendToken' | 'resolveAgentSkillVersions' | 'apiKey'
+  'listAgentSkills' | 'listAgentSkillVersions' | 'resolveAgentSkillVersions' | 'apiKey'
 >;
 
 function toRegistryRecord(tenant_id: string, skill: SfyRegistrySkill): SkillRecord {
@@ -47,26 +45,15 @@ function toRegistryRecord(tenant_id: string, skill: SfyRegistrySkill): SkillReco
 }
 
 /** Read-only TrueFoundry registry skill catalog; writes are managed by TrueFoundry.
- * Pass `agent` on turn/cron paths so catalog reads use the same vend token as models and MCP.
- * Save validate uses the caller JWT; turn mounts pass the service API key.
+ * Catalog / save validate use the caller JWT; turn mounts use the service API key.
  */
 export class TrueFoundrySkillStore<TTransaction = never> implements ISkillStore<TTransaction> {
   readonly #client: TrueFoundrySkillApiClient;
   readonly #resolveAccessToken: ResolveAccessToken;
 
-  constructor(input: {
-    client: TrueFoundrySkillApiClient;
-    context: RequestContext;
-    agent: AgentRecord | undefined;
-    logger: Logger;
-  }) {
+  constructor(input: { client: TrueFoundrySkillApiClient; context: RequestContext }) {
     this.#client = input.client;
-    this.#resolveAccessToken = accessTokenForRequest({
-      client: input.client,
-      context: asTrueFoundryRequestContext(input.context),
-      agent: input.agent,
-      logger: input.logger,
-    });
+    this.#resolveAccessToken = callerAccessToken(input.context);
   }
 
   async listSkills(input: ListSkillsInput, transaction?: TTransaction): Promise<SkillRecord[]> {

--- a/packages/trueforge/tests/unit/truefoundry/TrueFoundrySkillStore.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/TrueFoundrySkillStore.test.ts
@@ -1,15 +1,9 @@
-import { AgentSpecSchema } from '@truefoundry/trueforge-core/agent-session';
-import { createLogger } from 'winston';
-import type { AgentRecord } from '../../../src/db/agentStore';
 import type { CreateSkillInput } from '../../../src/db/skillStore';
-import { createTrueFoundryRequestContext } from '../../../src/truefoundry/accessToken';
 import { TRUEFOUNDRY_MANAGED_MESSAGE, TRUEFOUNDRY_MANAGED_STATUS } from '../../../src/truefoundry/errors';
 import { TrueFoundrySkillStore } from '../../../src/truefoundry/TrueFoundrySkillStore';
 
 const TENANT = 'acme';
 const ACCESS_TOKEN = 'caller-access-token';
-const AGENT_TOKEN = 'agent-vend-token';
-const LOGGER = createLogger({ silent: true });
 const SFY_SKILL = {
   id: 'skill-1',
   fqn: 'agent-skill:acme/team-a/echo',
@@ -27,19 +21,7 @@ const SFY_SKILL = {
   },
 };
 
-const AGENT: AgentRecord = {
-  id: 'agent-1',
-  tenant_id: TENANT,
-  name: 'named',
-  manifest: AgentSpecSchema.parse({ model: { name: 'p/m' } }),
-  external_id: 'ext-agent',
-  created_by_subject: { subject_id: 'user-1', subject_type: 'user', subject_display_name: 'user-1' },
-  created_at: '2026-01-01T00:00:00.000Z',
-  updated_at: '2026-01-01T00:00:00.000Z',
-};
-
 function createStore(
-  agent: AgentRecord | undefined = undefined,
   versions: unknown[] = [
     {
       id: 'ver-3',
@@ -67,19 +49,16 @@ function createStore(
         description: 'Echo skill',
       },
     ]),
-    vendToken: jest.fn().mockResolvedValue(AGENT_TOKEN),
     apiKey: 'tfy-api-key',
   };
   const store = new TrueFoundrySkillStore({
     client,
-    context: createTrueFoundryRequestContext({
+    context: {
       tenant_id: TENANT,
       subject: { id: 'user-1', type: 'user', display_name: 'user-1' },
       roles: [],
       user_credential: ACCESS_TOKEN,
-    }),
-    agent,
-    logger: LOGGER,
+    },
   });
   return { store, client };
 }
@@ -89,7 +68,6 @@ describe('TrueFoundrySkillStore', () => {
     const { store, client } = createStore();
     const records = await store.listSkills({ tenant_id: TENANT, names: undefined });
     expect(client.listAgentSkills).toHaveBeenCalledWith({ accessToken: ACCESS_TOKEN });
-    expect(client.vendToken).not.toHaveBeenCalled();
     expect(records).toHaveLength(1);
     expect(records[0]?.name).toBe('agent-skill:acme/team-a/echo:3');
     expect(records[0]?.manifest).toEqual({
@@ -166,32 +144,8 @@ describe('TrueFoundrySkillStore', () => {
     expect(client.resolveAgentSkillVersions).not.toHaveBeenCalled();
   });
 
-  it('uses a vend token when listing as a saved agent', async () => {
-    const { store, client } = createStore(AGENT);
-    await store.listSkills({ tenant_id: TENANT, names: undefined });
-    expect(client.vendToken).toHaveBeenCalledWith({
-      subject: { id: 'user-1', type: 'user', display_name: 'user-1' },
-      agentId: 'ext-agent',
-      tenantName: TENANT,
-    });
-    expect(client.listAgentSkills).toHaveBeenCalledWith({ accessToken: AGENT_TOKEN });
-  });
-
-  it('uses a vend token for skill versions when listing as a saved agent', async () => {
-    const { store, client } = createStore(AGENT);
-    await store.listSkillVersions({ name: 'agent-skill:acme/team-a/echo:3' });
-    expect(client.listAgentSkillVersions).toHaveBeenNthCalledWith(1, {
-      accessToken: AGENT_TOKEN,
-      fqn: 'agent-skill:acme/team-a/echo:3',
-    });
-    expect(client.listAgentSkillVersions).toHaveBeenNthCalledWith(2, {
-      accessToken: AGENT_TOKEN,
-      agent_skill_id: 'skill-1',
-    });
-  });
-
   it('listSkillVersions returns every SFY version row', async () => {
-    const { store } = createStore(undefined, [
+    const { store } = createStore([
       {
         id: 'ver-1',
         agent_skill_id: 'skill-1',


### PR DESCRIPTION
## Summary

Fix: Stop vend tokens for TrueFoundry skill catalog; use caller JWT and API key mounts

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth for ServiceFoundry skill catalog and validate on agent-bound turns and schedules; wrong JWT scoping could hide skills or fail validation, but turn mounts still use the service API key.
> 
> **Overview**
> **TrueFoundry skill registry calls no longer mint or use agent vend tokens.** Catalog listing, version listing, and agent save validation always authenticate to ServiceFoundry with the **caller's JWT** (`callerAccessToken`), including turns and scheduled runs that previously passed the saved agent into `resolveSkillStore`.
> 
> `ResolveSkillStore` is now `(c: Context) => ISkillStore` everywhere (turns, schedules, skills APIs). `TrueFoundrySkillStore` drops `agent`, `logger`, and `vendToken` from its client surface; **runtime sandbox mounts** still resolve skills via `resolveTurnSkills` using the **service API key**, unchanged.
> 
> Unit tests drop vend-token scenarios and assert caller-token catalog/validate plus API-key turn resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e18275546d03410865df68d99b2a504a76a1546. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->