### PR TITLE
Propagate truefoundry managed agent id in internal import

### DIFF
--- a/.changeset/pre/tfy-import-collaborators.md
+++ b/.changeset/pre/tfy-import-collaborators.md
@@ -2,4 +2,4 @@
 "@truefoundry/trueforge": patch
 ---
 
-Pass collaborators through TrueFoundry agent import.
+Pass TrueFoundry agents metadata through TrueFoundry agent import.

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -1701,20 +1701,9 @@
         ],
         "type": "object"
       },
-      "ImportAgentCollaborator": {
-        "additionalProperties": {},
-        "properties": {},
-        "type": "object"
-      },
       "ImportAgentItem": {
         "additionalProperties": false,
         "properties": {
-          "collaborators": {
-            "items": {
-              "$ref": "#/components/schemas/ImportAgentCollaborator"
-            },
-            "type": "array"
-          },
           "created_by_subject": {
             "allOf": [
               {
@@ -1739,6 +1728,9 @@
           "tenant_id": {
             "description": "Tenant to create the agent under.",
             "minLength": 1,
+            "type": "string"
+          },
+          "trueFoundryManagedAgentId": {
             "type": "string"
           }
         },
@@ -5653,7 +5645,7 @@
   "info": {
     "description": "HTTP API for the TrueForge agent server (`/api/v1`). Interactive docs are served at `/api/v1/docs` (OpenAPI JSON at `/api/v1/openapi.json`).\n\n**Authentication:** Standalone auth accepts requests without credentials — middleware stamps a local default user. When OIDC or TrueFoundry auth is configured, protected routes require a valid cookie or `Authorization: Bearer` token. There is no built-in API-key scheme; pass custom headers only if your reverse proxy or IdP layer requires them.\n\nCovers DB-backed sessions, the agent registry, settings catalogs, and model/MCP/skill/sandbox providers.",
     "title": "TrueForge API",
-    "version": "0.2.0-rc.6"
+    "version": "0.2.0-rc.7"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -1738,7 +1738,8 @@
           "name",
           "manifest",
           "tenant_id",
-          "created_by_subject"
+          "created_by_subject",
+          "truefoundry_managed_agent_id"
         ],
         "type": "object"
       },

--- a/.github/fern/openapi/openapi.json
+++ b/.github/fern/openapi/openapi.json
@@ -1730,7 +1730,7 @@
             "minLength": 1,
             "type": "string"
           },
-          "trueFoundryManagedAgentId": {
+          "truefoundry_managed_agent_id": {
             "type": "string"
           }
         },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1701,20 +1701,9 @@
         ],
         "type": "object"
       },
