### PR TITLE
feat(ui): avatar gradient fallbacks, ThinkingOrb indicator, PopoverSelect flip, lazy Schedules agents

### DIFF
--- a/.changeset/avatar-gradient-initial.md
+++ b/.changeset/avatar-gradient-initial.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Avatar fallbacks use a light primary-button gradient in light mode, a solid primary gradient in dark mode, and show a single initial character.

--- a/.changeset/message-indicator-thinking-orb.md
+++ b/.changeset/message-indicator-thinking-orb.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Assistant message loading indicator uses ThinkingOrb with left-to-right shimmering Working... text.

--- a/.changeset/popover-select-flip.md
+++ b/.changeset/popover-select-flip.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Flip PopoverSelect menus when the preferred side lacks viewport room (e.g. table rows-per-page).

--- a/.changeset/schedules-lazy-agents.md
+++ b/.changeset/schedules-lazy-agents.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Stop draining the full agents catalog on Schedules mount; load agents only when the filter opens (infinite scroll).

--- a/.changeset/settings-nav-selected.md
+++ b/.changeset/settings-nav-selected.md
@@ -1,0 +1,5 @@
+---
+'@truefoundry/trueforge-ui': patch
+---
+
+Settings sidebar uses a subtle primary tint for the selected section instead of a solid fill.

