### PR TITLE
Chore: enhance MCP authentication flow with automatic resume and connection status updates

### DIFF
--- a/.changeset/pre/auto-resume-mcp-auth.md
+++ b/.changeset/pre/auto-resume-mcp-auth.md
@@ -1,0 +1,6 @@
+---
+"@truefoundry/trueforge-ui": patch
+---
+
+Show successful MCP authentication in chat, automatically continue after every required server connects, and indicate
+while the turn is starting.

--- a/charts/trueforge/Chart.yaml
+++ b/charts/trueforge/Chart.yaml
@@ -4,8 +4,8 @@ description: TrueForge server (API + UI) served from a single container image.
 type: application
 # version / appVersion are maintained on main (bot chart-release PR or human).
 # Publishing is gated by git tag charts/trueforge@<version> (must match version).
-version: "0.2.0-rc.1"
-appVersion: "0.2.0-rc.4"
+version: "0.2.0-rc.2"
+appVersion: "0.2.0-rc.5"
 kubeVersion: ">=1.25.0-0"
 home: https://truefoundry.com
 sources:

--- a/charts/trueforge/values.yaml
+++ b/charts/trueforge/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: tfy.jfrog.io/tfy-images/trueforge
   # Tag defaults to chart appVersion when empty. Prod chart-release PRs set this
   # to {appVersion}-{shortSha} for the npm-install image already in the registry.
-  tag: "0.2.0-rc.4-d4e84ac"
+  tag: "0.2.0-rc.5-380bdde"
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 # Default tfy.jfrog.io repos are anonymously pullable. Set secrets only when

