### PR TITLE
Support reading values for external postgres value from

### DIFF
--- a/charts/trueforge/README.md
+++ b/charts/trueforge/README.md
@@ -172,15 +172,34 @@ Also set `postgresql.auth.username` and `postgresql.auth.database` as needed;
 the server connects to the bundled instance automatically.
 
 To use an **external** Postgres, set `postgresql.enabled=false` and provide
-`externalPostgres.host` (+ `port`, `database`, `user`). Set
-`externalPostgres.password` as a string (inlined as env `value`) or as
+`externalPostgres.host` (+ `port`, `database`, `user`, `password`). Each of
+those accepts an inline scalar (inlined as env `value`) or
 `valueFrom.secretKeyRef` (preferred in production — you create the Secret):
 
 ```yaml
 postgresql:
   enabled: false
 externalPostgres:
-  host: postgres.databases.svc
+  host:
+    valueFrom:
+      secretKeyRef:
+        name: my-postgres-secret
+        key: host
+  port:
+    valueFrom:
+      secretKeyRef:
+        name: my-postgres-secret
+        key: port
+  database:
+    valueFrom:
+      secretKeyRef:
+        name: my-postgres-secret
+        key: database
+  user:
+    valueFrom:
+      secretKeyRef:
+        name: my-postgres-secret
+        key: user
   password:
     valueFrom:
       secretKeyRef:
@@ -254,7 +273,9 @@ chart does **not** create Secrets for chart-owned fields — supply
 `valueFrom.secretKeyRef` (or create Secrets yourself and point at them).
 
 Fields that accept string | `valueFrom.secretKeyRef`:
-`externalPostgres.password`, `externalRedis.url`, `configs.oidc.clientSecret`.
+`externalPostgres.host`, `externalPostgres.port`, `externalPostgres.database`,
+`externalPostgres.user`, `externalPostgres.password`, `externalRedis.url`,
+`configs.oidc.clientSecret`.
 `configs.oidc.issuerUrl` and `clientId` are plain strings only.
 
 **Bundled Postgres password** still uses Bitnami's API (`postgresql.auth.existingSecret`,

--- a/charts/trueforge/templates/NOTES.txt
+++ b/charts/trueforge/templates/NOTES.txt
@@ -10,7 +10,7 @@ Port-forward it locally with:
 
 Then open http://localhost:8790 and check http://localhost:8790/healthz.
 
-Postgres: {{ if .Values.postgresql.enabled }}bundled ({{ include "trueforge.postgres.host" . }}){{ else }}external ({{ include "trueforge.postgres.host" . }}){{ end }}
+Postgres: {{ if .Values.postgresql.enabled }}bundled ({{ include "trueforge.postgres.host" . }}){{ else }}external (literal or valueFrom){{ end }}
 Redis:    {{ if .Values.redis.enabled }}bundled{{- else }}external (literal or valueFrom){{- end }}
 OIDC:     {{ if .Values.configs.oidc.enabled }}enabled{{- else }}disabled (local admin identity){{- end }}
 
@@ -52,7 +52,9 @@ https://<your-public-origin>/api/v1/auth/callback at your IdP.
 WARNING: server.publicBaseUrl is empty. MCP OAuth and OIDC callbacks will fail until you set it to the public application URL (e.g. https://trueforge.example.com or https://host/custom/proxy/path).
 {{- end }}
 
-{{- if and (not .Values.postgresql.enabled) (not .Values.externalPostgres.host) }}
+{{- $extHost := .Values.externalPostgres.host -}}
+{{- $extHostSet := or (eq (include "trueforge.isLiteralString" (dict "value" $extHost)) "true") (and (kindIs "map" $extHost) $extHost.valueFrom) -}}
+{{- if and (not .Values.postgresql.enabled) (not $extHostSet) }}
 
-WARNING: postgresql.enabled is false and externalPostgres.host is empty. Set one so the server can reach Postgres.
+WARNING: postgresql.enabled is false and externalPostgres.host is unset. Set a host string or valueFrom so the server can reach Postgres.
 {{- end }}

--- a/charts/trueforge/templates/_helpers.tpl
+++ b/charts/trueforge/templates/_helpers.tpl
@@ -128,8 +128,8 @@ Container image reference; tag falls back to the chart appVersion.
 {{- end }}
 
 {{/*
-True when .value is a non-empty string (vs a valueFrom map).
-Expects dict with key "value".
+True when .value is an inline scalar (string or number), not a valueFrom map.
+Used so NOTES / helpers can print "postgres.svc" and skip secretKeyRef maps.
 */}}
 {{- define "trueforge.isLiteralString" -}}
 {{- $v := index . "value" -}}
@@ -137,43 +137,48 @@ Expects dict with key "value".
 {{- end }}
 
 {{/*
-Fail unless .value is a non-empty string or a map with valueFrom.
+Fail unless .value is a non-empty string, a number, or a map with valueFrom.
 Expects dict with keys "name" and "value".
 */}}
 {{- define "trueforge.requireStringOrValueFrom" -}}
 {{- $v := index . "value" -}}
 {{- $name := index . "name" -}}
 {{- if kindIs "string" $v -}}
-{{- if eq $v "" -}}{{- fail (printf "%s is required (string or valueFrom.secretKeyRef)" $name) -}}{{- end -}}
+{{- if eq $v "" -}}{{- fail (printf "%s is required (string, number, or valueFrom.secretKeyRef)" $name) -}}{{- end -}}
+{{- else if or (kindIs "int" $v) (kindIs "int64" $v) (kindIs "float64" $v) -}}
 {{- else if kindIs "map" $v -}}
 {{- if not $v.valueFrom -}}{{- fail (printf "%s map must set valueFrom" $name) -}}{{- end -}}
 {{- else -}}
-{{- fail (printf "%s must be a string or a valueFrom object" $name) -}}
+{{- fail (printf "%s must be a string, number, or valueFrom object" $name) -}}
 {{- end -}}
 {{- end }}
 
 {{/*
-Postgres connection. Sourced from the bundled Bitnami postgresql subchart when
-postgresql.enabled, otherwise from externalPostgres.
+Literal Postgres host/user/database for NOTES and bundled-subchart env.
+Empty when the field is a valueFrom map (external secret/configmap).
 */}}
 {{- define "trueforge.postgres.host" -}}
 {{- if .Values.postgresql.enabled -}}
 {{- printf "%s-postgresql" .Release.Name -}}
-{{- else -}}
-{{- required "externalPostgres.host is required when postgresql.enabled is false" .Values.externalPostgres.host -}}
+{{- else if eq (include "trueforge.isLiteralString" (dict "value" .Values.externalPostgres.host)) "true" -}}
+{{- .Values.externalPostgres.host -}}
 {{- end -}}
 {{- end }}
 
-{{- define "trueforge.postgres.port" -}}
-{{- if .Values.postgresql.enabled -}}5432{{- else -}}{{ .Values.externalPostgres.port }}{{- end -}}
-{{- end }}
-
 {{- define "trueforge.postgres.user" -}}
-{{- if .Values.postgresql.enabled -}}{{ .Values.postgresql.auth.username }}{{- else -}}{{ .Values.externalPostgres.user }}{{- end -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.username -}}
+{{- else if eq (include "trueforge.isLiteralString" (dict "value" .Values.externalPostgres.user)) "true" -}}
+{{- .Values.externalPostgres.user -}}
+{{- end -}}
 {{- end }}
 
 {{- define "trueforge.postgres.database" -}}
-{{- if .Values.postgresql.enabled -}}{{ .Values.postgresql.auth.database }}{{- else -}}{{ .Values.externalPostgres.database }}{{- end -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.database -}}
+{{- else if eq (include "trueforge.isLiteralString" (dict "value" .Values.externalPostgres.database)) "true" -}}
+{{- .Values.externalPostgres.database -}}
+{{- end -}}
 {{- end }}
 
 {{/*
@@ -341,10 +346,10 @@ not create Secrets; callers who need secretKeyRef must supply valueFrom.
 {{- $field := index . "field" -}}
 {{- $value := index . "value" -}}
 {{- include "trueforge.requireStringOrValueFrom" (dict "name" $field "value" $value) -}}
-{{- if eq (include "trueforge.isLiteralString" (dict "value" $value)) "true" -}}
-{{- dict "name" $name "value" $value | toJson -}}
-{{- else -}}
+{{- if kindIs "map" $value -}}
 {{- dict "name" $name "valueFrom" $value.valueFrom | toJson -}}
+{{- else -}}
+{{- dict "name" $name "value" ($value | toString) | toJson -}}
 {{- end -}}
 {{- end }}
 
@@ -391,13 +396,17 @@ fields, wires bundled Postgres/Redis, optional OIDC, then server.extraEnv.
 {{- end -}}
 {{- end -}}
 
+{{- if .Values.postgresql.enabled -}}
 {{- $env = append $env (dict "name" "POSTGRES_HOST" "value" (include "trueforge.postgres.host" .)) -}}
-{{- $env = append $env (dict "name" "POSTGRES_PORT" "value" (include "trueforge.postgres.port" . | toString)) -}}
+{{- $env = append $env (dict "name" "POSTGRES_PORT" "value" "5432") -}}
 {{- $env = append $env (dict "name" "POSTGRES_DB" "value" (include "trueforge.postgres.database" .)) -}}
 {{- $env = append $env (dict "name" "POSTGRES_USER" "value" (include "trueforge.postgres.user" .)) -}}
-{{- if .Values.postgresql.enabled -}}
 {{- $env = append $env (dict "name" "POSTGRES_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" (include "trueforge.postgres.secretName" .) "key" "password"))) -}}
 {{- else -}}
+{{- $env = append $env (include "trueforge.env.fromStringOrValueFrom" (dict "name" "POSTGRES_HOST" "field" "externalPostgres.host" "value" .Values.externalPostgres.host) | fromJson) -}}
+{{- $env = append $env (include "trueforge.env.fromStringOrValueFrom" (dict "name" "POSTGRES_PORT" "field" "externalPostgres.port" "value" .Values.externalPostgres.port) | fromJson) -}}
+{{- $env = append $env (include "trueforge.env.fromStringOrValueFrom" (dict "name" "POSTGRES_DB" "field" "externalPostgres.database" "value" .Values.externalPostgres.database) | fromJson) -}}
+{{- $env = append $env (include "trueforge.env.fromStringOrValueFrom" (dict "name" "POSTGRES_USER" "field" "externalPostgres.user" "value" .Values.externalPostgres.user) | fromJson) -}}
 {{- $env = append $env (include "trueforge.env.fromStringOrValueFrom" (dict "name" "POSTGRES_PASSWORD" "field" "externalPostgres.password" "value" .Values.externalPostgres.password) | fromJson) -}}
 {{- if .Values.externalPostgres.sslMode -}}
 {{- $env = append $env (dict "name" "POSTGRES_SSL_MODE" "value" .Values.externalPostgres.sslMode) -}}

--- a/charts/trueforge/values.yaml
+++ b/charts/trueforge/values.yaml
@@ -216,17 +216,20 @@ redis:
       enabled: false
 # --- External services (used when the matching bundled dependency is disabled) -
 externalPostgres:
+  # host / port / database / user / password: inline scalar, or
+  # { valueFrom: { secretKeyRef: { name, key } } } (or configMapKeyRef).
+  # Required when postgresql.enabled is false. Defaults below are for a
+  # standalone install; a parent chart can replace any of them with valueFrom.
   host: ""
   port: 5432
   database: trueforge
   user: trueforge
-  # string, or { valueFrom: { secretKeyRef: { name, key } } }. Prefer valueFrom in prod.
   password: ""
-  # password:
+  # host / port / database / user / password:
   #   valueFrom:
   #     secretKeyRef:
   #       name: my-postgres-secret
-  #       key: password
+  #       key: host  # or port / database / user / password
   # Optional TLS for the app → Postgres pool (`POSTGRES_SSL_MODE`). Empty = unset (no TLS).
   # Modes: disable | prefer | require | verify-ca | verify-full | no-verify.
   sslMode: ""
@@ -235,6 +238,11 @@ externalRedis:
   # string, or { valueFrom: { secretKeyRef: { name, key } } }. Prefer valueFrom in prod.
   url: ""
   # Redis Sentinel connection settings, injected as REDIS_SENTINEL_* env.
+  # url:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: my-redis-secret
+  #       key: redis-url
   sentinel:
     enabled: false
     # Comma-separated host:port list -> REDIS_SENTINEL_HOSTS.
@@ -243,11 +251,6 @@ externalRedis:
     masterName: ""
     # string or valueFrom -> REDIS_SENTINEL_PASSWORD.
     password: ""
-    # url:
-    #   valueFrom:
-    #     secretKeyRef:
-    #       name: my-redis-secret
-    #       key: redis-url
 # Extra raw manifests deployed alongside the server, e.g. an Istio
 # VirtualService, a Gateway, an Ingress, or a NetworkPolicy. Each entry is a
 # full Kubernetes object rendered through `tpl`, so Helm templating works and


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes external database env wiring for server and controller; misconfigured Secrets or values can prevent Postgres connectivity at deploy time.
> 
> **Overview**
> Extends the TrueForge Helm chart so **all** `externalPostgres` connection settings (`host`, `port`, `database`, `user`, `password`) can be supplied as inline values or **`valueFrom.secretKeyRef`** (same pattern as password and `externalRedis.url`).
> 
> When bundled Postgres is disabled, `POSTGRES_*` env vars are built through `trueforge.env.fromStringOrValueFrom` instead of inlining only the password from a Secret. Numeric `port` literals are supported, and install **NOTES** / validation treat a `valueFrom` host as configured (without printing secret-backed values).
> 
> README and `values.yaml` document the expanded Secret-backed external Postgres example for parent charts and production installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0529a641d42c4d02761dbe030272bd5c81b80c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->