--- a/packages/trueforge-ui/src/atoms/AttachmentCard.tsx
+++ b/packages/trueforge-ui/src/atoms/AttachmentCard.tsx
@@ -60,7 +60,8 @@ export function AttachmentCard({
         <div className="bg-secondary-bg relative size-full overflow-hidden rounded-[calc(var(--composer-radius,1.5rem)-var(--composer-padding,8px))] border border-primary-button-bg/20">
           <Avatar className="size-full rounded-none">
             <AvatarImage src={isImage ? previewSrc : undefined} alt={name} className="object-cover" />
-            <AvatarFallback className="rounded-none">
+            {/* bg-none drops the default gradient (bg-image group), which bg-secondary-bg alone would not override. */}
+            <AvatarFallback className="rounded-none bg-secondary-bg bg-none text-text-secondary">
               <Icon name="file" size="1.5rem" className="text-text-secondary" />
             </AvatarFallback>
           </Avatar>

--- a/packages/trueforge-ui/src/atoms/MessageIndicator.tsx
+++ b/packages/trueforge-ui/src/atoms/MessageIndicator.tsx
@@ -1,3 +1,5 @@
+import { ThinkingOrb } from 'thinking-orbs';
+
 import { cn } from './lib/cn.js';
 
 export type MessageIndicatorProps = {
@@ -8,10 +10,11 @@ export function MessageIndicator({ className }: MessageIndicatorProps) {
   return (
     <span
       data-slot="aui_assistant-message-indicator"
-      className={cn('animate-pulse font-sans', className)}
-      aria-label="Assistant is working"
+      role="status"
+      className={cn('inline-flex items-center gap-1.5 font-sans text-sm text-text-secondary', className)}
     >
-      {'●'}
+      <ThinkingOrb state="listening" size={20} aria-hidden />
+      <span className="aui-message-indicator-shimmer">Working...</span>
     </span>
   );
 }

--- a/packages/trueforge-ui/src/atoms/ThreadListRow.tsx
+++ b/packages/trueforge-ui/src/atoms/ThreadListRow.tsx
@@ -37,7 +37,7 @@ export function ThreadListRow({
       data-slot="aui_thread-list-item"
       data-active={active || undefined}
       className={cn(
-        'group flex min-w-0 items-center gap-0.5 rounded-[0.75rem] transition-colors',
+        'group flex min-w-0 items-center gap-0.5 rounded-[0.5rem] transition-colors',
         active
           ? 'bg-dropdown-selected-item-bg text-dropdown-selected-item-text'
           : 'text-text-secondary hover:bg-ghost-button-hover hover:text-text-primary',
@@ -58,10 +58,10 @@ export function ThreadListRow({
         })}
       >
         <span className="min-w-0 flex-1">
-          <span className="block truncate text-sm font-medium text-text-primary">{title}</span>
+          <span className="block truncate text-sm font-normal text-text-primary">{title}</span>
           {agentName != null ? (
-            <span className="mt-0.5 flex min-w-0 items-center gap-1 text-xs text-text-secondary">
-              <Icon name="agent-2" className="size-3 shrink-0" />
+            <span className="mt-0.5 flex min-w-0 items-center gap-1 text-[0.75rem] text-text-secondary">
+              <Icon name="bot" className="shrink-0" />
               <span className="truncate">{agentName}</span>
             </span>
           ) : null}

--- a/packages/trueforge-ui/src/atoms/UserAvatar.tsx
+++ b/packages/trueforge-ui/src/atoms/UserAvatar.tsx
@@ -10,20 +10,8 @@ export type UserAvatarProps = {
 };
 
 export function getUserInitials(displayName: string): string {
-  // split by spaces and filter out empty strings
-  const parts = displayName.trim().split(/\s+/).filter(Boolean);
-  const first = parts[0];
-  if (first === undefined) {
-    return '';
-  }
-  const last = parts.at(-1);
-  const characters =
-    parts.length === 1 ? Array.from(first).slice(0, 2) : [Array.from(first)[0], Array.from(last ?? '')[0]];
-
-  return characters
-    .filter(character => character !== undefined)
-    .join('')
-    .toLocaleUpperCase();
+  const first = Array.from(displayName.trim())[0];
+  return first === undefined ? '' : first.toLocaleUpperCase();
 }
 
 // Default current-user chrome; hosts can replace it through `overrides.UserAvatar`.
@@ -46,9 +34,7 @@ export function UserAvatar({ labeled = false, className }: UserAvatarProps) {
       )}
     >
       <Avatar size="sm">
-        <AvatarFallback className="bg-primary-button-bg text-primary-button-text">
-          {getUserInitials(displayName)}
-        </AvatarFallback>
+        <AvatarFallback>{getUserInitials(displayName)}</AvatarFallback>
       </Avatar>
       <span className="w-full truncate text-center text-[0.625rem] leading-tight">{displayName}</span>
     </div>

--- a/packages/trueforge-ui/src/atoms/primitives/Avatar.tsx
+++ b/packages/trueforge-ui/src/atoms/primitives/Avatar.tsx
@@ -3,9 +3,9 @@ import React, { useState } from 'react';
 import { cn } from '../lib/cn.js';
 
 const sizeClasses = {
-  sm: 'h-6 w-6 text-xs',
-  default: 'h-8 w-8 text-sm',
-  lg: 'h-10 w-10 text-base',
+  sm: 'h-5 w-5 text-[0.625rem] leading-none',
+  default: 'h-8 w-8 text-sm leading-none',
+  lg: 'h-10 w-10 text-base leading-none',
 };
 
 export type AvatarProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -52,7 +52,7 @@ export function AvatarFallback({ className, ...props }: AvatarFallbackProps) {
     <div
       data-slot="avatar-fallback"
       className={cn(
-        'flex h-full w-full items-center justify-center rounded-full bg-secondary-bg font-medium text-text-secondary',
+        'flex h-full w-full items-center justify-center rounded-full bg-gradient-to-br from-primary-button-bg/20 to-primary-button-bg/10 font-medium text-primary-button-bg dark:from-primary-button-bg dark:to-primary-button-hover dark:text-primary-button-text',
         className,
       )}
       {...props}

--- a/packages/trueforge-ui/src/atoms/primitives/PopoverSelect.tsx
+++ b/packages/trueforge-ui/src/atoms/primitives/PopoverSelect.tsx
@@ -13,6 +13,40 @@ import {
 } from '../lib/selectClasses.js';
 import { themePortalRoot } from '../lib/themePortalRoot.js';
 
+const MENU_GAP_PX = 4;
+/** Matches `max-h-64` on the shared select menu chrome. */
+const MENU_MAX_HEIGHT_PX = 256;
+
+type MenuPlacement = 'top' | 'bottom';
+
+function estimateMenuHeight({ optionCount, hasFooter }: { optionCount: number; hasFooter: boolean }): number {
+  // Approximate option row (`text-sm` + `py-1.5`) plus menu `p-1` padding.
+  const rows = Math.max(optionCount, 1) * 32;
+  const footer = hasFooter ? 40 : 0;
+  return Math.min(8 + rows + footer, MENU_MAX_HEIGHT_PX);
+}
+
+function resolveMenuPlacement({
+  preferred,
+  spaceAbove,
+  spaceBelow,
+  menuHeight,
+}: {
+  preferred: MenuPlacement;
+  spaceAbove: number;
+  spaceBelow: number;
+  menuHeight: number;
+}): MenuPlacement {
+  if (preferred === 'bottom') {
+    if (spaceBelow >= menuHeight) return 'bottom';
+    if (spaceAbove >= menuHeight) return 'top';
+    return spaceAbove > spaceBelow ? 'top' : 'bottom';
+  }
+  if (spaceAbove >= menuHeight) return 'top';
+  if (spaceBelow >= menuHeight) return 'bottom';
+  return spaceBelow > spaceAbove ? 'bottom' : 'top';
+}
+
 export type PopoverSelectOption<T extends string> = {
   value: T;
   label: string;
@@ -25,8 +59,8 @@ type CommonPopoverSelectProps<T extends string> = {
   disabled?: boolean;
   className?: string;
   menuClassName?: string;
-  /** Which edge of the trigger the menu opens toward. Default `bottom`. */
-  menuPlacement?: 'top' | 'bottom';
+  /** Preferred open edge; flips when that side lacks room. Default `bottom`. */
+  menuPlacement?: MenuPlacement;
   /** When set, renders a labeled chip trigger (label | value chip + chevron). */
   prefix?: string;
   emptyContent?: ReactNode;
@@ -50,14 +84,16 @@ export type PopoverSelectProps<T extends string> = CommonPopoverSelectProps<T> &
 
 export function PopoverSelect<T extends string>(props: PopoverSelectProps<T>) {
   const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState<{ top: number; left: number; width: number } | null>(null);
+  const [pos, setPos] = useState<{ top: number; left: number; width: number; placement: MenuPlacement } | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const listboxRef = useRef<HTMLDivElement>(null);
   const focusedOpenRef = useRef(false);
   const listboxId = useId();
-  const menuPlacement = props.menuPlacement ?? 'bottom';
+  const preferredPlacement = props.menuPlacement ?? 'bottom';
+  const hasFooter = props.footer != null;
+  const optionCount = props.options.length;
 
   useLayoutEffect(() => {
     if (!open) {
@@ -69,21 +105,36 @@ export function PopoverSelect<T extends string>(props: PopoverSelectProps<T>) {
       const el = triggerRef.current;
       if (!el) return;
       const rect = el.getBoundingClientRect();
+      const spaceBelow = window.innerHeight - rect.bottom - MENU_GAP_PX;
+      const spaceAbove = rect.top - MENU_GAP_PX;
+      const measuredHeight = menuRef.current?.offsetHeight;
+      const menuHeight =
+        measuredHeight != null && measuredHeight > 0 ? measuredHeight : estimateMenuHeight({ optionCount, hasFooter });
+      const placement = resolveMenuPlacement({
+        preferred: preferredPlacement,
+        spaceAbove,
+        spaceBelow,
+        menuHeight,
+      });
       setPos({
-        top: menuPlacement === 'top' ? rect.top - 4 : rect.bottom + 4,
+        top: placement === 'top' ? rect.top - MENU_GAP_PX : rect.bottom + MENU_GAP_PX,
         left: rect.left,
         width: rect.width,
+        placement,
       });
     };
 
     update();
+    // Remeasure after the menu mounts so flip uses the real height.
+    const rafId = requestAnimationFrame(update);
     window.addEventListener('scroll', update, true);
     window.addEventListener('resize', update);
     return () => {
+      cancelAnimationFrame(rafId);
       window.removeEventListener('scroll', update, true);
       window.removeEventListener('resize', update);
     };
-  }, [open, menuPlacement]);
+  }, [open, preferredPlacement, optionCount, hasFooter]);
 
   useEffect(() => {
     if (!open) return;
@@ -178,7 +229,7 @@ export function PopoverSelect<T extends string>(props: PopoverSelectProps<T>) {
               top: pos.top,
               left: pos.left,
               width: pos.width,
-              transform: menuPlacement === 'top' ? 'translateY(-100%)' : undefined,
+              transform: pos.placement === 'top' ? 'translateY(-100%)' : undefined,
             }}
             onMouseDown={event => event.stopPropagation()}
           >

--- a/packages/trueforge-ui/src/atoms/schedules/SchedulesPage.tsx
+++ b/packages/trueforge-ui/src/atoms/schedules/SchedulesPage.tsx
@@ -16,7 +16,6 @@ import { CreatedByCell } from '../CreatedByCell.js';
 import { EmptyScreen } from '../EmptyScreen.js';
 import { auiButtonClass } from '../lib/buttonClasses.js';
 import { cn } from '../lib/cn.js';
-import { searchAllAgents } from '../lib/useSearchAgentsList.js';
 import { PageHeader } from '../PageHeader.js';
 import { Button } from '../primitives/Button.js';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../primitives/Dialog.js';
@@ -38,8 +37,6 @@ import { formatCadenceSummary } from './cadence.js';
 import { ScheduleFormDrawer } from './ScheduleFormDrawer.js';
 import { ScheduleLastRunsCell } from './ScheduleLastRunsCell.js';
 import { ScheduleStatusBadge } from './ScheduleStatusBadge.js';
-
-type AgentOption = { agentId: string; name: string };
 
 type DrawerState = { kind: 'closed' } | { kind: 'create'; agentId?: string } | { kind: 'edit'; schedule: Schedule };
 
@@ -166,7 +163,8 @@ export function SchedulesPage({ agentId }: SchedulesPageProps) {
   const [runsByScheduleId, setRunsByScheduleId] = useState<Record<string, ScheduleRun[]>>({});
   const [runsLoading, setRunsLoading] = useState(false);
   const [runningScheduleIds, setRunningScheduleIds] = useState<ReadonlySet<string>>(() => new Set());
-  const [agentOptions, setAgentOptions] = useState<AgentOption[]>([]);
+  /** Names learned from picker picks; no mount-time catalog drain. */
+  const [agentLabelById, setAgentLabelById] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [nameQuery, setNameQuery] = useState(() => filtersFromSearch(window.location.search).nameQuery);
@@ -176,20 +174,14 @@ export function SchedulesPage({ agentId }: SchedulesPageProps) {
   const [agentFilter, setAgentFilter] = useState(
     () => agentId ?? filtersFromSearch(window.location.search).agentFilter,
   );
+  // Specific agent (filter or embedded): gate Create on USE. Filter "all": enable and let the drawer enforce USE.
   const permissionAgentId = agentId ?? (agentFilter === 'all' ? null : agentFilter);
-  const permissionAgentIds = useMemo(
-    () => (permissionAgentId == null ? agentOptions.map(option => option.agentId) : [permissionAgentId]),
-    [agentOptions, permissionAgentId],
-  );
   const { allows: allowsAgent } = useResourcePermissions({
     resourceType: 'agent',
-    resourceIds: permissionAgentIds,
+    resourceIds: permissionAgentId == null ? [] : [permissionAgentId],
   });
   const canCreateSchedule =
-    server.permissions == null ||
-    (permissionAgentId == null
-      ? agentOptions.some(option => allowsAgent(option.agentId, 'USE'))
-      : allowsAgent(permissionAgentId, 'USE'));
+    server.permissions == null || permissionAgentId == null || allowsAgent(permissionAgentId, 'USE');
   const [drawer, setDrawer] = useState<DrawerState>(() => initialDrawerState(agentId));
   const [pendingDelete, setPendingDelete] = useState<Schedule | null>(null);
   const [pageSize, setPageSize] = useState(() => clampPageSize(DEFAULT_TABLE_PAGE_SIZE));
@@ -318,27 +310,6 @@ export function SchedulesPage({ agentId }: SchedulesPageProps) {
     void loadSchedules({ token: pageToken, size: pageSize, agentId: agentFilter });
   }, [agentFilter, pageSize, pageToken, loadSchedules]);
 
-  useEffect(() => {
-    let cancelled = false;
-    void searchAllAgents(server)
-      .then(rows => {
-        if (cancelled) return;
-        setAgentOptions(rows.map(agent => ({ agentId: libraryAgentId(agent), name: agent.name })));
-      })
-      .catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, [server]);
-
-  const agentNameById = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const agent of agentOptions) {
-      map.set(agent.agentId, agent.name);
-    }
-    return map;
-  }, [agentOptions]);
-
   // Name + status are client-side on the current server page only.
   const filtered = useMemo(() => {
     const q = nameQuery.trim().toLowerCase();
@@ -427,11 +398,17 @@ export function SchedulesPage({ agentId }: SchedulesPageProps) {
             {agentId === undefined ? (
               <AgentSearchPicker
                 value={agentFilter}
-                selectedLabel={agentFilter === 'all' ? 'All agents' : (agentNameById.get(agentFilter) ?? agentFilter)}
+                selectedLabel={agentFilter === 'all' ? 'All agents' : (agentLabelById[agentFilter] ?? agentFilter)}
                 onValueChange={value => {
                   setAgentFilter(value);
                   setPageToken(undefined);
                   setPrevTokenStack([]);
+                }}
+                onAgentPicked={agent => {
+                  setAgentLabelById(current => ({
+                    ...current,
+                    [libraryAgentId(agent)]: agent.name,
+                  }));
                 }}
                 allOption={{ value: 'all', label: 'All agents' }}
                 className="sm:w-48"
@@ -508,7 +485,7 @@ export function SchedulesPage({ agentId }: SchedulesPageProps) {
               <TableBody>
                 {filtered.map(schedule => {
                   const cadence = formatCadenceSummary({ cron: schedule.cron, timezone: schedule.timezone });
-                  const agentLabel = schedule.agentName ?? agentNameById.get(schedule.agentId) ?? schedule.agentId;
+                  const agentLabel = schedule.agentName ?? agentLabelById[schedule.agentId] ?? schedule.agentId;
                   return (
                     <TableRow key={schedule.id}>
                       <TableCell className="text-text-primary font-medium">

--- a/packages/trueforge-ui/src/containers/SettingsBuilder/index.tsx
+++ b/packages/trueforge-ui/src/containers/SettingsBuilder/index.tsx
@@ -134,7 +134,7 @@ const TruefoundrySettingsBuilder = () => {
                 // Narrow panels cannot fit fixed-width tabs, so tabs split the row instead.
                 compact ? 'min-w-0 flex-1 justify-center gap-1.5 px-1.5' : 'shrink-0',
                 section === item.id
-                  ? 'bg-primary-button-bg text-primary-button-text'
+                  ? 'bg-primary-button-bg/10 text-primary-button-bg'
                   : 'text-text-secondary hover:bg-ghost-button-hover/60 hover:text-text-primary',
               )}
               onClick={() => {

--- a/packages/trueforge-ui/src/styles.css
+++ b/packages/trueforge-ui/src/styles.css
@@ -409,3 +409,31 @@
     border-radius: 0.375rem;
   }
 }
+
+/* Left-to-right shimmer for assistant "Working..." indicator text. */
+@keyframes aui-text-shimmer {
+  from {
+    background-position: 100% center;
+  }
+  to {
+    background-position: -100% center;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .aui-message-indicator-shimmer {
+    background-image: linear-gradient(
+      90deg,
+      var(--text-secondary) 0%,
+      var(--text-secondary) 40%,
+      var(--text-primary) 50%,
+      var(--text-secondary) 60%,
+      var(--text-secondary) 100%
+    );
+    background-size: 200% auto;
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+    animation: aui-text-shimmer 1.5s linear infinite;
+  }
+}

--- a/packages/trueforge-ui/test/atoms/AgentsLibrary.test.tsx
+++ b/packages/trueforge-ui/test/atoms/AgentsLibrary.test.tsx
@@ -675,7 +675,7 @@ describe('AgentsLibraryButton', () => {
 
     expect(await screen.findByRole('columnheader', { name: 'Created by' })).toBeInTheDocument();
     expect(screen.getByText('alice@example.com')).toBeInTheDocument();
-    expect(document.querySelector('[data-slot="avatar-fallback"]')).toHaveTextContent('AL');
+    expect(document.querySelector('[data-slot="avatar-fallback"]')).toHaveTextContent(/^A$/);
   });
 
   it('hides Created by when no agent has createdBySubject', async () => {

--- a/packages/trueforge-ui/test/atoms/CreatedByCell.test.tsx
+++ b/packages/trueforge-ui/test/atoms/CreatedByCell.test.tsx
@@ -21,6 +21,6 @@ describe('CreatedByCell', () => {
     );
     expect(screen.getByText('alice@example.com')).toBeInTheDocument();
     expect(container.querySelector('[data-slot="avatar"]')).toBeInTheDocument();
-    expect(container.querySelector('[data-slot="avatar-fallback"]')).toHaveTextContent('AL');
+    expect(container.querySelector('[data-slot="avatar-fallback"]')).toHaveTextContent('A');
   });
 });

--- a/packages/trueforge-ui/test/atoms/MessageIndicator.test.tsx
+++ b/packages/trueforge-ui/test/atoms/MessageIndicator.test.tsx
@@ -1,15 +1,21 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { MessageIndicator } from '@/atoms/MessageIndicator.js';
 
+vi.mock('thinking-orbs', () => ({
+  ThinkingOrb: () => <div data-testid="thinking-orb" />,
+}));
+
 describe('MessageIndicator', () => {
-  it('provides an accessible working state and preserves host styling', () => {
+  it('shows ThinkingOrb with Working... and preserves host styling', () => {
     render(<MessageIndicator className="host-indicator" />);
 
-    const indicator = screen.getByLabelText('Assistant is working');
-    expect(indicator).toHaveTextContent('●');
+    const indicator = screen.getByRole('status');
+    expect(indicator).toHaveTextContent('Working...');
     expect(indicator).toHaveAttribute('data-slot', 'aui_assistant-message-indicator');
-    expect(indicator).toHaveClass('animate-pulse', 'host-indicator');
+    expect(indicator).toHaveClass('host-indicator');
+    expect(screen.getByText('Working...')).toHaveClass('aui-message-indicator-shimmer');
+    expect(screen.getByTestId('thinking-orb')).toBeInTheDocument();
   });
 });

--- a/packages/trueforge-ui/test/atoms/UserAvatar.test.tsx
+++ b/packages/trueforge-ui/test/atoms/UserAvatar.test.tsx
@@ -6,20 +6,20 @@ import { CurrentUserProvider } from '@/contexts/CurrentUserContext.js';
 
 describe('getUserInitials', () => {
   it.each([
-    ['Ada Lovelace', 'AL'],
-    ['Ada King Lovelace', 'AL'],
-    ['Ada', 'AD'],
-    ['Ada Ada', 'AA'],
-    ['  ada   lovelace  ', 'AL'],
+    ['Ada Lovelace', 'A'],
+    ['Ada King Lovelace', 'A'],
+    ['Ada', 'A'],
+    ['bob', 'B'],
+    ['  ada   lovelace  ', 'A'],
     ['', ''],
     ['   ', ''],
-  ])('returns initials for %j', (displayName, expected) => {
+  ])('returns the first character for %j', (displayName, expected) => {
     expect(getUserInitials(displayName)).toBe(expected);
   });
 });
 
 describe('UserAvatar', () => {
-  it('shows initials with the full display name underneath', () => {
+  it('shows the first character with the full display name underneath', () => {
     render(
       <CurrentUserProvider currentUser={{ displayName: 'Ada Lovelace' }}>
         <UserAvatar labeled />
@@ -27,7 +27,7 @@ describe('UserAvatar', () => {
     );
 
     const avatar = screen.getByLabelText('Ada Lovelace');
-    expect(avatar).toHaveTextContent('AL');
+    expect(avatar).toHaveTextContent('A');
     expect(avatar).toHaveTextContent('Ada Lovelace');
     expect(avatar).toHaveAttribute('title', 'Ada Lovelace');
     expect(avatar).toHaveClass('w-14.5');

--- a/packages/trueforge-ui/test/atoms/primitives/Avatar.test.tsx
+++ b/packages/trueforge-ui/test/atoms/primitives/Avatar.test.tsx
@@ -45,13 +45,22 @@ describe('AvatarFallback', () => {
   it('renders fallback content and forwards host attributes', () => {
     render(
       <AvatarFallback className="host-fallback" aria-label="Ada initials">
-        AL
+        A
       </AvatarFallback>,
     );
 
     const fallback = screen.getByLabelText('Ada initials');
-    expect(fallback).toHaveTextContent('AL');
+    expect(fallback).toHaveTextContent('A');
     expect(fallback).toHaveAttribute('data-slot', 'avatar-fallback');
-    expect(fallback).toHaveClass('host-fallback');
+    expect(fallback).toHaveClass(
+      'host-fallback',
+      'bg-gradient-to-br',
+      'from-primary-button-bg/20',
+      'to-primary-button-bg/10',
+      'text-primary-button-bg',
+      'dark:from-primary-button-bg',
+      'dark:to-primary-button-hover',
+      'dark:text-primary-button-text',
+    );
   });
 });

--- a/packages/trueforge-ui/test/atoms/primitives/PopoverSelect.test.tsx
+++ b/packages/trueforge-ui/test/atoms/primitives/PopoverSelect.test.tsx
@@ -70,7 +70,8 @@ describe('PopoverSelect', () => {
     expect(trigger.querySelector('.border-r')).not.toBeNull();
   });
 
-  it('opens the menu above the trigger when menuPlacement is top', () => {
+  it('opens the menu above the trigger when menuPlacement is top and there is room', () => {
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
     render(
       <PopoverSelect
         aria-label="Timezone"
@@ -81,11 +82,60 @@ describe('PopoverSelect', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Timezone' }));
+    const trigger = screen.getByRole('button', { name: 'Timezone' });
+    trigger.getBoundingClientRect = () => new DOMRect(12, 400, 120, 32);
+
+    fireEvent.click(trigger);
 
     const menu = screen.getByRole('listbox').parentElement;
     expect(menu).toHaveClass('fixed');
     expect(menu).toHaveStyle({ transform: 'translateY(-100%)' });
+  });
+
+  it('flips the menu above the trigger when there is no room below', () => {
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 200 });
+    render(
+      <PopoverSelect
+        aria-label="Rows per page"
+        options={[
+          { value: '10', label: '10' },
+          { value: '25', label: '25' },
+          { value: '50', label: '50' },
+        ]}
+        value="10"
+        onValueChange={() => undefined}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Rows per page' });
+    // Trigger sits near the bottom edge of a short viewport.
+    trigger.getBoundingClientRect = () => new DOMRect(100, 170, 72, 32);
+
+    fireEvent.click(trigger);
+
+    expect(screen.getByRole('listbox').parentElement).toHaveStyle({ transform: 'translateY(-100%)' });
+  });
+
+  it('keeps the menu below the trigger when there is room', () => {
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+    render(
+      <PopoverSelect
+        aria-label="Rows per page"
+        options={[
+          { value: '10', label: '10' },
+          { value: '25', label: '25' },
+        ]}
+        value="10"
+        onValueChange={() => undefined}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Rows per page' });
+    trigger.getBoundingClientRect = () => new DOMRect(100, 40, 72, 32);
+
+    fireEvent.click(trigger);
+
+    expect(screen.getByRole('listbox').parentElement).not.toHaveStyle({ transform: 'translateY(-100%)' });
   });
 
   it('portals the menu so overflow parents do not clip it', () => {

--- a/packages/trueforge-ui/test/atoms/schedules/SchedulesPage.test.tsx
+++ b/packages/trueforge-ui/test/atoms/schedules/SchedulesPage.test.tsx
@@ -97,12 +97,12 @@ function renderPage(
       </ToasterProvider>
     </ServerProvider>,
   );
-  return { scheduleServer };
+  return { scheduleServer, searchAgents: server.searchAgents };
 }
 
 describe('SchedulesPage', () => {
   it('lists schedules in the table', async () => {
-    const { scheduleServer } = renderPage();
+    const { scheduleServer, searchAgents } = renderPage();
     expect(await screen.findByRole('heading', { name: 'Scheduled Agents' })).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByText('daily-digest')).toBeInTheDocument();
@@ -111,6 +111,8 @@ describe('SchedulesPage', () => {
     expect(screen.getByText('—')).toBeInTheDocument();
     expect(screen.getByText('Showing 1')).toBeInTheDocument();
     expect(scheduleServer.listSchedules).toHaveBeenCalledWith(expect.objectContaining({ limit: 10 }));
+    // Agent catalog loads only when the filter opens (infinite scroll), not on mount.
+    expect(searchAgents).not.toHaveBeenCalled();
   });
 
   it('disables schedule mutations without MANAGE or DELETE', async () => {
@@ -149,21 +151,31 @@ describe('SchedulesPage', () => {
     expect(screen.getByRole('button', { name: 'Run now daily-digest' })).toBeDisabled();
   });
 
-  it('disables global schedule creation when no listed agent has USE', async () => {
-    const listPermissions = vi.fn(async () => ({ data: { 'demo-agent': [] } }));
+  it('leaves Create enabled for All agents and gates USE when a specific agent is selected', async () => {
+    const listPermissions = vi.fn(async ({ resourceType }): Promise<ListPermissionsResponse> => ({
+      data: resourceType === 'agent' ? { 'demo-agent': [] } : {},
+    }));
     renderPage(sampleSchedules, {}, undefined, undefined, {
       permissions: { listPermissions },
     });
+
+    expect(await screen.findByRole('button', { name: 'Create Schedule' })).toBeEnabled();
+    expect(listPermissions).not.toHaveBeenCalledWith(
+      expect.objectContaining({ resourceType: 'agent', resourceIds: expect.arrayContaining(['demo-agent']) }),
+    );
+
+    const filter = screen.getByRole('combobox', { name: 'Filter by agent' });
+    fireEvent.focus(filter);
+    fireEvent.click(await screen.findByRole('option', { name: 'demo-agent' }));
 
     await waitFor(() => {
       expect(listPermissions).toHaveBeenCalledWith({
         resourceType: 'agent',
         resourceIds: ['demo-agent'],
       });
+      expect(screen.getByRole('button', { name: 'Create Schedule' })).toBeDisabled();
     });
-    expect(screen.getByRole('button', { name: 'Create Schedule' })).toBeDisabled();
   });
-
   it('locks embedded schedules to the supplied agent', async () => {
     const { scheduleServer } = renderPage(sampleSchedules, {}, undefined, undefined, { agentId: 'demo-agent' });
 
@@ -489,7 +501,7 @@ describe('SchedulesPage', () => {
     ]);
     expect(await screen.findByRole('columnheader', { name: 'Created by' })).toBeInTheDocument();
     expect(screen.getByText('bob@example.com')).toBeInTheDocument();
-    expect(document.querySelector('[data-slot="avatar-fallback"]')).toHaveTextContent('BO');
+    expect(document.querySelector('[data-slot="avatar-fallback"]')).toHaveTextContent(/^B$/);
   });
 
   it('keeps Created by when filters hide the row that has createdBySubject', async () => {

--- a/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
+++ b/packages/trueforge-ui/test/containers/TrueForgeUI.test.tsx
@@ -160,7 +160,7 @@ describe('TrueForgeUI', () => {
     }
 
     const avatar = await screen.findByLabelText('Ada Lovelace');
-    expect(avatar).toHaveTextContent('AL');
+    expect(avatar.querySelector('[data-slot="avatar-fallback"]')).toHaveTextContent(/^A$/);
     expect(avatar).toHaveTextContent('Ada Lovelace');
     if (layout === 'sidebar') {
       expect(avatar.closest('aside')).not.toBeNull();


### PR DESCRIPTION
## Summary

UI polish batch for `@truefoundry/trueforge-ui` (one changeset per theme, all patch bumps):

- **Avatar fallbacks** use a light primary-button gradient in light mode and the solid primary gradient in dark mode, show a single initial character, and shrink the `sm` preset to 20px. `AttachmentCard` keeps its neutral fallback via `bg-none` (the gradient is a background-image, so a bg-color override alone would not remove it).
- **MessageIndicator** replaces the pulsing dot with a `ThinkingOrb` (new `thinking-orbs` dep) plus left-to-right shimmering "Working..." text; `role="status"` for a11y and the shimmer is scoped to `prefers-reduced-motion: no-preference`.
- **PopoverSelect** flips the menu to the opposite side when the preferred side lacks viewport room (estimate first, remeasure after mount via rAF). Fixes clipped rows-per-page menus near the bottom edge.
- **SchedulesPage** no longer drains the full agents catalog on mount; agent labels are learned from picker picks and the agent filter loads lazily with infinite scroll. "Create Schedule" now stays enabled under the All-agents filter and USE is enforced per-agent in the drawer.
- **Settings sidebar** selected section uses a subtle primary tint instead of a solid fill.
- **ThreadListRow**: softer radius (0.5rem), normal-weight title, `bot` icon.

## Behavioral notes for reviewers

- Schedules rows without a server-provided `agentName` now fall back to the raw agent id (previously resolved from the drained catalog) — accepted trade-off for dropping the mount-time catalog scan.
- Create-schedule gating under "All agents" moved from a mount-time permission sweep to submit-time enforcement in `ScheduleFormDrawer`.

## Testing

- `pnpm test` in `packages/trueforge-ui`: 190 files, 1407 tests, all passing.
- New coverage: PopoverSelect flip/no-flip placement, lazy agent-catalog assertion, single-initial avatar expectations.

Made with [Cursor](https://cursor.com)