### PR TITLE
fix: Don't collapse fullname when release name is also trueforge

### DIFF
--- a/charts/trueforge/Chart.yaml
+++ b/charts/trueforge/Chart.yaml
@@ -4,7 +4,7 @@ description: TrueForge server (API + UI) served from a single container image.
 type: application
 # version / appVersion are maintained on main (bot chart-release PR or human).
 # Publishing is gated by git tag charts/trueforge@<version> (must match version).
-version: "0.2.0-rc.2"
+version: "0.2.0-rc.3"
 appVersion: "0.2.0-rc.5"
 kubeVersion: ">=1.25.0-0"
 home: https://truefoundry.com

--- a/charts/trueforge/templates/_helpers.tpl
+++ b/charts/trueforge/templates/_helpers.tpl
@@ -7,17 +7,18 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
+
+Always `{release}-{name}` (unless fullnameOverride). The usual Helm
+`contains` collapse is skipped so a parent that dials
+`{{ .Release.Name }}-trueforge` keeps working when the release name
+itself contains "trueforge".
 */}}
 {{- define "trueforge.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrades where the release name contained the chart name will get renamed Kubernetes objects (Service, Deployments, ServiceAccount, custom CA ConfigMap), which can cause a disruptive replace unless names were already `{release}-trueforge`.
> 
> **Overview**
> Fixes **Helm resource naming** when the release name already includes `trueforge` (common as a subchart). The `trueforge.fullname` helper no longer uses Helm’s default `contains` collapse that returned only the release name; it **always** renders `{release}-{chartName}` unless `fullnameOverride` is set.
> 
> That keeps names aligned with parent charts and URLs that expect `{release}-trueforge` (e.g. controller `serverUrl` and in-cluster Service DNS). The chart version is bumped to **0.2.0-rc.3** for release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d52e3eb1a9d63d2e79b3cd5e6d26eef6f12cbf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->