### PR TITLE
Accept description on agent import API

### DIFF
--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -1714,6 +1714,11 @@
               }
             ]
           },
+          "description": {
+            "maxLength": 1024,
+            "minLength": 1,
+            "type": "string"
+          },
           "manifest": {
             "$ref": "#/components/schemas/AgentSpec"
           },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1714,6 +1714,11 @@
               }
             ]
           },
+          "description": {
+            "maxLength": 1024,
+            "minLength": 1,
+            "type": "string"
+          },
           "manifest": {
             "$ref": "#/components/schemas/AgentSpec"
           },

--- a/packages/trueforge/src/apis/agentImport.ts
+++ b/packages/trueforge/src/apis/agentImport.ts
@@ -46,7 +46,7 @@ export function createAgentImportRouter(deps: AgentImportRouterDeps) {
         const created = await agentStore.createAgent({
           tenant_id: agent.tenant_id,
           name: agent.name,
-          description: agent.name,
+          description: agent.description ?? agent.name,
           manifest: agent.manifest,
           external_id: null,
           created_by_subject: agent.created_by_subject,

--- a/packages/trueforge/src/schemas/agentImport.ts
+++ b/packages/trueforge/src/schemas/agentImport.ts
@@ -3,6 +3,7 @@
  */
 import { z } from '@hono/zod-openapi';
 import { AgentSpecSchema, CreatedBySubjectSchema } from '@truefoundry/trueforge-core/agent-session';
+import { AgentDescriptionSchema } from './agent';
 import { NameSchema } from './common';
 
 const RESERVED_AGENT_NAMES = new Set(['tfg', 'trueforge']);
@@ -13,6 +14,7 @@ export const ImportAgentItemSchema = z
     name: NameSchema.refine(name => !RESERVED_AGENT_NAMES.has(name), {
       message: 'Agent name is reserved, cannot be used',
     }),
+    description: AgentDescriptionSchema.optional(),
     manifest: AgentSpecSchema,
     tenant_id: z.string().min(1).describe('Tenant to create the agent under.'),
     created_by_subject: CreatedBySubjectSchema.describe('Original creator to persist on the agent.'),


### PR DESCRIPTION
## Summary


AGE-2174: Accept description on agent import API



## Changes

-

## How was this tested?

<!-- e.g. unit tests added, `pnpm test`, `pnpm smoke`, manual steps in the UI -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [ ] Tests added/updated where it makes sense
- [ ] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible additive API field with a safe default; no changes to auth or core agent runtime logic.
> 
> **Overview**
> Agent import rows can now include an optional **description**, aligned with normal agent creation validation (1–1024 characters via `AgentDescriptionSchema`).
> 
> The internal import handler passes **`agent.description ?? agent.name`** into `createAgent`, so imports without a description keep the previous behavior of using the agent name. OpenAPI specs for the import payload were updated to document the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82874808a01eda3c16fe2a87ceb9c175ec0fe5d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->