### PR TITLE
docs: fix native Windows support wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Open a feature request in the issue tracker, or upvote an existing request that 
 
 ## Prerequisites
 
-Source development (`pnpm install`, `pnpm dev`, `pnpm standalone:dev`, `pnpm build`) is supported on **macOS, Linux, and Windows via WSL2**. Native Windows (PowerShell / cmd) is not a supported at this time.
+Source development (`pnpm install`, `pnpm dev`, `pnpm standalone:dev`, `pnpm build`) is supported on **macOS, Linux, and Windows via WSL2**. Native Windows (PowerShell / cmd) is not supported at this time.
 
 - **Node.js 22.14+** (see [`.nvmrc`](.nvmrc); pnpm 11.16 needs 22.13+, and `better-sqlite3` v13 needs Node-API 10)
 - **pnpm** (version pinned via `packageManager` in [`package.json`](package.json); `corepack enable` handles it)


### PR DESCRIPTION
## Summary

Correct a grammatical error in the native Windows support note so the development prerequisites read clearly.

## Changes

- Change "is not a supported" to "is not supported" in `CONTRIBUTING.md`.

## How was this tested?

- `pnpm exec prettier --check CONTRIBUTING.md --config .prettierrc`
- `git diff --check`

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [ ] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally (not run for this docs-only change)
- [x] Tests added/updated where it makes sense (not applicable: docs-only change)
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`)
- [x] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no runtime, security, or configuration impact.
> 
> **Overview**
> Fixes a grammar mistake in the **Prerequisites** section of `CONTRIBUTING.md`: native Windows (PowerShell / cmd) **is not supported** at this time, replacing the incorrect phrase “is not a supported.”
> 
> The supported platforms sentence is unchanged; only the native Windows note is corrected for clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b7cd1724a0fb03460e0516c30f9bc38762c25b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->