### PR TITLE
feat: include user API key in TypeScript agent code snippets for OIDC and TrueFoundry auth

### DIFF
--- a/.changeset/agent-snippet-token.md
+++ b/.changeset/agent-snippet-token.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge': patch
+---
+
+Include `token: "USER_API_KEY"` in TypeScript agent code snippets when OIDC or TrueFoundry auth is enabled.

--- a/packages/trueforge/src/apis/agentCodeSnippets.ts
+++ b/packages/trueforge/src/apis/agentCodeSnippets.ts
@@ -1,12 +1,20 @@
+import { getTrueForgeAuthMode, TrueForgeAuthMode } from '../config';
 import type { AgentCodeSnippets } from '../schemas/agent';
 import { typescriptNonStreamTemplate, typescriptStreamTemplate } from './codesnippet-templates/typescript';
 
 const TYPESCRIPT_ICON = 'https://assets.production.truefoundry.com/typescript.svg';
 
-function renderSnippetTemplate(template: string, vars: { agentName: string; baseUrl: string }): string {
+/** Bearer `token` for OIDC / TrueFoundry; omitted in standalone where login is off. */
+const TOKEN_LINE = '\n  token: "USER_API_KEY",';
+
+function renderSnippetTemplate(
+  template: string,
+  vars: { agentName: string; baseUrl: string; includeToken: boolean },
+): string {
   const literals: Record<string, string> = {
     agentName: JSON.stringify(vars.agentName),
     baseUrl: JSON.stringify(vars.baseUrl),
+    tokenLine: vars.includeToken ? TOKEN_LINE : '',
   };
   return template.replaceAll(/\{\{(\w+)\}\}/g, (match, key: string) => {
     const value = literals[key];
@@ -18,6 +26,8 @@ function renderSnippetTemplate(template: string, vars: { agentName: string; base
 }
 
 export function buildAgentCodeSnippets(input: { agentName: string; baseUrl: string }): AgentCodeSnippets {
+  const includeToken = getTrueForgeAuthMode() !== TrueForgeAuthMode.Standalone;
+  const vars = { ...input, includeToken };
   return {
     base_url: input.baseUrl,
     snippets: [
@@ -26,8 +36,8 @@ export function buildAgentCodeSnippets(input: { agentName: string; baseUrl: stri
         language: 'typescript',
         icon: TYPESCRIPT_ICON,
         sample_code: {
-          stream: renderSnippetTemplate(typescriptStreamTemplate, input),
-          non_stream: renderSnippetTemplate(typescriptNonStreamTemplate, input),
+          stream: renderSnippetTemplate(typescriptStreamTemplate, vars),
+          non_stream: renderSnippetTemplate(typescriptNonStreamTemplate, vars),
         },
       },
     ],

--- a/packages/trueforge/src/apis/codesnippet-templates/typescript.ts
+++ b/packages/trueforge/src/apis/codesnippet-templates/typescript.ts
@@ -2,7 +2,7 @@ export const typescriptStreamTemplate = `// npm install @truefoundry/trueforge-s
 import { TrueForge, TrueForgeApi, isEventDelta, mergeEventDelta } from "@truefoundry/trueforge-sdk";
 
 const client = new TrueForge({
-  baseUrl: {{baseUrl}},
+  baseUrl: {{baseUrl}},{{tokenLine}}
 });
 
 const { data: session } = await client.sessions.create({
@@ -30,7 +30,7 @@ export const typescriptNonStreamTemplate = `// npm install @truefoundry/trueforg
 import { TrueForge } from "@truefoundry/trueforge-sdk";
 
 const client = new TrueForge({
-  baseUrl: {{baseUrl}},
+  baseUrl: {{baseUrl}},{{tokenLine}}
 });
 
 const { data: session } = await client.sessions.create({

--- a/packages/trueforge/tests/unit/apis/agents.test.ts
+++ b/packages/trueforge/tests/unit/apis/agents.test.ts
@@ -171,13 +171,20 @@ describe('agents router', () => {
 
     const response = await router.request(`/${createdJson.data.id}/code-snippets`);
     expect(response.status).toBe(200);
-    const body = (await response.json()) as { data: { base_url: string; snippets: unknown[] } };
+    const body = (await response.json()) as {
+      data: {
+        base_url: string;
+        snippets: Array<{ sample_code: { stream: string; non_stream: string } }>;
+      };
+    };
     expect(body.data.base_url).toBe(
       configuration.PUBLIC_BASE_URL
         ? new URL(new URL(configuration.PUBLIC_BASE_URL).pathname, 'http://localhost').href
         : 'http://localhost',
     );
     expect(body.data.snippets.length).toBeGreaterThan(0);
+    expect(body.data.snippets[0]?.sample_code.stream).not.toContain('USER_API_KEY');
+    expect(body.data.snippets[0]?.sample_code.non_stream).not.toContain('USER_API_KEY');
 
     const overridden = await router.request(
       `/${createdJson.data.id}/code-snippets?base_url=${encodeURIComponent('https://sample.com/trueforge')}`,


### PR DESCRIPTION

## Summary

feat: include user API key in TypeScript agent code snippets for OIDC and TrueFoundry auth

Closes #<add-issue-number-here>

## Changes



## How was this tested?

<img width="1777" height="992" alt="Screenshot 2026-09-11 at 10 59 38 AM" src="https://github.com/user-attachments/assets/60ff013f-51ea-4184-b636-e1a23ef7742d" />


## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect generated sample code strings, not runtime auth or secret handling.
> 
> **Overview**
> TypeScript **stream** and **non-stream** agent code snippets now optionally include `token: "USER_API_KEY"` on the SDK client when TrueForge is not in **standalone** mode (OIDC or TrueFoundry auth). Standalone deployments keep snippets unchanged with no token line.
> 
> Snippet rendering in `buildAgentCodeSnippets` reads `getTrueForgeAuthMode()` and injects a `{{tokenLine}}` placeholder into the TypeScript templates. Unit tests assert the default test router (standalone) does **not** emit `USER_API_KEY` in returned snippets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3e455cdb76f9c5c4d869de603d64c3ad1985f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->