### PR TITLE
fix: use user token for mcp auth calls

### DIFF
--- a/.changeset/trueforge-dual-vend-tokens.md
+++ b/.changeset/trueforge-dual-vend-tokens.md
@@ -2,4 +2,4 @@
 '@truefoundry/trueforge': minor
 ---
 
-Use ServiceFoundry dual vend-token response: `actorToken` for ServiceFoundry calls and `subjectToken` for gateway (model api_key and MCP invoke).
+Use ServiceFoundry dual vend-token response: authenticate as the agent for registry lookups, and as the user (with agent in `act`) for MCP authorize/auth status, gateway model api_key, and MCP invoke.

--- a/packages/trueforge/src/truefoundry/TrueFoundryMcpServerStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryMcpServerStore.ts
@@ -234,7 +234,7 @@ export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServ
       throw new McpServerNotFoundError(input.name);
     }
     await this.#client.deleteMcpAuth({
-      accessToken: await this.#asAgent(),
+      accessToken: await this.#asUser(),
       mcpServerId: record.id,
       subjectId: this.#subject.id,
       subjectType: this.#subject.type,

--- a/packages/trueforge/src/truefoundry/TrueFoundryMcpServerStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryMcpServerStore.ts
@@ -63,8 +63,8 @@ export function resolveAuthorizeRedirectURL(input: { returnTo?: string }): strin
 /** Read-only MCP registry for TrueFoundry mode (writes managed elsewhere). */
 export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServerWithAuthStore<TTransaction> {
   readonly #client: TrueFoundryMcpApiClient;
-  readonly #forServiceFoundry: ResolveAccessToken;
-  readonly #forGateway: ResolveAccessToken;
+  readonly #asAgent: ResolveAccessToken;
+  readonly #asUser: ResolveAccessToken;
   readonly #subject: RequestSubject;
   readonly #perServerHeaders: PerServerMcpHeaders;
   #gatewayUrl: string | undefined;
@@ -83,8 +83,8 @@ export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServ
       agent: input.agent,
       logger: input.logger,
     });
-    this.#forServiceFoundry = tokens.forServiceFoundry;
-    this.#forGateway = tokens.forGateway;
+    this.#asAgent = tokens.asAgent;
+    this.#asUser = tokens.asUser;
     this.#subject = input.requestContext.subject;
     this.#perServerHeaders = input.perServerHeaders ?? {};
   }
