### PR TITLE
chore: TFY sandbox should discover working directory before writing files

### DIFF
--- a/.changeset/tfy-sandbox-pwd-instructions.md
+++ b/.changeset/tfy-sandbox-pwd-instructions.md
@@ -2,4 +2,4 @@
 "@truefoundry/trueforge-core": patch
 ---
 
-Restore TFY sandbox agent instructions to discover the working directory via `pwd` before writing files (matching tfy-llm-gateway).
+Add TFY sandbox agent instructions to discover the working directory via `pwd` before writing files.

--- a/.changeset/tfy-sandbox-pwd-instructions.md
+++ b/.changeset/tfy-sandbox-pwd-instructions.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge-core": patch
+---
+
+Restore TFY sandbox agent instructions to discover the working directory via `pwd` before writing files (matching tfy-llm-gateway).

--- a/packages/trueforge-core/src/core/sandbox/provider/TFYSandboxProvider.ts
+++ b/packages/trueforge-core/src/core/sandbox/provider/TFYSandboxProvider.ts
@@ -251,8 +251,9 @@ export class TFYSandboxProvider implements SandboxProvider {
   getAdditionalInstructions(): string {
     return dedent`
     SANDBOX RULES:
-    - uploads, skills, and tool-results live in the sandbox working directory (not /tmp or /opt).
-    - ALL file creation and writes MUST stay within the sandbox working directory.
+    - The Agent's first sandbox command should be \`pwd\` to discover the working directory.
+    - uploads, skills, and tool-results live in that working directory (not /tmp or /opt).
+    - ALL file creation and writes MUST stay within that working directory.
     - The Agent must NOT write to /tmp/, ~/, or any absolute path outside the working directory.
   `;
   }

--- a/packages/trueforge-core/tests/core/sandbox/provider/tfyLayout.test.ts
+++ b/packages/trueforge-core/tests/core/sandbox/provider/tfyLayout.test.ts
@@ -26,7 +26,10 @@ describe('TFYSandboxProvider layout', () => {
     expect(install.remotePath.startsWith('/')).toBe(false);
     expect(install.pathBinSymlink).toBeUndefined();
     const instructions = provider.getAdditionalInstructions();
-    expect(instructions).toContain('uploads, skills, and tool-results live in the sandbox working directory');
+    expect(instructions).toContain(
+      "The Agent's first sandbox command should be `pwd` to discover the working directory.",
+    );
+    expect(instructions).toContain('uploads, skills, and tool-results live in that working directory');
     expect(instructions).not.toContain('/data/sandboxes');
   });
 


### PR DESCRIPTION
…iles

## Summary

<!-- What does this PR change, and why? Link the related issue if there is one. -->

Closes #<add-issue-number-here>

## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change to TFY sandbox instructions; no exec, path, or auth logic is modified.
> 
> **Overview**
> Updates **TFY sandbox agent prompt rules** so the model is told to run **`pwd` as its first sandbox command** and treat uploads, skills, and tool-results as living in **that discovered working directory**, instead of assuming a fixed “sandbox working directory” label.
> 
> Tests in `tfyLayout.test.ts` now assert the new `pwd` line and the “that working directory” wording. A **patch changeset** records the `@truefoundry/trueforge-core` release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a75de8d8f92f8325edfe57a1a61f48f6a7ac2b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->