--- a/packages/trueforge-ui/src/atoms/adapters/McpAuthPromptAdapter.tsx
+++ b/packages/trueforge-ui/src/atoms/adapters/McpAuthPromptAdapter.tsx
@@ -9,6 +9,8 @@ export type McpServer = {
 
 export type McpAuthPromptProps = {
   servers: McpServer[];
+  connectedServerIds?: ReadonlySet<string>;
+  continueLoading?: boolean;
   onConnect: (serverId: string) => void;
   onContinue?: () => void;
   readOnly?: boolean;
@@ -21,6 +23,8 @@ const DEFAULT_TITLE = 'MCP Authentication Required';
 
 export function McpAuthPrompt({
   servers,
+  connectedServerIds,
+  continueLoading = false,
   onConnect,
   onContinue,
   readOnly = false,
@@ -46,15 +50,28 @@ export function McpAuthPrompt({
               <span className="shrink-0 text-xs font-semibold text-text-secondary">:</span>
               <span className="truncate font-sans font-medium text-text-primary">{server.name}</span>
             </div>
-            <Button.Primary size="small" disabled={readOnly} onClick={() => onConnect(server.id)} className="shrink-0">
-              Connect
-              <Icon name="external-link" size="0.75em" className="ml-1" />
-            </Button.Primary>
+            {connectedServerIds?.has(server.id) ? (
+              <Button.Primary size="small" disabled className="shrink-0">
+                Connected
+                <Icon name="check" size="0.75em" className="ml-1" />
+              </Button.Primary>
+            ) : (
+              <Button.Primary
+                size="small"
+                disabled={readOnly}
+                onClick={() => onConnect(server.id)}
+                className="shrink-0"
+              >
+                Connect
+                <Icon name="external-link" size="0.75em" className="ml-1" />
+              </Button.Primary>
+            )}
           </div>
         ))}
         {onContinue && (
           <div className="flex justify-end border-t border-border pt-2">
-            <Button.Primary size="small" disabled={readOnly} onClick={onContinue}>
+            <Button.Primary size="small" disabled={readOnly || continueLoading} onClick={onContinue}>
+              {continueLoading ? <Icon name="loader" className="animate-spin" /> : null}
               Continue
             </Button.Primary>
           </div>

--- a/packages/trueforge-ui/src/atoms/adapters/McpAuthPromptAdapter.tsx
+++ b/packages/trueforge-ui/src/atoms/adapters/McpAuthPromptAdapter.tsx
@@ -53,7 +53,6 @@ export function McpAuthPrompt({
             {connectedServerIds?.has(server.id) ? (
               <Button.Primary size="small" disabled className="shrink-0">
                 Connected
-                <Icon name="check" size="0.75em" className="ml-1" />
               </Button.Primary>
             ) : (
               <Button.Primary

--- a/packages/trueforge-ui/src/containers/McpAuthContainer.tsx
+++ b/packages/trueforge-ui/src/containers/McpAuthContainer.tsx
@@ -11,7 +11,7 @@ import { useSlot } from '../theme/SlotsProvider.js';
 
 type McpAuthPromptProps = {
   servers: NonNullable<ReturnType<typeof useTrueFoundryMcpAuth>['pending']>['mcpServers'];
-  onContinue: () => void;
+  onContinue: () => Promise<void>;
   readOnly: boolean;
 };
 
@@ -28,7 +28,10 @@ function CatalogMcpAuthPrompt({ servers, onContinue, readOnly }: McpAuthPromptPr
     if (readOnly || resumedRef.current) return;
     resumedRef.current = true;
     setIsResuming(true);
-    onContinue();
+    void onContinue().catch(() => {
+      resumedRef.current = false;
+      setIsResuming(false);
+    });
   };
 
   const handleConnect = (serverId: string) => {
@@ -64,12 +67,12 @@ export function McpAuthContainer({ disabled = false }: { disabled?: boolean }) {
   if (!pending) return null;
 
   if (catalog) {
+    const pendingServerKey = JSON.stringify(pending.mcpServers.map(server => server.id));
     return (
       <CatalogMcpAuthPrompt
+        key={pendingServerKey}
         servers={pending.mcpServers}
-        onContinue={() => {
-          if (!disabled) void resume();
-        }}
+        onContinue={resume}
         readOnly={isRunning || disabled}
       />
     );

--- a/packages/trueforge-ui/src/containers/McpAuthContainer.tsx
+++ b/packages/trueforge-ui/src/containers/McpAuthContainer.tsx
@@ -2,6 +2,7 @@
 
 import { useThreadIsRunning } from '@assistant-ui/core/react';
 import { useTrueFoundryMcpAuth } from '@truefoundry/assistant-ui-runtime';
+import { useRef, useState } from 'react';
 
 import { useDraftCatalog } from '@/atoms/draft/DraftCatalogProvider.js';
 import { useMCPAuth } from '@/hooks/useMcpAuth.js';
@@ -18,16 +19,40 @@ function CatalogMcpAuthPrompt({ servers, onContinue, readOnly }: McpAuthPromptPr
   const McpAuthPrompt = useSlot('McpAuthPrompt');
   const { handleAuthorize } = useMCPAuth();
   const { refreshConnectors } = useDraftCatalog();
+  const [connectedServerIds, setConnectedServerIds] = useState<ReadonlySet<string>>(() => new Set());
+  const connectedServerIdsRef = useRef(connectedServerIds);
+  const [isResuming, setIsResuming] = useState(false);
+  const resumedRef = useRef(false);
+
+  const startResume = () => {
+    if (readOnly || resumedRef.current) return;
+    resumedRef.current = true;
+    setIsResuming(true);
+    onContinue();
+  };
 
   const handleConnect = (serverId: string) => {
     void handleAuthorize(serverId, isSuccess => {
       if (isSuccess) {
+        const nextConnectedServerIds = new Set([...connectedServerIdsRef.current, serverId]);
+        connectedServerIdsRef.current = nextConnectedServerIds;
+        setConnectedServerIds(nextConnectedServerIds);
         void refreshConnectors();
+        if (servers.every(server => nextConnectedServerIds.has(server.id))) startResume();
       }
     });
   };
 
-  return <McpAuthPrompt servers={servers} onConnect={handleConnect} onContinue={onContinue} readOnly={readOnly} />;
+  return (
+    <McpAuthPrompt
+      servers={servers}
+      connectedServerIds={connectedServerIds}
+      continueLoading={isResuming}
+      onConnect={handleConnect}
+      onContinue={startResume}
+      readOnly={readOnly}
+    />
+  );
 }
 
 export function McpAuthContainer({ disabled = false }: { disabled?: boolean }) {

--- a/packages/trueforge-ui/test/containers/McpAuthContainer.test.tsx
+++ b/packages/trueforge-ui/test/containers/McpAuthContainer.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
 import { AssistantRuntimeProvider, useExternalStoreRuntime, type ThreadMessageLike } from '@assistant-ui/react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { trueFoundryExtras, type TrueFoundryRuntimeExtras } from '@truefoundry/assistant-ui-runtime';
 import { describe, expect, it, vi } from 'vitest';
 
+import { DraftCatalogProvider } from '@/atoms/draft/DraftCatalogProvider.js';
 import { McpAuthContainer } from '@/containers/McpAuthContainer.js';
+import { ServerProvider } from '@/server/ServerContext.js';
+import type { AgentUIServer } from '@/server/types.js';
+import { createMockAgentUIServer, createMockCatalog } from '../server/mockServer.js';
 
 const SERVERS = [
   { id: 'srv-1', name: 'github', authUrl: 'https://example.com/auth/github' },
@@ -16,10 +20,12 @@ function McpAuthHarness({
   pendingMcpAuth,
   resumeMcpAuth,
   isRunning = false,
+  server,
 }: {
   pendingMcpAuth: TrueFoundryRuntimeExtras['pendingMcpAuth'];
   resumeMcpAuth: TrueFoundryRuntimeExtras['resumeMcpAuth'];
   isRunning?: boolean;
+  server?: AgentUIServer;
 }) {
   const messages: ThreadMessageLike[] = [];
   const runtime = useExternalStoreRuntime({
@@ -47,10 +53,18 @@ function McpAuthHarness({
     }),
   });
 
-  return (
+  const content = (
     <AssistantRuntimeProvider runtime={runtime}>
       <McpAuthContainer />
     </AssistantRuntimeProvider>
+  );
+
+  return server ? (
+    <ServerProvider server={server}>
+      <DraftCatalogProvider>{content}</DraftCatalogProvider>
+    </ServerProvider>
+  ) : (
+    content
   );
 }
 
@@ -92,5 +106,54 @@ describe('McpAuthContainer', () => {
   it('disables Continue while the thread is running', () => {
     render(<McpAuthHarness pendingMcpAuth={PENDING} resumeMcpAuth={vi.fn()} isRunning={true} />);
     expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
+  });
+
+  it('shows each successful catalog connection and resumes once all servers are connected', async () => {
+    const resumeMcpAuth = vi.fn().mockResolvedValue(undefined);
+    const authenticateConnector = vi.fn().mockResolvedValue({ status: 'AUTHENTICATED' });
+    const catalog = createMockCatalog({
+      connectorCatalog: {
+        ...createMockCatalog().connectorCatalog,
+        authenticateConnector,
+      },
+    });
+    const server = createMockAgentUIServer({ catalog });
+
+    render(<McpAuthHarness pendingMcpAuth={PENDING} resumeMcpAuth={resumeMcpAuth} server={server} />);
+
+    const firstConnect = screen.getAllByRole('button', { name: 'Connect' })[0];
+    if (!firstConnect) throw new Error('Expected the first MCP Connect button');
+    fireEvent.click(firstConnect);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Connected' })).toBeDisabled());
+    expect(resumeMcpAuth).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Connected' })).toHaveLength(2));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled());
+    expect(resumeMcpAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a failed catalog connection available without resuming', async () => {
+    const resumeMcpAuth = vi.fn().mockResolvedValue(undefined);
+    const authenticateConnector = vi.fn().mockRejectedValue(new Error('Authorization failed'));
+    const catalog = createMockCatalog({
+      connectorCatalog: {
+        ...createMockCatalog().connectorCatalog,
+        authenticateConnector,
+      },
+    });
+    const server = createMockAgentUIServer({ catalog });
+
+    render(<McpAuthHarness pendingMcpAuth={PENDING} resumeMcpAuth={resumeMcpAuth} server={server} />);
+
+    const firstConnect = screen.getAllByRole('button', { name: 'Connect' })[0];
+    if (!firstConnect) throw new Error('Expected the first MCP Connect button');
+    fireEvent.click(firstConnect);
+
+    await waitFor(() => expect(authenticateConnector).toHaveBeenCalledTimes(1));
+    expect(screen.getAllByRole('button', { name: 'Connect' })).toHaveLength(2);
+    expect(resumeMcpAuth).not.toHaveBeenCalled();
   });
 });

--- a/packages/trueforge-ui/test/containers/McpAuthContainer.test.tsx
+++ b/packages/trueforge-ui/test/containers/McpAuthContainer.test.tsx
@@ -10,10 +10,9 @@ import { ServerProvider } from '@/server/ServerContext.js';
 import type { AgentUIServer } from '@/server/types.js';
 import { createMockAgentUIServer, createMockCatalog } from '../server/mockServer.js';
 
-const SERVERS = [
-  { id: 'srv-1', name: 'github', authUrl: 'https://example.com/auth/github' },
-  { id: 'srv-2', name: 'slack', authUrl: 'https://example.com/auth/slack' },
-];
+const GITHUB_SERVER = { id: 'srv-1', name: 'github', authUrl: 'https://example.com/auth/github' };
+const SLACK_SERVER = { id: 'srv-2', name: 'slack', authUrl: 'https://example.com/auth/slack' };
+const SERVERS = [GITHUB_SERVER, SLACK_SERVER];
 const PENDING = { mcpServers: SERVERS };
 
 function McpAuthHarness({
@@ -155,5 +154,29 @@ describe('McpAuthContainer', () => {
     await waitFor(() => expect(authenticateConnector).toHaveBeenCalledTimes(1));
     expect(screen.getAllByRole('button', { name: 'Connect' })).toHaveLength(2);
     expect(resumeMcpAuth).not.toHaveBeenCalled();
+  });
+
+  it('allows retrying Continue when resume fails', async () => {
+    const resumeMcpAuth = vi.fn().mockRejectedValue(new Error('Resume failed'));
+    const authenticateConnector = vi.fn().mockResolvedValue({ status: 'AUTHENTICATED' });
+    const catalog = createMockCatalog({
+      connectorCatalog: {
+        ...createMockCatalog().connectorCatalog,
+        authenticateConnector,
+      },
+    });
+    const server = createMockAgentUIServer({ catalog });
+
+    render(
+      <McpAuthHarness pendingMcpAuth={{ mcpServers: [GITHUB_SERVER] }} resumeMcpAuth={resumeMcpAuth} server={server} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+
+    await waitFor(() => expect(resumeMcpAuth).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    await waitFor(() => expect(resumeMcpAuth).toHaveBeenCalledTimes(2));
   });
 });


### PR DESCRIPTION


## Summary

<img width="1920" height="922" alt="image" src="https://github.com/user-attachments/assets/24caab50-f54c-4053-917d-cd929bc4fffe" />
<img width="1920" height="922" alt="image" src="https://github.com/user-attachments/assets/5c0615a4-e3e3-481f-8237-3f414cf4fdb6" />


## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth success criteria and when paused turns resume; mistakes could block chat or resume incorrectly, but behavior is guarded with server-side re-reads and broad unit tests.
> 
> **Overview**
> Improves the **in-chat MCP auth prompt** so each server shows a **Connected** state after OAuth succeeds, **Continue** shows a loading state while the turn resumes, and the catalog path **auto-resumes** once every required server is verified—without requiring a manual Continue when all connectors are done.
> 
> **`useMCPAuth`** no longer treats popup or `AUTHENTICATED` responses as final success. It re-fetches the connector and only succeeds when `authenticated` is true, preferring **`getMcpConnector`** in chat so non-admins are not blocked by admin-only **`getConnector`**. Concurrent authorizations get separate popup IDs and listeners; stale callbacks are dropped after unmount or when the auth prompt is torn down mid-flow.
> 
> Container and hook tests cover verification failures, **`getMcpConnector`** fallback, auto-resume, and unmount safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8a34264517898a9ef73de2c1aaeb6fce738b5b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->