### PR TITLE
fix(chart): distinct Redis nameOverride vs gateway Redis

### DIFF
--- a/charts/trueforge/README.md
+++ b/charts/trueforge/README.md
@@ -226,6 +226,10 @@ externalRedis:
         key: redis-url
 ```
 
+`redis.nameOverride` defaults to `trueforge-redis` so bundled Redis objects do
+not share names with the LLM gateway Redis (`truefoundry-redis-*`) when this
+chart is a dependency of the truefoundry control-plane chart.
+
 For passworded Redis, prefer an external instance and load `REDIS_URL` via
 `valueFrom`.
 
@@ -328,6 +332,7 @@ extraObjects:
 | `configs.oidc.enabled`| `false`                             | Inject `OIDC_*` env for IdP login.    |
 | `postgresql.enabled`  | `true`                              | Bundle the Bitnami Postgres subchart. |
 | `redis.enabled`       | `true`                              | Bundle the Bitnami Redis subchart.    |
+| `redis.nameOverride`  | `trueforge-redis`                   | Bitnami name prefix; keeps objects distinct from `tfy-llm-gateway` Redis when embedded under truefoundry. |
 | `service.type`        | `ClusterIP`                         | Service type.                         |
 | `service.port`        | `8790`                              | Service port.                         |
 | `server.port`         | `8790`                              | Container port (`PORT`).              |

--- a/charts/trueforge/README.md
+++ b/charts/trueforge/README.md
@@ -226,9 +226,9 @@ externalRedis:
         key: redis-url
 ```
 
-`redis.nameOverride` defaults to `trueforge-redis` so bundled Redis objects keep
-a distinct name when this chart is embedded under another release (for example
-the truefoundry control-plane chart).
+`redis.nameOverride` defaults to `trueforge-redis` so bundled Redis objects do
+not share names with other Redis chart dependencies when this chart is a
+dependency of some other chart.
 
 For passworded Redis, prefer an external instance and load `REDIS_URL` via
 `valueFrom`.

--- a/charts/trueforge/README.md
+++ b/charts/trueforge/README.md
@@ -226,9 +226,9 @@ externalRedis:
         key: redis-url
 ```
 
-`redis.nameOverride` defaults to `trueforge-redis` so bundled Redis objects do
-not share names with the LLM gateway Redis (`truefoundry-redis-*`) when this
-chart is a dependency of the truefoundry control-plane chart.
+`redis.nameOverride` defaults to `trueforge-redis` so bundled Redis objects keep
+a distinct name when this chart is embedded under another release (for example
+the truefoundry control-plane chart).
 
 For passworded Redis, prefer an external instance and load `REDIS_URL` via
 `valueFrom`.
@@ -332,7 +332,7 @@ extraObjects:
 | `configs.oidc.enabled`| `false`                             | Inject `OIDC_*` env for IdP login.    |
 | `postgresql.enabled`  | `true`                              | Bundle the Bitnami Postgres subchart. |
 | `redis.enabled`       | `true`                              | Bundle the Bitnami Redis subchart.    |
-| `redis.nameOverride`  | `trueforge-redis`                   | Bitnami name prefix; keeps objects distinct from `tfy-llm-gateway` Redis when embedded under truefoundry. |
+| `redis.nameOverride`  | `trueforge-redis`                   | Bitnami name prefix for bundled Redis objects. |
 | `service.type`        | `ClusterIP`                         | Service type.                         |
 | `service.port`        | `8790`                              | Service port.                         |
 | `server.port`         | `8790`                              | Container port (`PORT`).              |

--- a/charts/trueforge/templates/_helpers.tpl
+++ b/charts/trueforge/templates/_helpers.tpl
@@ -190,8 +190,26 @@ postgresql subchart (existingSecret override or <release>-postgresql).
 {{- default (printf "%s-postgresql" .Release.Name) .Values.postgresql.auth.existingSecret -}}
 {{- end }}
 
+{{/*
+Bitnami redis fullname (mirrors common.names.fullname) so REDIS_URL tracks
+redis.nameOverride / redis.fullnameOverride.
+*/}}
+{{- define "trueforge.redis.fullname" -}}
+{{- if .Values.redis.fullnameOverride -}}
+{{- .Values.redis.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "redis" .Values.redis.nameOverride -}}
+{{- $releaseName := regexReplaceAll "(-?[^a-z\\d\\-])+-?" (lower .Release.Name) "-" -}}
+{{- if contains $name $releaseName -}}
+{{- $releaseName | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
 {{- define "trueforge.redis.bundledUrl" -}}
-{{- printf "redis://%s-redis-master:6379" .Release.Name -}}
+{{- printf "redis://%s-master:6379" (include "trueforge.redis.fullname" .) -}}
 {{- end }}
 
 {{/*

--- a/charts/trueforge/values.yaml
+++ b/charts/trueforge/values.yaml
@@ -203,6 +203,10 @@ postgresql:
 redis:
   enabled: true
   architecture: standalone
+  # Distinct from tfy-llm-gateway's redis (truefoundry-redis-*) when this chart
+  # is embedded under the truefoundry control-plane release. Without this,
+  # both subcharts emit the same object names and collide.
+  nameOverride: trueforge-redis
   # The redis 24.0.0 subchart floats `latest`; pin a legacy tag mirrored to JFrog
   # for reproducibility (bitnamilegacy has no 8.4.x, so we track 8.2.x here).
   image:

--- a/charts/trueforge/values.yaml
+++ b/charts/trueforge/values.yaml
@@ -203,9 +203,6 @@ postgresql:
 redis:
   enabled: true
   architecture: standalone
-  # Distinct from tfy-llm-gateway's redis (truefoundry-redis-*) when this chart
-  # is embedded under the truefoundry control-plane release. Without this,
-  # both subcharts emit the same object names and collide.
   nameOverride: trueforge-redis
   # The redis 24.0.0 subchart floats `latest`; pin a legacy tag mirrored to JFrog
   # for reproducibility (bitnamilegacy has no 8.4.x, so we track 8.2.x here).


### PR DESCRIPTION
## Summary
- Under the `truefoundry` release, bundled TrueForge Redis and `tfy-llm-gateway` Redis both emitted `truefoundry-redis-*` objects and collided when both were enabled.
- Default `redis.nameOverride` to `trueforge-redis` so TrueForge objects become `truefoundry-trueforge-redis-*`.
- Update `trueforge.redis.bundledUrl` (via a Bitnami-compatible `trueforge.redis.fullname` helper) so `REDIS_URL` matches the renamed Service.

## Test plan
- [x] `helm template` trueforge with release name `truefoundry` → StatefulSet `truefoundry-trueforge-redis-master`, `REDIS_URL=redis://truefoundry-trueforge-redis-master:6379`
- [x] Parent chart with gateway + CP + trueforge redis all on → three distinct StatefulSet names (`truefoundry-redis-master`, `truefoundry-truefoundry-redis-master`, `truefoundry-trueforge-redis-master`); no gateway∩trueforge name overlap
- [x] Chart lint / CI on this PR


Made with [Cursor](https://cursor.com)