@@ -94,7 +94,7 @@ export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServ
     const { record, userRef } = input;
     const headers = async (): Promise<Record<string, string>> => ({
       ...withoutAuthorization(this.#perServerHeaders[record.name]),
-      Authorization: `Bearer ${await this.#forGateway()}`,
+      Authorization: `Bearer ${await this.#asUser()}`,
     });
     return async () => {
       const status = await this.authorize({
@@ -125,7 +125,7 @@ export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServ
       return [];
     }
 
-    const accessToken = await this.#forServiceFoundry();
+    const accessToken = await this.#asAgent();
     const [rows, gatewayUrl] = await Promise.all([
       this.#client.listMcpServers({
         accessToken,
@@ -138,7 +138,7 @@ export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServ
 
   async getServer(input: GetMcpServerInput, transaction?: TTransaction): Promise<McpServerRecord | undefined> {
     void transaction;
-    const accessToken = await this.#forServiceFoundry();
+    const accessToken = await this.#asAgent();
     const [row, gatewayUrl] = await Promise.all([
       this.#client.getMcpServerByName({ accessToken, name: input.name }),
       this.#resolveGatewayUrl(),
@@ -203,7 +203,7 @@ export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServ
     out.set(
       record.name,
       await this.#client.getMcpAuthStatus({
-        accessToken: await this.#forServiceFoundry(),
+        accessToken: await this.#asUser(),
         mcpServerId: record.id,
         subjectId: this.#subject.id,
         subjectType: this.#subject.type,
@@ -219,7 +219,7 @@ export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServ
       throw new McpServerNotFoundError(input.name);
     }
     return this.#client.getMcpAuthorize({
-      accessToken: await this.#forServiceFoundry(),
+      accessToken: await this.#asUser(),
       mcpServerId: record.id,
       redirectURL: resolveAuthorizeRedirectURL({
         ...(input.returnTo !== undefined ? { returnTo: input.returnTo } : {}),
@@ -234,7 +234,7 @@ export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServ
       throw new McpServerNotFoundError(input.name);
     }
     await this.#client.deleteMcpAuth({
-      accessToken: await this.#forServiceFoundry(),
+      accessToken: await this.#asAgent(),
       mcpServerId: record.id,
       subjectId: this.#subject.id,
       subjectType: this.#subject.type,
@@ -244,7 +244,7 @@ export class TrueFoundryMcpServerStore<TTransaction = never> implements IMcpServ
 
   async #resolveGatewayUrl(): Promise<string> {
     if (this.#gatewayUrl === undefined) {
-      const installations = await this.#client.listGatewayInstallations(await this.#forServiceFoundry());
+      const installations = await this.#client.listGatewayInstallations(await this.#asAgent());
       this.#gatewayUrl = resolveDefaultGatewayUrl(installations);
     }
     return this.#gatewayUrl;

--- a/packages/trueforge/src/truefoundry/TrueFoundryModelProviderStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryModelProviderStore.ts
@@ -19,8 +19,8 @@ import { TrueFoundryServiceFoundryServerClient } from './TrueFoundryServiceFound
 
 export class TrueFoundryModelProviderStore<TTransaction = never> implements IModelProviderStore<TTransaction> {
   readonly #client: TrueFoundryServiceFoundryServerClient;
-  readonly #forServiceFoundry: ResolveAccessToken;
-  readonly #forGateway: ResolveAccessToken;
+  readonly #asAgent: ResolveAccessToken;
+  readonly #asUser: ResolveAccessToken;
 
   constructor(input: {
     client: TrueFoundryServiceFoundryServerClient;
@@ -35,8 +35,8 @@ export class TrueFoundryModelProviderStore<TTransaction = never> implements IMod
       agent: input.agent,
       logger: input.logger,
     });
-    this.#forServiceFoundry = tokens.forServiceFoundry;
-    this.#forGateway = tokens.forGateway;
+    this.#asAgent = tokens.asAgent;
+    this.#asUser = tokens.asUser;
   }
 
   async listProviders(input: ListModelProvidersInput, transaction?: TTransaction): Promise<ModelProviderRecord[]> {
@@ -85,19 +85,19 @@ export class TrueFoundryModelProviderStore<TTransaction = never> implements IMod
     tenant_id: string;
     filter?: { provider_account_name: string; name: string };
   }): Promise<ModelProviderRecord[]> {
-    const [sfyToken, gatewayToken] = await Promise.all([this.#forServiceFoundry(), this.#forGateway()]);
+    const [agentToken, userToken] = await Promise.all([this.#asAgent(), this.#asUser()]);
     const [integrations, installations] = await Promise.all([
       this.#client.listProviderIntegrations({
-        accessToken: sfyToken,
+        accessToken: agentToken,
         ...(input.filter !== undefined ? { filter: input.filter } : {}),
       }),
-      this.#client.listGatewayInstallations(sfyToken),
+      this.#client.listGatewayInstallations(agentToken),
     ]);
     const gatewayUrl = resolveDefaultGatewayUrl(installations);
     return toRecords({
       tenant_id: input.tenant_id,
       gatewayUrl,
-      accessToken: gatewayToken,
+      accessToken: userToken,
       models: mapEnabledModels({ integrations }),
     });
   }

--- a/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
@@ -530,7 +530,7 @@ export class TrueFoundryServiceFoundryServerClient {
 
   /**
    * Exchange a TrueFoundry API key for dual agent-scoped tokens.
-   * `actorToken` is the agent identity (ServiceFoundry); `subjectToken` is user+act (gateway).
+   * Wire `actorToken` is the agent identity (`asAgent`); wire `subjectToken` is the user with agent in `act` (`asUser`).
    * Authenticated with the server API key, not the user bearer.
    */
   async vendToken(input: {

--- a/packages/trueforge/src/truefoundry/accessToken.ts
+++ b/packages/trueforge/src/truefoundry/accessToken.ts
@@ -12,13 +12,13 @@ import type { TrueFoundryServiceFoundryServerClient, VendedTokens } from './True
 export type ResolveAccessToken = () => Promise<string>;
 
 /**
- * Destination-specific tokens for a TrueFoundry request.
- * ServiceFoundry uses the agent identity (`actorToken`); gateway uses user+act (`subjectToken`).
- * Without a saved agent, both resolve to the caller's credential.
+ * Dual tokens from vend-token (or the caller credential when there is no saved agent).
+ * - `asAgent` — agent identity (vend-token `actorToken`)
+ * - `asUser` — triggering user with agent in `act` (vend-token `subjectToken`)
  */
-export interface DestinationTokens {
-  forServiceFoundry: ResolveAccessToken;
-  forGateway: ResolveAccessToken;
+export interface AccessTokens {
+  asAgent: ResolveAccessToken;
+  asUser: ResolveAccessToken;
 }
 
 type AgentTokenVendor = Pick<TrueFoundryServiceFoundryServerClient, 'vendToken'>;
@@ -31,7 +31,7 @@ const accessTokenCache: unique symbol = Symbol('truefoundryAccessTokenCache');
  * lifetime of one HTTP request; a later request gets a new context and vends again.
  */
 export type TrueFoundryRequestContext = RequestContext & {
-  readonly [accessTokenCache]: Map<string, DestinationTokens>;
+  readonly [accessTokenCache]: Map<string, AccessTokens>;
 };
 
 export function createTrueFoundryRequestContext(base: RequestContext): TrueFoundryRequestContext {
@@ -49,22 +49,22 @@ export function asTrueFoundryRequestContext(context: RequestContext): TrueFoundr
   return context;
 }
 
-function destinationTokensFromCaller(context: RequestContext): DestinationTokens {
+function accessTokensFromCaller(context: RequestContext): AccessTokens {
   const resolve = callerAccessToken(context);
-  return { forServiceFoundry: resolve, forGateway: resolve };
+  return { asAgent: resolve, asUser: resolve };
 }
 
 /**
  * Dual tokens scoped to a saved agent, for work the agent does on the caller's behalf.
  * Throws 500 up front when the agent was never registered with TrueFoundry.
- * Vends once; ServiceFoundry gets `actorToken`, gateway gets `subjectToken`.
+ * Vends once; callers pick `asAgent` or `asUser`.
  */
 export function agentAccessToken(input: {
   client: AgentTokenVendor;
   requestContext: Pick<RequestContext, 'tenant_id' | 'subject'>;
   agent: AgentRecord;
   logger: Pick<Logger, 'info'>;
-}): DestinationTokens {
+}): AccessTokens {
   const { client, requestContext: context } = input;
   const agentId = requireTrueFoundryAgentExternalId(input.agent);
   let pending: Promise<VendedTokens> | undefined;
@@ -86,8 +86,8 @@ export function agentAccessToken(input: {
   };
 
   return {
-    forServiceFoundry: async () => (await vended()).actorToken,
-    forGateway: async () => (await vended()).subjectToken,
+    asAgent: async () => (await vended()).actorToken,
+    asUser: async () => (await vended()).subjectToken,
   };
 }
 
@@ -103,7 +103,7 @@ export function callerAccessToken(context: RequestContext): ResolveAccessToken {
 }
 
 /**
- * Destination tokens for a TrueFoundry request, optionally scoped to the saved agent executing a turn.
+ * Access tokens for a TrueFoundry request, optionally scoped to the saved agent executing a turn.
  * Saved-agent callables are stored on this request's context so model and MCP stores share one vend.
  */
 export function accessTokenForRequest(input: {
@@ -111,9 +111,9 @@ export function accessTokenForRequest(input: {
   requestContext: TrueFoundryRequestContext;
   agent: AgentRecord | undefined;
   logger: Pick<Logger, 'info'>;
-}): DestinationTokens {
+}): AccessTokens {
   if (input.agent === undefined) {
-    return destinationTokensFromCaller(input.requestContext);
+    return accessTokensFromCaller(input.requestContext);
   }
   const agentId = requireTrueFoundryAgentExternalId(input.agent);
   const cache = input.requestContext[accessTokenCache];

--- a/packages/trueforge/tests/unit/truefoundry/TrueFoundryMcpServerStore.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/TrueFoundryMcpServerStore.test.ts
@@ -221,6 +221,12 @@ describe('TrueFoundryMcpServerStore', () => {
       });
     });
 
+    it('uses asUser for live status with a saved agent', async () => {
+      const { store, client } = createStore({ agent: AGENT });
+      await store.resolveAuthStatuses({ records: [dcrRecord()], userRef: 'user-1' });
+      expect(client.getMcpAuthStatus).toHaveBeenCalledWith(expect.objectContaining({ accessToken: SUBJECT_TOKEN }));
+    });
+
     it('calls live status for a single truefoundry record without wire auth', async () => {
       const { store, client } = createStore();
       client.getMcpAuthStatus.mockResolvedValue({ status: 'auth_required' });
@@ -291,12 +297,12 @@ describe('TrueFoundryMcpServerStore', () => {
       });
     });
 
-    it('uses actorToken for SFY authorize and subjectToken for gateway Bearer with a saved agent', async () => {
+    it('uses asUser for authorize and gateway Bearer, asAgent for SFY lookups with a saved agent', async () => {
       const { store, client } = createStore({ agent: AGENT });
       await expect(invoke(store)).resolves.toEqual({
         headers: { Authorization: `Bearer ${SUBJECT_TOKEN}` },
       });
-      expect(client.getMcpAuthorize).toHaveBeenCalledWith(expect.objectContaining({ accessToken: ACTOR_TOKEN }));
+      expect(client.getMcpAuthorize).toHaveBeenCalledWith(expect.objectContaining({ accessToken: SUBJECT_TOKEN }));
       expect(client.getMcpServerByName).toHaveBeenCalledWith(expect.objectContaining({ accessToken: ACTOR_TOKEN }));
       expect(client.listGatewayInstallations).toHaveBeenCalledWith(ACTOR_TOKEN);
       expect(client.vendToken).toHaveBeenCalledTimes(1);

--- a/packages/trueforge/tests/unit/truefoundry/TrueFoundryMcpServerStore.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/TrueFoundryMcpServerStore.test.ts
@@ -185,6 +185,12 @@ describe('TrueFoundryMcpServerStore', () => {
         authSource: 'oauth',
       });
     });
+
+    it('uses asUser with a saved agent', async () => {
+      const { store, client } = createStore({ agent: AGENT });
+      await store.deleteAuthorization({ tenant_id: TENANT, name: 'github', userRef: 'ignored' });
+      expect(client.deleteMcpAuth).toHaveBeenCalledWith(expect.objectContaining({ accessToken: SUBJECT_TOKEN }));
+    });
   });
 
   describe('resolveAuthStatuses', () => {

--- a/packages/trueforge/tests/unit/truefoundry/TrueFoundryModelProviderStore.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/TrueFoundryModelProviderStore.test.ts
@@ -21,7 +21,7 @@ const AGENT: AgentRecord = {
 };
 
 describe('TrueFoundryModelProviderStore dual tokens', () => {
-  it('uses actorToken for SFY list calls and subjectToken as gateway api_key', async () => {
+  it('uses asAgent for SFY list calls and asUser as gateway api_key', async () => {
     const client = {
       listProviderIntegrations: jest.fn().mockResolvedValue([
         {

--- a/packages/trueforge/tests/unit/truefoundry/accessToken.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/accessToken.test.ts
@@ -18,7 +18,7 @@ const CONTEXT: RequestContext = {
 };
 const LOGGER = { info: jest.fn() };
 
-const VENDED = { subjectToken: 'subject-token', actorToken: 'actor-token' };
+const VENDED = { subjectToken: 'user-token', actorToken: 'agent-token' };
 
 const AGENT: AgentRecord = {
   id: 'agent-1',
@@ -49,8 +49,8 @@ describe('agentAccessToken', () => {
     const logger = { info: jest.fn() };
 
     const tokens = agentAccessToken({ client, requestContext: CONTEXT, agent: AGENT, logger });
-    await expect(tokens.forServiceFoundry()).resolves.toBe('actor-token');
-    await expect(tokens.forGateway()).resolves.toBe('subject-token');
+    await expect(tokens.asAgent()).resolves.toBe('agent-token');
+    await expect(tokens.asUser()).resolves.toBe('user-token');
     expect(logger.info).toHaveBeenCalledWith('Exchanging user context for agent access token', {
       subject: 'user-1',
       agentId: 'ext-agent',
@@ -66,9 +66,11 @@ describe('agentAccessToken', () => {
     const client = { vendToken: jest.fn().mockResolvedValue(VENDED) };
     const tokens = agentAccessToken({ client, requestContext: CONTEXT, agent: AGENT, logger: LOGGER });
 
-    await expect(
-      Promise.all([tokens.forServiceFoundry(), tokens.forGateway(), tokens.forServiceFoundry()]),
-    ).resolves.toEqual(['actor-token', 'subject-token', 'actor-token']);
+    await expect(Promise.all([tokens.asAgent(), tokens.asUser(), tokens.asAgent()])).resolves.toEqual([
+      'agent-token',
+      'user-token',
+      'agent-token',
+    ]);
     expect(client.vendToken).toHaveBeenCalledTimes(1);
   });
 
@@ -78,8 +80,8 @@ describe('agentAccessToken', () => {
     };
     const tokens = agentAccessToken({ client, requestContext: CONTEXT, agent: AGENT, logger: LOGGER });
 
-    await expect(tokens.forServiceFoundry()).rejects.toThrow('vend failed');
-    await expect(tokens.forGateway()).resolves.toBe('subject-token');
+    await expect(tokens.asAgent()).rejects.toThrow('vend failed');
+    await expect(tokens.asUser()).resolves.toBe('user-token');
     expect(client.vendToken).toHaveBeenCalledTimes(2);
   });
 
@@ -105,7 +107,7 @@ describe('asTrueFoundryRequestContext', () => {
 });
 
 describe('accessTokenForRequest', () => {
-  it('uses the caller token for both destinations without an agent', async () => {
+  it('uses the caller token for both identities without an agent', async () => {
     const client = { vendToken: jest.fn() };
     const context = createTrueFoundryRequestContext(CONTEXT);
 
@@ -115,19 +117,19 @@ describe('accessTokenForRequest', () => {
       agent: undefined,
       logger: LOGGER,
     });
-    await expect(tokens.forServiceFoundry()).resolves.toBe('caller-token');
-    await expect(tokens.forGateway()).resolves.toBe('caller-token');
-    expect(tokens.forServiceFoundry).toBe(tokens.forGateway);
+    await expect(tokens.asAgent()).resolves.toBe('caller-token');
+    await expect(tokens.asUser()).resolves.toBe('caller-token');
+    expect(tokens.asAgent).toBe(tokens.asUser);
     expect(client.vendToken).not.toHaveBeenCalled();
   });
 
-  it('uses actorToken for ServiceFoundry and subjectToken for gateway with an agent', async () => {
+  it('maps vend actorToken to asAgent and subjectToken to asUser', async () => {
     const client = { vendToken: jest.fn().mockResolvedValue(VENDED) };
     const context = createTrueFoundryRequestContext(CONTEXT);
 
     const tokens = accessTokenForRequest({ client, requestContext: context, agent: AGENT, logger: LOGGER });
-    await expect(tokens.forServiceFoundry()).resolves.toBe('actor-token');
-    await expect(tokens.forGateway()).resolves.toBe('subject-token');
+    await expect(tokens.asAgent()).resolves.toBe('agent-token');
+    await expect(tokens.asUser()).resolves.toBe('user-token');
     expect(client.vendToken).toHaveBeenCalledTimes(1);
   });
 
@@ -139,10 +141,10 @@ describe('accessTokenForRequest', () => {
     const mcp = accessTokenForRequest({ client, requestContext: context, agent: AGENT, logger: LOGGER });
 
     expect(model).toBe(mcp);
-    await expect(Promise.all([model.forServiceFoundry(), mcp.forGateway(), model.forGateway()])).resolves.toEqual([
-      'actor-token',
-      'subject-token',
-      'subject-token',
+    await expect(Promise.all([model.asAgent(), mcp.asUser(), model.asUser()])).resolves.toEqual([
+      'agent-token',
+      'user-token',
+      'user-token',
     ]);
     expect(client.vendToken).toHaveBeenCalledTimes(1);
   });
@@ -153,11 +155,11 @@ describe('accessTokenForRequest', () => {
     const secondRequest = createTrueFoundryRequestContext(CONTEXT);
 
     await expect(
-      accessTokenForRequest({ client, requestContext: firstRequest, agent: AGENT, logger: LOGGER }).forServiceFoundry(),
-    ).resolves.toBe('actor-token');
+      accessTokenForRequest({ client, requestContext: firstRequest, agent: AGENT, logger: LOGGER }).asAgent(),
+    ).resolves.toBe('agent-token');
     await expect(
-      accessTokenForRequest({ client, requestContext: secondRequest, agent: AGENT, logger: LOGGER }).forGateway(),
-    ).resolves.toBe('subject-token');
+      accessTokenForRequest({ client, requestContext: secondRequest, agent: AGENT, logger: LOGGER }).asUser(),
+    ).resolves.toBe('user-token');
     expect(client.vendToken).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION


## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication identity on MCP OAuth and gateway paths for agent turns, which is security-sensitive but narrowly scoped with test coverage.
> 
> **Overview**
> Renames vend-token helpers from destination-based names (`forServiceFoundry` / `forGateway`) to identity-based **`asAgent`** / **`asUser`**, mapping wire **`actorToken`** and **`subjectToken`** respectively.
> 
> **Behavior fix for saved agents:** MCP **authorize**, **auth status**, and **delete authorization** now authenticate with **`asUser`** instead of the agent token, so ServiceFoundry evaluates per-user OAuth/consent correctly. **Registry reads** (MCP list/get, gateway installations, provider integrations) stay on **`asAgent`**. Gateway-facing paths—MCP invoke Bearer, model provider **`api_key`**—continue to use **`asUser`**.
> 
> Unit tests and the changeset note are updated to match the split and the authorize-token correction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9498ebf1fdf924d327364ff64d447e3df232487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->