-      "ImportAgentCollaborator": {
-        "additionalProperties": {},
-        "properties": {},
-        "type": "object"
-      },
       "ImportAgentItem": {
         "additionalProperties": false,
         "properties": {
-          "collaborators": {
-            "items": {
-              "$ref": "#/components/schemas/ImportAgentCollaborator"
-            },
-            "type": "array"
-          },
           "created_by_subject": {
             "allOf": [
               {
@@ -1739,6 +1728,9 @@
           "tenant_id": {
             "description": "Tenant to create the agent under.",
             "minLength": 1,
+            "type": "string"
+          },
+          "trueFoundryManagedAgentId": {
             "type": "string"
           }
         },
@@ -5653,7 +5645,7 @@
   "info": {
     "description": "HTTP API for the TrueForge agent server (`/api/v1`). Interactive docs are served at `/api/v1/docs` (OpenAPI JSON at `/api/v1/openapi.json`).\n\n**Authentication:** Standalone auth accepts requests without credentials — middleware stamps a local default user. When OIDC or TrueFoundry auth is configured, protected routes require a valid cookie or `Authorization: Bearer` token. There is no built-in API-key scheme; pass custom headers only if your reverse proxy or IdP layer requires them.\n\nCovers DB-backed sessions, the agent registry, settings catalogs, and model/MCP/skill/sandbox providers.",
     "title": "TrueForge API",
-    "version": "0.2.0-rc.6"
+    "version": "0.2.0-rc.7"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1738,7 +1738,8 @@
           "name",
           "manifest",
           "tenant_id",
-          "created_by_subject"
+          "created_by_subject",
+          "truefoundry_managed_agent_id"
         ],
         "type": "object"
       },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1730,7 +1730,7 @@
             "minLength": 1,
             "type": "string"
           },
-          "trueFoundryManagedAgentId": {
+          "truefoundry_managed_agent_id": {
             "type": "string"
           }
         },

--- a/packages/trueforge/src/apis/agentImport.ts
+++ b/packages/trueforge/src/apis/agentImport.ts
@@ -51,7 +51,7 @@ export function createAgentImportRouter(deps: AgentImportRouterDeps) {
           external_id: null,
           created_by_subject: agent.created_by_subject,
           custom: {
-            ...(agent.collaborators ? { collaborators: agent.collaborators } : {}),
+            ...(agent.trueFoundryManagedAgentId ? { trueFoundryManagedAgentId: agent.trueFoundryManagedAgentId } : {}),
           },
         });
         results.push({

--- a/packages/trueforge/src/apis/agentImport.ts
+++ b/packages/trueforge/src/apis/agentImport.ts
@@ -51,9 +51,7 @@ export function createAgentImportRouter(deps: AgentImportRouterDeps) {
           external_id: null,
           created_by_subject: agent.created_by_subject,
           custom: {
-            ...(agent.truefoundry_managed_agent_id
-              ? { trueFoundryManagedAgentId: agent.truefoundry_managed_agent_id }
-              : {}),
+            trueFoundryManagedAgentId: agent.truefoundry_managed_agent_id,
           },
         });
         results.push({

--- a/packages/trueforge/src/apis/agentImport.ts
+++ b/packages/trueforge/src/apis/agentImport.ts
@@ -51,7 +51,9 @@ export function createAgentImportRouter(deps: AgentImportRouterDeps) {
           external_id: null,
           created_by_subject: agent.created_by_subject,
           custom: {
-            ...(agent.trueFoundryManagedAgentId ? { trueFoundryManagedAgentId: agent.trueFoundryManagedAgentId } : {}),
+            ...(agent.truefoundry_managed_agent_id
+              ? { trueFoundryManagedAgentId: agent.truefoundry_managed_agent_id }
+              : {}),
           },
         });
         results.push({

--- a/packages/trueforge/src/schemas/agentImport.ts
+++ b/packages/trueforge/src/schemas/agentImport.ts
@@ -18,7 +18,7 @@ export const ImportAgentItemSchema = z
     manifest: AgentSpecSchema,
     tenant_id: z.string().min(1).describe('Tenant to create the agent under.'),
     created_by_subject: CreatedBySubjectSchema.describe('Original creator to persist on the agent.'),
-    truefoundry_managed_agent_id: z.string().optional(),
+    truefoundry_managed_agent_id: z.string(),
   })
   .strict()
   .openapi('ImportAgentItem');

--- a/packages/trueforge/src/schemas/agentImport.ts
+++ b/packages/trueforge/src/schemas/agentImport.ts
@@ -8,9 +8,6 @@ import { NameSchema } from './common';
 
 const RESERVED_AGENT_NAMES = new Set(['tfg', 'trueforge']);
 
-/** Opaque collaborator grant forwarded to ServiceFoundry on import. */
-export const ImportAgentCollaboratorSchema = z.object({}).loose().openapi('ImportAgentCollaborator');
-
 /** One import row: same fields as create-agent, plus explicit tenant and creator. */
 export const ImportAgentItemSchema = z
   .object({
@@ -21,7 +18,7 @@ export const ImportAgentItemSchema = z
     manifest: AgentSpecSchema,
     tenant_id: z.string().min(1).describe('Tenant to create the agent under.'),
     created_by_subject: CreatedBySubjectSchema.describe('Original creator to persist on the agent.'),
-    collaborators: z.array(ImportAgentCollaboratorSchema).optional(),
+    trueFoundryManagedAgentId: z.string().optional(),
   })
   .strict()
   .openapi('ImportAgentItem');

--- a/packages/trueforge/src/schemas/agentImport.ts
+++ b/packages/trueforge/src/schemas/agentImport.ts
@@ -18,7 +18,7 @@ export const ImportAgentItemSchema = z
     manifest: AgentSpecSchema,
     tenant_id: z.string().min(1).describe('Tenant to create the agent under.'),
     created_by_subject: CreatedBySubjectSchema.describe('Original creator to persist on the agent.'),
-    trueFoundryManagedAgentId: z.string().optional(),
+    truefoundry_managed_agent_id: z.string().optional(),
   })
   .strict()
   .openapi('ImportAgentItem');

--- a/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
@@ -30,19 +30,19 @@ function toPutRemoteAgentPayload({
   name,
   description,
   manifest,
-  collaborators,
+  trueFoundryManagedAgentId,
 }: {
   name: string;
   description: string;
   manifest: AgentSpec;
-  collaborators?: Record<string, unknown>[];
+  trueFoundryManagedAgentId?: Record<string, unknown>[];
 }): Omit<PutRemoteAgentInput, 'accessToken'> {
   return {
     name,
     description: (description || name).slice(0, AGENT_DESCRIPTION_MAX_LENGTH),
     model: manifest.model.name,
     mcp_servers: (manifest.mcp_servers ?? []).map(server => server.name),
-    ...(collaborators ? { collaborators } : {}),
+    ...(trueFoundryManagedAgentId ? { trueFoundryManagedAgentId } : {}),
   };
 }
 
@@ -138,14 +138,15 @@ export class TrueFoundryAgentStore implements IAgentStore<Transaction<Database>>
 
     let externalId: string | undefined;
     try {
-      const collaborators = input.custom?.['collaborators'] as Record<string, unknown>[] | undefined;
+      const trueFoundryManagedAgentId = input.custom?.['trueFoundryManagedAgentId'] as
+        Record<string, unknown>[] | undefined;
       ({ externalId } = await this.#client.putRemoteAgent({
         accessToken: await this.#resolveAccessToken(),
         ...toPutRemoteAgentPayload({
           name: input.name,
           description: input.description,
           manifest: input.manifest,
-          ...(collaborators ? { collaborators } : {}),
+          ...(trueFoundryManagedAgentId ? { trueFoundryManagedAgentId } : {}),
         }),
       }));
       const updated = await this.#inner.updateAgent(

