### PR TITLE
Passthrough collaborators for truefoundry agents import

### DIFF
--- a/.changeset/tfy-import-collaborators.md
+++ b/.changeset/tfy-import-collaborators.md
@@ -1,0 +1,5 @@
+---
+"@truefoundry/trueforge": patch
+---
+
+Pass collaborators through TrueFoundry agent import.

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -1704,6 +1704,13 @@
       "ImportAgentItem": {
         "additionalProperties": false,
         "properties": {
+          "collaborators": {
+            "items": {
+              "properties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
           "created_by_subject": {
             "allOf": [
               {

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -1701,13 +1701,17 @@
         ],
         "type": "object"
       },
+      "ImportAgentCollaborator": {
+        "additionalProperties": {},
+        "properties": {},
+        "type": "object"
+      },
       "ImportAgentItem": {
         "additionalProperties": false,
         "properties": {
           "collaborators": {
             "items": {
-              "properties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/ImportAgentCollaborator"
             },
             "type": "array"
           },

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ service-account*.json
 .cursor/plans/
 
 .vscode
+
+.certs/

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1704,6 +1704,13 @@
       "ImportAgentItem": {
         "additionalProperties": false,
         "properties": {
+          "collaborators": {
+            "items": {
+              "properties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
           "created_by_subject": {
             "allOf": [
               {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1701,13 +1701,17 @@
         ],
         "type": "object"
       },
+      "ImportAgentCollaborator": {
+        "additionalProperties": {},
+        "properties": {},
+        "type": "object"
+      },
       "ImportAgentItem": {
         "additionalProperties": false,
         "properties": {
           "collaborators": {
             "items": {
-              "properties": {},
-              "type": "object"
+              "$ref": "#/components/schemas/ImportAgentCollaborator"
             },
             "type": "array"
           },

--- a/packages/trueforge/src/apis/agentImport.ts
+++ b/packages/trueforge/src/apis/agentImport.ts
@@ -50,6 +50,9 @@ export function createAgentImportRouter(deps: AgentImportRouterDeps) {
           manifest: agent.manifest,
           external_id: null,
           created_by_subject: agent.created_by_subject,
+          custom: {
+            ...(agent.collaborators ? { collaborators: agent.collaborators } : {}),
+          },
         });
         results.push({
           name: created.name,

--- a/packages/trueforge/src/db/agentStore.ts
+++ b/packages/trueforge/src/db/agentStore.ts
@@ -71,6 +71,7 @@ export interface CreateAgentInput {
   manifest: AgentSpec;
   external_id: string | null;
   created_by_subject: CreatedBySubject;
+  custom?: Record<string, unknown>;
 }
 
 /**

--- a/packages/trueforge/src/schemas/agentImport.ts
+++ b/packages/trueforge/src/schemas/agentImport.ts
@@ -18,6 +18,7 @@ export const ImportAgentItemSchema = z
     manifest: AgentSpecSchema,
     tenant_id: z.string().min(1).describe('Tenant to create the agent under.'),
     created_by_subject: CreatedBySubjectSchema.describe('Original creator to persist on the agent.'),
+    collaborators: z.array(z.object()).optional(),
   })
   .strict()
   .openapi('ImportAgentItem');

--- a/packages/trueforge/src/schemas/agentImport.ts
+++ b/packages/trueforge/src/schemas/agentImport.ts
@@ -8,6 +8,9 @@ import { NameSchema } from './common';
 
 const RESERVED_AGENT_NAMES = new Set(['tfg', 'trueforge']);
 
+/** Opaque collaborator grant forwarded to ServiceFoundry on import. */
+export const ImportAgentCollaboratorSchema = z.object({}).loose().openapi('ImportAgentCollaborator');
+
 /** One import row: same fields as create-agent, plus explicit tenant and creator. */
 export const ImportAgentItemSchema = z
   .object({
@@ -18,7 +21,7 @@ export const ImportAgentItemSchema = z
     manifest: AgentSpecSchema,
     tenant_id: z.string().min(1).describe('Tenant to create the agent under.'),
     created_by_subject: CreatedBySubjectSchema.describe('Original creator to persist on the agent.'),
-    collaborators: z.array(z.object()).optional(),
+    collaborators: z.array(ImportAgentCollaboratorSchema).optional(),
   })
   .strict()
   .openapi('ImportAgentItem');

--- a/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
@@ -35,20 +35,15 @@ function toPutRemoteAgentPayload({
   name: string;
   description: string;
   manifest: AgentSpec;
-  collaborators?: object[];
+  collaborators?: Record<string, unknown>[];
 }): Omit<PutRemoteAgentInput, 'accessToken'> {
   return {
     name,
     description: (description || name).slice(0, AGENT_DESCRIPTION_MAX_LENGTH),
     model: manifest.model.name,
     mcp_servers: (manifest.mcp_servers ?? []).map(server => server.name),
-    ...(collaborators && collaborators.length > 0 ? { collaborators } : {}),
+    ...(collaborators ? { collaborators } : {}),
   };
-}
-
-// TODO (chiragjn): This is temporary - only till we have import agents route.
-export interface CreateTrueFoundryAgentInput extends CreateAgentInput {
-  collaborators?: object[];
 }
 
 /**
@@ -143,7 +138,7 @@ export class TrueFoundryAgentStore implements IAgentStore<Transaction<Database>>
 
     let externalId: string | undefined;
     try {
-      const collaborators = input.custom?.['collaborators'] as object[] | undefined;
+      const collaborators = input.custom?.['collaborators'] as Record<string, unknown>[] | undefined;
       ({ externalId } = await this.#client.putRemoteAgent({
         accessToken: await this.#resolveAccessToken(),
         ...toPutRemoteAgentPayload({

--- a/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
@@ -42,7 +42,7 @@ function toPutRemoteAgentPayload({
     description: (description || name).slice(0, AGENT_DESCRIPTION_MAX_LENGTH),
     model: manifest.model.name,
     mcp_servers: (manifest.mcp_servers ?? []).map(server => server.name),
-    ...(collaborators ? { collaborators } : {}),
+    ...(collaborators && collaborators.length > 0 ? { collaborators } : {}),
   };
 }
 

--- a/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
@@ -30,17 +30,25 @@ function toPutRemoteAgentPayload({
   name,
   description,
   manifest,
+  collaborators,
 }: {
   name: string;
   description: string;
   manifest: AgentSpec;
+  collaborators?: object[];
 }): Omit<PutRemoteAgentInput, 'accessToken'> {
   return {
     name,
     description: (description || name).slice(0, AGENT_DESCRIPTION_MAX_LENGTH),
     model: manifest.model.name,
     mcp_servers: (manifest.mcp_servers ?? []).map(server => server.name),
+    ...(collaborators ? { collaborators } : {}),
   };
+}
+
+// TODO (chiragjn): This is temporary - only till we have import agents route.
+export interface CreateTrueFoundryAgentInput extends CreateAgentInput {
+  collaborators?: object[];
 }
 
 /**
@@ -135,12 +143,14 @@ export class TrueFoundryAgentStore implements IAgentStore<Transaction<Database>>
 
     let externalId: string | undefined;
     try {
+      const collaborators = input.custom?.['collaborators'] as object[] | undefined;
       ({ externalId } = await this.#client.putRemoteAgent({
         accessToken: await this.#resolveAccessToken(),
         ...toPutRemoteAgentPayload({
           name: input.name,
           description: input.description,
           manifest: input.manifest,
+          ...(collaborators ? { collaborators } : {}),
         }),
       }));
       const updated = await this.#inner.updateAgent(

--- a/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
@@ -97,6 +97,7 @@ export interface PutRemoteAgentInput {
   description: string;
   model: string;
   mcp_servers: string[];
+  collaborators?: Record<string, unknown>[];
 }
 
 export interface PutRemoteAgentResult {
@@ -245,6 +246,7 @@ export class TrueFoundryServiceFoundryServerClient {
 
   /** PUT `/internal/tfg/agents` — create/reuse remote agent + sync model/MCP grants. */
   async putRemoteAgent(input: PutRemoteAgentInput): Promise<PutRemoteAgentResult> {
+    const hasCollaborators = input.collaborators && input.collaborators.length > 0;
     const payload = await this.#requestJson({
       url: this.#url(TFG_AGENTS_PATH),
       accessToken: input.accessToken,
@@ -255,6 +257,7 @@ export class TrueFoundryServiceFoundryServerClient {
         description: input.description,
         model: input.model,
         mcp_servers: input.mcp_servers,
+        ...(hasCollaborators ? { collaborators: input.collaborators } : {}),
       },
     });
     const parsed = PutRemoteAgentResponseSchema.safeParse(payload);

--- a/packages/trueforge/tests/unit/truefoundry/TrueFoundryAgentStore.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/TrueFoundryAgentStore.test.ts
@@ -204,6 +204,44 @@ describe('TrueFoundryAgentStore', () => {
     expect(firstInvocationOrder(putRemoteAgent)).toBeLessThan(firstInvocationOrder(updateAgent));
   });
 
+  it('createAgent forwards collaborators from custom into putRemoteAgent', async () => {
+    const collaborators = [{ subject: 'user:alice@example.com', role_id: 'agent-manager' }];
+    const local = record({ external_id: null });
+    const linked = record({ external_id: 'sf-1' });
+    const putRemoteAgent = jest.fn(async (input: PutRemoteAgentInput) => {
+      expect(input.collaborators).toEqual(collaborators);
+      return { externalId: 'sf-1' };
+    });
+    const store = tfStore({
+      inner: mockInner({
+        createAgent: jest.fn(async () => local),
+        updateAgent: jest.fn(async () => linked),
+      }),
+      client: mockClient({ putRemoteAgent }),
+    });
+
+    await expect(
+      store.createAgent(
+        {
+          tenant_id: TENANT,
+          created_by_subject: CREATED_BY_SUBJECT,
+          name: 'research',
+          description: 'research',
+          manifest: manifest(),
+          external_id: null,
+          custom: { collaborators },
+        },
+        TXN,
+      ),
+    ).resolves.toBe(linked);
+    expect(putRemoteAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'research',
+        collaborators,
+      }),
+    );
+  });
+
   it('createAgent rejects a duplicate local name before calling ServiceFoundry', async () => {
     const createAgent = jest.fn(async () => {
       throw new AgentNameConflictError({ tenant_id: TENANT, name: 'research' });


### PR DESCRIPTION
AGE-2176


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes propagate collaborator grants to ServiceFoundry on import, which affects access control for newly imported agents; scope is limited to the internal import create path and is covered by a new unit test.
> 
> **Overview**
> **Agent import** can now include an optional **`collaborators`** array on each imported agent. Those grants are treated as opaque objects, validated on the wire, and forwarded when the agent is created in ServiceFoundry—not stored as a first-class DB field.
> 
> The path is: import payload → optional `custom.collaborators` on **`CreateAgentInput`** → **`TrueFoundryAgentStore.createAgent`** → **`putRemoteAgent`** PUT body (only when the list is non-empty). OpenAPI/Fern specs add **`ImportAgentCollaborator`** and the new field on **`ImportAgentItem`**.
> 
> Also adds **`.certs/`** to **`.gitignore`** (unrelated housekeeping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6041cb98fb70383d32edbd86e321ed1185ca7946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->