### PR TITLE
Fix: Preserve active agent draft when returning to Build Agent from other pages

### DIFF
--- a/.changeset/preserve-agent-builder-draft.md
+++ b/.changeset/preserve-agent-builder-draft.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Preserve the active agent draft when returning to Build Agent from another page.

--- a/packages/trueforge-ui/src/server/ShellModeContext.tsx
+++ b/packages/trueforge-ui/src/server/ShellModeContext.tsx
@@ -483,11 +483,31 @@ export function ShellModeProvider({
     selectLibraryAgent({ isMutable: true, isCreateAgent: false, agentSpec: chatSeedRef.current });
   }, [isComposerEnabled, refreshCapabilities, selectLibraryAgent]);
 
+  const isActiveAgentBuilder =
+    effectiveMode.status === 'active' && effectiveMode.isMutable && effectiveMode.isCreateAgent;
   const openAgentBuilder = useCallback(() => {
     if (!isComposerEnabled) return;
     refreshCapabilities?.();
+    // Returning from an overlay must keep the live draft runtime and its unsaved instructions.
+    if (isActiveAgentBuilder) {
+      setSettingsOpen(false);
+      setLibraryOpenState(false);
+      setLibraryAgentId(null);
+      setSessionsOpen(false);
+      setSchedulesOpen(false);
+      setAgentConfigOpenState(true);
+      return;
+    }
     selectLibraryAgent({ isMutable: true, isCreateAgent: true, agentSpec: agentSeedRef.current });
-  }, [isComposerEnabled, refreshCapabilities, selectLibraryAgent]);
+  }, [
+    isActiveAgentBuilder,
+    isComposerEnabled,
+    refreshCapabilities,
+    selectLibraryAgent,
+    setSchedulesOpen,
+    setSessionsOpen,
+    setSettingsOpen,
+  ]);
 
   const sandboxEnabled = capabilities?.sandbox.enabled;
   const rememberDraftSpec = useCallback(
@@ -497,7 +517,8 @@ export function ShellModeProvider({
       if (kind === 'chat') {
         chatSeedRef.current = preferences;
       } else {
-        agentSeedRef.current = preferences;
+        // Keep the active builder intact in memory; storage remains limited to reusable preferences.
+        agentSeedRef.current = withCapabilitiesSandbox(agentSpec, sandboxEnabled);
       }
       writeDraftSpecPreferences(kind, preferences);
     },

--- a/packages/trueforge-ui/test/server/ShellModeContext.test.tsx
+++ b/packages/trueforge-ui/test/server/ShellModeContext.test.tsx
@@ -177,6 +177,43 @@ describe('ShellModeProvider', () => {
     expect(result.current.agentConfigOpen).toBe(false);
   });
 
+  it('resumes the active agent builder without resetting its runtime', () => {
+    const { result } = renderHook(() => useShellMode(), { wrapper: wrap() });
+
+    act(() => result.current.openAgentBuilder());
+    const builderRuntimeKey = result.current.runtimeKey;
+
+    act(() => result.current.setLibraryOpen(true));
+    expect(result.current.libraryOpen).toBe(true);
+    expect(result.current.agentConfigOpen).toBe(false);
+
+    act(() => result.current.openAgentBuilder());
+    expect(result.current.libraryOpen).toBe(false);
+    expect(result.current.agentConfigOpen).toBe(true);
+    expect(result.current.runtimeKey).toBe(builderRuntimeKey);
+  });
+
+  it('restores the active agent draft after visiting New Chat', () => {
+    const { result } = renderHook(() => useShellMode(), { wrapper: wrap() });
+    const agentDraft = {
+      model: { name: 'chosen/model' },
+      instructions: 'Keep these instructions.',
+    };
+
+    act(() => result.current.openAgentBuilder());
+    act(() => result.current.rememberDraftSpec(agentDraft, 'agent'));
+    act(() => result.current.openDraft());
+    act(() => result.current.openAgentBuilder());
+
+    expect(result.current.mode).toMatchObject({
+      status: 'active',
+      isMutable: true,
+      isCreateAgent: true,
+      agentSpec: agentDraft,
+    });
+    expect(readDraftSpecPreferences('agent')).not.toHaveProperty('instructions');
+  });
+
   it('openDraft starts New Chat without agent config; openAgentBuilder opens config', () => {
     const { result } = renderHook(() => useShellMode(), { wrapper: wrap() });
 


### PR DESCRIPTION

## Summary

[Screencast from 2026-09-11 10-49-58.webm](https://github.com/user-attachments/assets/1a1b7c55-bbc6-45fa-bc1e-e61d0de8e47b)


## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized shell navigation and in-memory draft seed behavior with new unit coverage; no auth, API, or persistence contract changes beyond existing draft preference storage.
> 
> **Overview**
> Fixes **Build Agent** losing in-progress work when users open the library, New Chat, settings, or other shell overlays and come back.
> 
> **`openAgentBuilder`** now detects an already-active mutable builder session and only closes competing chrome and reopens the agent config drawer—**without** calling `selectLibraryAgent`, so **`runtimeKey` stays the same** and the live draft runtime (including unsaved instructions) is not remounted.
> 
> **`rememberDraftSpec`** for agent drafts keeps the **full in-memory** `agentSeedRef` (with sandbox capability adjustments) while **localStorage** still stores only reusable preference fields (e.g. instructions are not persisted there). Returning to Build Agent after New Chat restores the full **`agentSpec`** from memory.
> 
> Adds **ShellModeContext** unit tests for runtime resumption and draft restoration; includes a **patch changeset** for `@truefoundry/trueforge-ui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 386e677df4340a588a792402f1ddc43eca5d9077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->