### PR TITLE
Fix: strip trailing slash from agent code-snippet base_url

### DIFF
--- a/.changeset/code-snippets-trim-base-url-slash.md
+++ b/.changeset/code-snippets-trim-base-url-slash.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge-ui": patch
+---
+
+Strip a trailing slash from the `base_url` passed to agent code-snippets.

--- a/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/agentSessionsServer.ts
+++ b/packages/trueforge-ui/src/plugins/trueforge-agent-server-adapter/agentSessionsServer.ts
@@ -56,7 +56,8 @@ export function createHarnessAgentSessionsServer(
       };
     },
     async getCodeSnippets({ agentId }) {
-      const absoluteBaseUrl = resolveTrueForgeBaseUrl(options.baseUrl ?? '/');
+      // Snippet SDK `baseUrl` should not end with `/` (hosts often pass a trailing path slash).
+      const absoluteBaseUrl = resolveTrueForgeBaseUrl(options.baseUrl ?? '/').replace(/\/$/, '');
       const { data } = await client.internal.agents.getCodeSnippets(
         agentId,
         /^https?:\/\//i.test(absoluteBaseUrl) ? { baseUrl: absoluteBaseUrl } : undefined,

--- a/packages/trueforge-ui/test/plugins/trueforge-agent-server-adapter/agentSessionsServer.test.ts
+++ b/packages/trueforge-ui/test/plugins/trueforge-agent-server-adapter/agentSessionsServer.test.ts
@@ -48,7 +48,10 @@ describe('createHarnessAgentSessionsServer', () => {
       },
     ]);
     assert.deepEqual(get.mock.calls[0], ['agent-1']);
-    assert.deepEqual(getCodeSnippets.mock.calls[0], ['agent-1', { baseUrl: resolveTrueForgeBaseUrl('/') }]);
+    assert.deepEqual(getCodeSnippets.mock.calls[0], [
+      'agent-1',
+      { baseUrl: resolveTrueForgeBaseUrl('/').replace(/\/$/, '') },
+    ]);
   });
 
   it('maps listSessions and listSessionEvents onto the UI contract', async () => {


### PR DESCRIPTION
## Summary
- Normalize `base_url` in `getCodeSnippets` by stripping a trailing `/` before forwarding to the SDK snippet generator.
- Update the adapter test to expect the trimmed URL.
- Add a patch changeset for `@truefoundry/trueforge-ui`.

## Test plan
- [ ] Run `packages/trueforge-ui` agentSessionsServer tests
- [ ] Open Use in Code for an agent with a trailing-slash public base URL and confirm snippet `baseUrl` has no trailing `/`


Made with [Cursor](https://cursor.com)