### PR TITLE
fix(trueforge-ui): encode artifact paths in download links

### DIFF
--- a/.changeset/encode-artifact-download-path.md
+++ b/.changeset/encode-artifact-download-path.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Encode sandbox artifact paths when building file-download links, so names containing spaces, `#`, `?`, `&`, `%` or non-ASCII characters resolve to the intended file instead of a truncated or misparsed URL.

--- a/packages/trueforge-ui/src/atoms/ChatFileDownload.tsx
+++ b/packages/trueforge-ui/src/atoms/ChatFileDownload.tsx
@@ -18,6 +18,12 @@ export type ChatFileDownloadProps = {
   readOnly?: boolean;
 };
 
+// Artifact paths are model-authored, so a name may carry characters that change what the
+// URL means. Encode per segment so `/` keeps its structural role and the rest stays literal.
+function encodeArtifactPath(path: string): string {
+  return path.split('/').map(encodeURIComponent).join('/');
+}
+
 export function ChatFileDownload({ files, fileDownloadBaseUrl, onDownloadArtifact, readOnly }: ChatFileDownloadProps) {
   const [downloadingPath, setDownloadingPath] = useState<string | null>(null);
 
@@ -49,7 +55,7 @@ export function ChatFileDownload({ files, fileDownloadBaseUrl, onDownloadArtifac
             );
           }
 
-          const href = fileDownloadBaseUrl ? `${fileDownloadBaseUrl}${path}` : undefined;
+          const href = fileDownloadBaseUrl ? `${fileDownloadBaseUrl}${encodeArtifactPath(path)}` : undefined;
           const canDownload = Boolean(onDownloadArtifact || href);
           const isDownloading = downloadingPath === path;
 

--- a/packages/trueforge-ui/test/atoms/ChatFileDownload.test.tsx
+++ b/packages/trueforge-ui/test/atoms/ChatFileDownload.test.tsx
@@ -30,6 +30,32 @@ describe('ChatFileDownload', () => {
     expect(screen.getByRole('link', { name: 'Download data.csv' })).toHaveAttribute('href', '/downloads/data.csv');
   });
 
+  it('encodes artifact names that would otherwise break or rewrite the URL', () => {
+    render(
+      <ChatFileDownload
+        files={[
+          { name: 'my report#final,v2.csv', path: '/tmp/my report#final,v2.csv' },
+          { name: 'a&b?c%d.txt', path: '/tmp/a&b?c%d.txt' },
+          { name: 'ünïcode.txt', path: '/tmp/ünïcode.txt' },
+        ]}
+        fileDownloadBaseUrl="https://files.example.com"
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Download my report#final,v2.csv' })).toHaveAttribute(
+      'href',
+      'https://files.example.com/tmp/my%20report%23final%2Cv2.csv',
+    );
+    expect(screen.getByRole('link', { name: 'Download a&b?c%d.txt' })).toHaveAttribute(
+      'href',
+      'https://files.example.com/tmp/a%26b%3Fc%25d.txt',
+    );
+    expect(screen.getByRole('link', { name: 'Download ünïcode.txt' })).toHaveAttribute(
+      'href',
+      'https://files.example.com/tmp/%C3%BCn%C3%AFcode.txt',
+    );
+  });
+
   it('shows per-file progress and suppresses duplicate artifact downloads', async () => {
     let resolveDownload: (() => void) | undefined;
     const downloadPromise = new Promise<void>(resolve => {


### PR DESCRIPTION
## Summary

Artifact paths come from the model's `sandbox_artifacts` fence and were concatenated into the download `href` unencoded, so a generated name containing a space, `#`, `?`, `&` or `%` produced a broken or misparsed URL. `#` in particular silently truncates the rest.

Closes #424

## Changes

- Encode each segment of the path in `ChatFileDownload`, so `/` keeps its structural meaning and everything else is escaped
- Test covering spaces, `#`, `&`, `?`, `%` and non-ASCII names

Worth flagging: not `encodeURIComponent(path)` as the issue suggests. `fileDownloadBaseUrl` is a path prefix, not a `?path=` query, so encoding the whole string turns `/report.pdf` into `%2Freport.pdf` and breaks the links the existing test pins.

## How was this tested?

`vitest run test/atoms/ChatFileDownload.test.tsx` in `packages/trueforge-ui` — 5 pass. Reverting only the encode call fails the new case and leaves the other four green.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [x] `format:check` passes repo-wide and eslint is clean on the touched files; ran the package's own tests rather than the full `pnpm test`. Repo-wide `lint:ci` has 55 pre-existing errors, all in `packages/frontend/*` and `DropdownMenu.tsx`, none in files this PR touches
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code
- [ ] Docs / `.env.example` — not applicable

Changeset included. On process: CONTRIBUTING asks for approval first, and all six `help wanted` issues are assigned or already have PRs, so there was nothing approved to pick up. Close this if you'd rather it went through the queue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI URL construction fix with tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes broken sandbox artifact downloads when model-generated filenames include spaces, `#`, query characters, `&`, `%`, or non-ASCII text—those values were appended to `fileDownloadBaseUrl` raw, so browsers could truncate or misparse the link (notably `#`).
> 
> **ChatFileDownload** now runs paths through **`encodeArtifactPath`**, which applies **`encodeURIComponent`** to each path segment while leaving **`/`** as separators (avoiding whole-path encoding that would turn `/report.pdf` into `%2Freport.pdf`). The **`onDownloadArtifact`** callback still receives the original path; only the anchor **`href`** is encoded.
> 
> Adds a unit test for the tricky filename cases and a patch changeset for **`@truefoundry/trueforge-ui`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c976529edaa67810caa775c4d99b2695a43b49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->