--- a/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryAgentStore.ts
@@ -35,7 +35,7 @@ function toPutRemoteAgentPayload({
   name: string;
   description: string;
   manifest: AgentSpec;
-  trueFoundryManagedAgentId?: Record<string, unknown>[];
+  trueFoundryManagedAgentId?: string;
 }): Omit<PutRemoteAgentInput, 'accessToken'> {
   return {
     name,
@@ -138,8 +138,7 @@ export class TrueFoundryAgentStore implements IAgentStore<Transaction<Database>>
 
     let externalId: string | undefined;
     try {
-      const trueFoundryManagedAgentId = input.custom?.['trueFoundryManagedAgentId'] as
-        Record<string, unknown>[] | undefined;
+      const trueFoundryManagedAgentId = input.custom?.['trueFoundryManagedAgentId'] as string | undefined;
       ({ externalId } = await this.#client.putRemoteAgent({
         accessToken: await this.#resolveAccessToken(),
         ...toPutRemoteAgentPayload({

--- a/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
@@ -97,7 +97,7 @@ export interface PutRemoteAgentInput {
   description: string;
   model: string;
   mcp_servers: string[];
-  trueFoundryManagedAgentId?: Record<string, unknown>[];
+  trueFoundryManagedAgentId?: string;
 }
 
 export interface PutRemoteAgentResult {

--- a/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
+++ b/packages/trueforge/src/truefoundry/TrueFoundryServiceFoundryServerClient.ts
@@ -97,7 +97,7 @@ export interface PutRemoteAgentInput {
   description: string;
   model: string;
   mcp_servers: string[];
-  collaborators?: Record<string, unknown>[];
+  trueFoundryManagedAgentId?: Record<string, unknown>[];
 }
 
 export interface PutRemoteAgentResult {
@@ -246,7 +246,7 @@ export class TrueFoundryServiceFoundryServerClient {
 
   /** PUT `/internal/tfg/agents` — create/reuse remote agent + sync model/MCP grants. */
   async putRemoteAgent(input: PutRemoteAgentInput): Promise<PutRemoteAgentResult> {
-    const hasCollaborators = input.collaborators && input.collaborators.length > 0;
+    const hasTrueFoundryManagedAgentId = input.trueFoundryManagedAgentId !== undefined;
     const payload = await this.#requestJson({
       url: this.#url(TFG_AGENTS_PATH),
       accessToken: input.accessToken,
@@ -257,7 +257,7 @@ export class TrueFoundryServiceFoundryServerClient {
         description: input.description,
         model: input.model,
         mcp_servers: input.mcp_servers,
-        ...(hasCollaborators ? { collaborators: input.collaborators } : {}),
+        ...(hasTrueFoundryManagedAgentId ? { trueFoundryManagedAgentId: input.trueFoundryManagedAgentId } : {}),
       },
     });
     const parsed = PutRemoteAgentResponseSchema.safeParse(payload);

--- a/packages/trueforge/tests/unit/truefoundry/TrueFoundryAgentStore.test.ts
+++ b/packages/trueforge/tests/unit/truefoundry/TrueFoundryAgentStore.test.ts
@@ -204,44 +204,6 @@ describe('TrueFoundryAgentStore', () => {
     expect(firstInvocationOrder(putRemoteAgent)).toBeLessThan(firstInvocationOrder(updateAgent));
   });
 
-  it('createAgent forwards collaborators from custom into putRemoteAgent', async () => {
-    const collaborators = [{ subject: 'user:alice@example.com', role_id: 'agent-manager' }];
-    const local = record({ external_id: null });
-    const linked = record({ external_id: 'sf-1' });
-    const putRemoteAgent = jest.fn(async (input: PutRemoteAgentInput) => {
-      expect(input.collaborators).toEqual(collaborators);
-      return { externalId: 'sf-1' };
-    });
-    const store = tfStore({
-      inner: mockInner({
-        createAgent: jest.fn(async () => local),
-        updateAgent: jest.fn(async () => linked),
-      }),
-      client: mockClient({ putRemoteAgent }),
-    });
-
-    await expect(
-      store.createAgent(
-        {
-          tenant_id: TENANT,
-          created_by_subject: CREATED_BY_SUBJECT,
-          name: 'research',
-          description: 'research',
-          manifest: manifest(),
-          external_id: null,
-          custom: { collaborators },
-        },
-        TXN,
-      ),
-    ).resolves.toBe(linked);
-    expect(putRemoteAgent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'research',
-        collaborators,
-      }),
-    );
-  });
-
   it('createAgent rejects a duplicate local name before calling ServiceFoundry', async () => {
     const createAgent = jest.fn(async () => {
       throw new AgentNameConflictError({ tenant_id: TENANT, name: 'research' });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking change to the internal import request shape and ServiceFoundry remote-agent payload; callers must send managed agent id and stop sending collaborators.
> 
> **Overview**
> **Internal agent import** now carries **`truefoundry_managed_agent_id`** (required on each `ImportAgentItem`) instead of optional **`collaborators`**. Import writes that value into agent **`custom.trueFoundryManagedAgentId`**, and **`TrueFoundryAgentStore`** / ServiceFoundry **`PUT /internal/tfg/agents`** forward **`trueFoundryManagedAgentId`** rather than collaborator grants.
> 
> OpenAPI/docs schemas drop **`ImportAgentCollaborator`** and bump the API version to **0.2.0-rc.7**. The unit test that asserted collaborator forwarding on create was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edfbfc933865179099484328f045d1d0f14c291c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->