### PR TITLE
Add a pluggable SessionPolicy seam to constrain session creation

### DIFF
--- a/.changeset/session-policy-seam.md
+++ b/.changeset/session-policy-seam.md
@@ -1,0 +1,8 @@
+---
+'@truefoundry/trueforge': minor
+---
+
+Add a SessionPolicy seam enforced at session creation, so operators can
+later restrict which agents, models, skills, and MCP servers an
+API-driven caller may request. Defaults to unrestricted — no behavior
+change until a restrictive SessionPolicyProvider is wired in.

--- a/packages/trueforge/scripts/write-openapi.ts
+++ b/packages/trueforge/scripts/write-openapi.ts
@@ -15,6 +15,7 @@ import path from 'node:path';
 import winston from 'winston';
 import { buildOpenApiDocument, createServerApp } from '../src/app';
 import { TrueForgeAuthorizer } from '../src/auth/authorizer';
+import { UnrestrictedSessionPolicyProvider } from '../src/auth/sessionPolicy';
 import { StandaloneAuthenticator } from '../src/auth/standaloneAuthenticator';
 import { McpCatalog } from '../src/catalog/McpCatalog';
 import { ModelCatalog } from '../src/catalog/ModelCatalog';
@@ -90,6 +91,7 @@ const app = createServerApp({
   oidcClient: undefined,
   authenticator: new StandaloneAuthenticator(),
   authorizer: new TrueForgeAuthorizer(),
+  sessionPolicyProvider: new UnrestrictedSessionPolicyProvider(),
 });
 
 // Runtime apps only advertise BearerAuth when OIDC is configured. The committed

--- a/packages/trueforge/src/apis/sessions.ts
+++ b/packages/trueforge/src/apis/sessions.ts
@@ -23,6 +23,7 @@ import type { Logger } from 'winston';
 import { z } from 'zod';
 import type { Authorizer } from '../auth/authorizer';
 import { createdBySubjectFromRequestContext, type ResolveRequestContext } from '../auth/identity';
+import { checkSessionPolicyForAgent, type SessionPolicyProvider } from '../auth/sessionPolicy';
 import configuration from '../config';
 import type { IAgentStore } from '../db/agentStore';
 import type { IMcpServerStore } from '../db/mcpServerStore';
@@ -86,6 +87,7 @@ export interface SessionsRouterDeps {
   resolveRequestContext: ResolveRequestContext;
   logger: Logger;
   authorizer: Authorizer;
+  sessionPolicyProvider: SessionPolicyProvider;
 }
 
 function cancelTurnOnThisExecutor(
@@ -239,6 +241,7 @@ type InternalSessionsRouterDeps = Pick<
   | 'resolveSandboxProviderStore'
   | 'resolveRequestContext'
   | 'authorizer'
+  | 'sessionPolicyProvider'
 >;
 
 function createGetOrCreateSessionByExternalIdHandler(
@@ -267,8 +270,17 @@ function createGetOrCreateSessionByExternalIdHandler(
       return c.json({ data: toWireSession(existing.record) }, 200);
     }
 
+    const sessionPolicy = await deps.sessionPolicyProvider.resolveSessionPolicy({ context: requestContext });
+    const policyDecision = checkSessionPolicyForAgent(sessionPolicy, body.agent);
+
     let agent: SessionRecord['agent'];
     if (isSessionAgentNameRef(body.agent)) {
+      if (!policyDecision.allowed) {
+        // Same response as "not found" — a policy-denied agent must not be
+        // distinguishable from one that doesn't exist (issue #541 requires
+        // callers never be able to enumerate shared agents).
+        return c.json({ error: { message: `Agent not found: ${body.agent.name}` } }, 404);
+      }
       const named = await agentIfAccessible({
         authorizer: deps.authorizer,
         context: requestContext,
@@ -283,6 +295,9 @@ function createGetOrCreateSessionByExternalIdHandler(
       }
       agent = { type: 'reference', id: named.id, name: named.name };
     } else {
+      if (!policyDecision.allowed) {
+        return c.json({ error: { message: policyDecision.reason } }, 403);
+      }
       await validateAgentSpec({
         spec: body.agent.spec,
         tenant_id: requestContext.tenant_id,
@@ -331,7 +346,16 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
     const sessionId = newId();
     const requestContext = deps.resolveRequestContext(c);
 
+    const sessionPolicy = await deps.sessionPolicyProvider.resolveSessionPolicy({ context: requestContext });
+    const policyDecision = checkSessionPolicyForAgent(sessionPolicy, body.agent);
+
     if (isSessionAgentNameRef(body.agent)) {
+      if (!policyDecision.allowed) {
+        // Same response as "not found" — a policy-denied agent must not be
+        // distinguishable from one that doesn't exist (issue #541 requires
+        // callers never be able to enumerate shared agents).
+        return c.json({ error: { message: `Agent not found: ${body.agent.name}` } }, 404);
+      }
       const agent = await agentIfAccessible({
         authorizer: deps.authorizer,
         context: requestContext,
@@ -355,6 +379,9 @@ export function createSessionsRouter(deps: SessionsRouterDeps) {
       return c.json({ data: toWireSession(session.record) }, 201);
     }
 
+    if (!policyDecision.allowed) {
+      return c.json({ error: { message: policyDecision.reason } }, 403);
+    }
     await validateAgentSpec({
       spec: body.agent.spec,
       tenant_id: requestContext.tenant_id,

--- a/packages/trueforge/src/app.ts
+++ b/packages/trueforge/src/app.ts
@@ -27,6 +27,7 @@ import type { Authenticator } from './auth/authenticator';
 import type { Authorizer } from './auth/authorizer';
 import { resolveRequestContext } from './auth/identity';
 import { createAdminAuthMiddleware, createAuthMiddleware } from './auth/middleware';
+import type { SessionPolicyProvider } from './auth/sessionPolicy';
 import type { McpCatalog } from './catalog/McpCatalog';
 import type { ModelCatalog } from './catalog/ModelCatalog';
 import type { SandboxCatalog } from './catalog/SandboxCatalog';
@@ -201,6 +202,8 @@ export interface ServerDeps<TTransaction> {
   authenticator: Authenticator;
   /** Startup-selected agent authorization policy. */
   authorizer: Authorizer;
+  /** Startup-selected session-creation policy; defaults to unrestricted. */
+  sessionPolicyProvider: SessionPolicyProvider;
 }
 
 export function createServerApp<TTransaction>(deps: ServerDeps<TTransaction>) {
@@ -364,6 +367,7 @@ export function createServerApp<TTransaction>(deps: ServerDeps<TTransaction>) {
         resolveSandboxProviderStore: deps.resolveSandboxProviderStore,
         resolveRequestContext,
         authorizer: deps.authorizer,
+        sessionPolicyProvider: deps.sessionPolicyProvider,
       }),
       authMiddleware,
     ),
@@ -397,6 +401,7 @@ export function createServerApp<TTransaction>(deps: ServerDeps<TTransaction>) {
         resolveRequestContext,
         logger: deps.logger,
         authorizer: deps.authorizer,
+        sessionPolicyProvider: deps.sessionPolicyProvider,
       }),
       authMiddleware,
     ),

--- a/packages/trueforge/src/auth/sessionPolicy.ts
+++ b/packages/trueforge/src/auth/sessionPolicy.ts
@@ -1,0 +1,92 @@
+import type { CreateSessionAgent } from '../schemas/session';
+import { isSessionAgentNameRef } from '../schemas/session';
+import type { RequestContext } from './identity';
+
+/**
+ * Server-enforced constraints on what a caller may request when creating a
+ * session. `undefined` on an allow-list means "unrestricted" for that
+ * dimension — distinct from an empty array, which permits nothing.
+ */
+export interface SessionPolicy {
+  /** Whether the caller may submit an inline (ad hoc) agent spec at all. */
+  allow_inline_agent_specs: boolean;
+  /** Named agents the caller may bind a session to. `undefined` = any. */
+  allowed_agent_names: readonly string[] | undefined;
+  /** Models an inline spec may request. `undefined` = any configured model. */
+  allowed_models: readonly string[] | undefined;
+  /** Skills an inline spec may request. `undefined` = any configured skill. */
+  allowed_skills: readonly string[] | undefined;
+  /** MCP servers an inline spec may request. `undefined` = any configured server. */
+  allowed_mcp_servers: readonly string[] | undefined;
+}
+
+/** No constraints beyond what already exists today (any agent, any resource). */
+export const UNRESTRICTED_SESSION_POLICY: SessionPolicy = {
+  allow_inline_agent_specs: true,
+  allowed_agent_names: undefined,
+  allowed_models: undefined,
+  allowed_skills: undefined,
+  allowed_mcp_servers: undefined,
+};
+
+/**
+ * Resolves the {@link SessionPolicy} that applies to a caller's session
+ * creation requests. Mirrors Authorizer: implementations may key off
+ * `context.subject`, `context.roles`, or tenant config to scope unattended
+ * / API-driven identities. Not consulted for reads of existing sessions —
+ * ownership there is still `created_by`.
+ */
+export interface SessionPolicyProvider {
+  resolveSessionPolicy(input: { context: RequestContext }): Promise<SessionPolicy>;
+}
+
+/** Default: every caller gets UNRESTRICTED_SESSION_POLICY — current behavior, unchanged. */
+export class UnrestrictedSessionPolicyProvider implements SessionPolicyProvider {
+  resolveSessionPolicy(): Promise<SessionPolicy> {
+    return Promise.resolve(UNRESTRICTED_SESSION_POLICY);
+  }
+}
+
+export type SessionPolicyDecision = { allowed: true } | { allowed: false; reason: string };
+
+/**
+ * Checks a requested session agent against a resolved policy. Called at
+ * session-creation time, before any store lookups — the server enforces
+ * this itself and never trusts restrictions the caller claims to already
+ * be honoring.
+ */
+export function checkSessionPolicyForAgent(policy: SessionPolicy, agent: CreateSessionAgent): SessionPolicyDecision {
+  if (isSessionAgentNameRef(agent)) {
+    if (policy.allowed_agent_names !== undefined && !policy.allowed_agent_names.includes(agent.name)) {
+      return { allowed: false, reason: `Agent "${agent.name}" is not permitted by session policy` };
+    }
+    return { allowed: true };
+  }
+
+  if (!policy.allow_inline_agent_specs) {
+    return { allowed: false, reason: 'Inline agent specifications are not permitted by session policy' };
+  }
+
+  const { spec } = agent;
+  if (policy.allowed_models !== undefined && !policy.allowed_models.includes(spec.model.name)) {
+    return { allowed: false, reason: `Model "${spec.model.name}" is not permitted by session policy` };
+  }
+
+  if (policy.allowed_skills !== undefined) {
+    const allowedSkills = policy.allowed_skills;
+    const disallowed = (spec.skills ?? []).find(skill => !allowedSkills.includes(skill.name));
+    if (disallowed !== undefined) {
+      return { allowed: false, reason: `Skill "${disallowed.name}" is not permitted by session policy` };
+    }
+  }
+
+  if (policy.allowed_mcp_servers !== undefined) {
+    const allowedServers = policy.allowed_mcp_servers;
+    const disallowed = (spec.mcp_servers ?? []).find(server => !allowedServers.includes(server.name));
+    if (disallowed !== undefined) {
+      return { allowed: false, reason: `MCP server "${disallowed.name}" is not permitted by session policy` };
+    }
+  }
+
+  return { allowed: true };
+}

--- a/packages/trueforge/src/main.ts
+++ b/packages/trueforge/src/main.ts
@@ -59,6 +59,7 @@ import { TrueForgeAuthorizer, type Authorizer } from './auth/authorizer';
 import { createAuthenticator } from './auth/createAuthenticator';
 import { resolveRequestContext } from './auth/identity';
 import { initOidc } from './auth/oidc';
+import { UnrestrictedSessionPolicyProvider } from './auth/sessionPolicy';
 import { McpCatalog } from './catalog/McpCatalog';
 import { ModelCatalog } from './catalog/ModelCatalog';
 import { SandboxCatalog } from './catalog/SandboxCatalog';
@@ -434,6 +435,10 @@ async function createServerRuntime<TTransaction>(persistence: ServerPersistence<
     authorizer = new TrueForgeAuthorizer();
   }
 
+  // No operator-configurable policy source yet — every caller gets the
+  // unrestricted policy, preserving current behavior. See issue #541.
+  const sessionPolicyProvider = new UnrestrictedSessionPolicyProvider();
+
   // Standalone is one process, so it owns the control loops too.
   const controller = configuration.STANDALONE
     ? createController({
@@ -468,6 +473,7 @@ async function createServerRuntime<TTransaction>(persistence: ServerPersistence<
     oidcClient,
     authenticator,
     authorizer,
+    sessionPolicyProvider,
   });
 
   return { activeTurns, app, controller, destroyDb, redis, requestReplyRouter };

--- a/packages/trueforge/src/routes/sessionRoutes.ts
+++ b/packages/trueforge/src/routes/sessionRoutes.ts
@@ -47,6 +47,10 @@ export const createSessionRoute = createRoute({
       content: { 'application/json': { schema: RequestErrorResponseSchema } },
       description: 'Invalid request body.',
     },
+    403: {
+      content: { 'application/json': { schema: RequestErrorResponseSchema } },
+      description: 'The request is not permitted by session policy.',
+    },
     404: {
       content: { 'application/json': { schema: RequestErrorResponseSchema } },
       description: 'Named agent not found.',
@@ -92,7 +96,7 @@ export const getOrCreateSessionByExternalIdRoute = createRoute({
     },
     403: {
       content: { 'application/json': { schema: RequestErrorResponseSchema } },
-      description: 'Caller is not the session creator.',
+      description: 'Caller is not the session creator, or the request is not permitted by session policy.',
     },
     404: {
       content: { 'application/json': { schema: RequestErrorResponseSchema } },

--- a/packages/trueforge/tests/unit/apis/deletedSessionCrud.test.ts
+++ b/packages/trueforge/tests/unit/apis/deletedSessionCrud.test.ts
@@ -7,6 +7,7 @@ import { createSessionsRouter } from '../../../src/apis/sessions';
 import { createTurnsRouter } from '../../../src/apis/turns';
 import { TrueForgeAuthorizer } from '../../../src/auth/authorizer';
 import { STANDALONE_REQUEST_CONTEXT } from '../../../src/auth/identity';
+import { UnrestrictedSessionPolicyProvider } from '../../../src/auth/sessionPolicy';
 import { McpServerWithAuthStore } from '../../../src/db/McpServerWithAuthStore';
 import { migrateSqliteToLatest } from '../../../src/db/migrateSqlite';
 import { SqliteAgentStore } from '../../../src/db/sqlite/agent-store/SqliteAgentStore';
@@ -56,6 +57,7 @@ describe('public CRUD after session deletion', () => {
         resolveRequestContext: () => STANDALONE_REQUEST_CONTEXT,
         logger: createLogger({ silent: true }),
         authorizer: new TrueForgeAuthorizer(),
+        sessionPolicyProvider: new UnrestrictedSessionPolicyProvider(),
       }),
     );
     app.route(

--- a/packages/trueforge/tests/unit/apis/sessionHttp.test.ts
+++ b/packages/trueforge/tests/unit/apis/sessionHttp.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../src/apis/sessions';
 import { TrueForgeAuthorizer, type Authorizer } from '../../../src/auth/authorizer';
 import { STANDALONE_REQUEST_CONTEXT } from '../../../src/auth/identity';
+import { UnrestrictedSessionPolicyProvider, type SessionPolicyProvider } from '../../../src/auth/sessionPolicy';
 import { migrateSqliteToLatest } from '../../../src/db/migrateSqlite';
 import { SqliteAgentStore } from '../../../src/db/sqlite/agent-store/SqliteAgentStore';
 import { createSqliteDb } from '../../../src/db/sqlite/client';
@@ -45,6 +46,17 @@ const deniedCanAccessAgent = jest.fn((_input: Parameters<Authorizer['canAccessAg
 const denyAllAuthorizer: Authorizer = {
   listAgentAccess: () => Promise.resolve({ kind: 'agent_external_ids', agent_external_ids: [] }),
   canAccessAgent: deniedCanAccessAgent,
+};
+
+const denyAllSessionPolicyProvider: SessionPolicyProvider = {
+  resolveSessionPolicy: () =>
+    Promise.resolve({
+      allow_inline_agent_specs: false,
+      allowed_agent_names: [],
+      allowed_models: undefined,
+      allowed_skills: undefined,
+      allowed_mcp_servers: undefined,
+    }),
 };
 
 describe('sessions HTTP agent binding', () => {
@@ -97,6 +109,7 @@ describe('sessions HTTP agent binding', () => {
       resolveRequestContext: () => STANDALONE_REQUEST_CONTEXT,
       logger: createLogger({ silent: true }),
       authorizer: new TrueForgeAuthorizer(),
+      sessionPolicyProvider: new UnrestrictedSessionPolicyProvider(),
     };
     sessionDeps = deps;
     app = new OpenAPIHono();
@@ -632,5 +645,43 @@ describe('sessions HTTP agent binding', () => {
   it('rejects create bodies that mix name and AgentSpec fields', async () => {
     const both = await app.request('/', jsonInit('POST', { agent: { name: 'named-agent', ...inlineSpec } }));
     expect(both.status).toBe(400);
+  });
+  it('403s creating an inline session when session policy forbids inline specs', async () => {
+    const restrictedApp = new OpenAPIHono();
+    restrictedApp.route(
+      '/',
+      createSessionsRouter({
+        ...sessionDeps,
+        requestReplyRouter: new RequestReplyRouter(),
+        sessionPolicyProvider: denyAllSessionPolicyProvider,
+      }),
+    );
+    const res = await restrictedApp.request('/', jsonInit('POST', { agent: { spec: inlineSpec } }));
+    expect(res.status).toBe(403);
+  });
+
+  it('404s creating a named-agent session when the name is not policy-permitted', async () => {
+    const agent = await agentStore.createAgent({
+      tenant_id: 'default',
+      created_by_subject: {
+        subject_id: STANDALONE_REQUEST_CONTEXT.subject.id,
+        subject_type: STANDALONE_REQUEST_CONTEXT.subject.type,
+        subject_display_name: STANDALONE_REQUEST_CONTEXT.subject.display_name,
+      },
+      name: 'policy-blocked-agent',
+      manifest: inlineSpec,
+      external_id: null,
+    });
+    const restrictedApp = new OpenAPIHono();
+    restrictedApp.route(
+      '/',
+      createSessionsRouter({
+        ...sessionDeps,
+        requestReplyRouter: new RequestReplyRouter(),
+        sessionPolicyProvider: denyAllSessionPolicyProvider,
+      }),
+    );
+    const res = await restrictedApp.request('/', jsonInit('POST', { agent: { name: agent.name } }));
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/trueforge/tests/unit/auth/sessionPolicy.test.ts
+++ b/packages/trueforge/tests/unit/auth/sessionPolicy.test.ts
@@ -1,0 +1,186 @@
+import { AgentSpecSchema } from '@truefoundry/trueforge-core/agent-session';
+import {
+  checkSessionPolicyForAgent,
+  type SessionPolicy,
+  UNRESTRICTED_SESSION_POLICY,
+} from '../../../src/auth/sessionPolicy';
+
+const baseSpec = AgentSpecSchema.parse({ model: { name: 'openai/gpt-4o' } });
+
+const specWithSkills = AgentSpecSchema.parse({
+  model: { name: 'openai/gpt-4o' },
+  skills: [{ name: 'code-interpreter' }, { name: 'web-search' }],
+});
+
+const specWithMcpServers = AgentSpecSchema.parse({
+  model: { name: 'openai/gpt-4o' },
+  mcp_servers: [{ name: 'github' }, { name: 'slack' }],
+});
+
+describe('checkSessionPolicyForAgent', () => {
+  describe('unrestricted policy', () => {
+    it('allows a named agent ref', () => {
+      const result = checkSessionPolicyForAgent(UNRESTRICTED_SESSION_POLICY, { name: 'my-agent' });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('allows an inline spec with a model', () => {
+      const result = checkSessionPolicyForAgent(UNRESTRICTED_SESSION_POLICY, { spec: baseSpec });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('allows an inline spec with skills', () => {
+      const result = checkSessionPolicyForAgent(UNRESTRICTED_SESSION_POLICY, { spec: specWithSkills });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('allows an inline spec with mcp_servers', () => {
+      const result = checkSessionPolicyForAgent(UNRESTRICTED_SESSION_POLICY, { spec: specWithMcpServers });
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('allow_inline_agent_specs: false', () => {
+    const policy: SessionPolicy = {
+      ...UNRESTRICTED_SESSION_POLICY,
+      allow_inline_agent_specs: false,
+    };
+
+    it('rejects any inline spec', () => {
+      const result = checkSessionPolicyForAgent(policy, { spec: baseSpec });
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toMatch(/inline agent/i);
+      }
+    });
+
+    it('still allows a named agent ref', () => {
+      const result = checkSessionPolicyForAgent(policy, { name: 'my-agent' });
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('allowed_agent_names', () => {
+    it('allows a name that is in the list', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        allowed_agent_names: ['permitted-agent', 'other-agent'],
+      };
+      expect(checkSessionPolicyForAgent(policy, { name: 'permitted-agent' }).allowed).toBe(true);
+    });
+
+    it('rejects a name that is not in the list', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        allowed_agent_names: ['permitted-agent'],
+      };
+      const result = checkSessionPolicyForAgent(policy, { name: 'forbidden-agent' });
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toMatch(/forbidden-agent/);
+      }
+    });
+
+    it('rejects every name when the allow-list is empty', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        allowed_agent_names: [],
+      };
+      expect(checkSessionPolicyForAgent(policy, { name: 'any-agent' }).allowed).toBe(false);
+    });
+
+    it('does not apply to inline specs (inline gate is separate)', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        allowed_agent_names: [],
+      };
+      expect(checkSessionPolicyForAgent(policy, { spec: baseSpec }).allowed).toBe(true);
+    });
+  });
+
+  describe('allowed_models', () => {
+    it('allows a model inside the list', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        allowed_models: ['openai/gpt-4o', 'anthropic/claude-sonnet-4-6'],
+      };
+      expect(checkSessionPolicyForAgent(policy, { spec: baseSpec }).allowed).toBe(true);
+    });
+
+    it('rejects a model outside the list', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        allowed_models: ['anthropic/claude-sonnet-4-6'],
+      };
+      const result = checkSessionPolicyForAgent(policy, { spec: baseSpec });
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toMatch(/openai\/gpt-4o/);
+      }
+    });
+  });
+
+  describe('allowed_skills', () => {
+    it('allows specs whose skills are all in the list', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        allowed_skills: ['code-interpreter', 'web-search', 'extra'],
+      };
+      expect(checkSessionPolicyForAgent(policy, { spec: specWithSkills }).allowed).toBe(true);
+    });
+
+    it('rejects a spec with a skill outside the list', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        allowed_skills: ['code-interpreter'],
+      };
+      const result = checkSessionPolicyForAgent(policy, { spec: specWithSkills });
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toMatch(/web-search/);
+      }
+    });
+
+    it('rejects when only the second skill is disallowed (not just first)', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        // code-interpreter is allowed, web-search is not
+        allowed_skills: ['code-interpreter'],
+      };
+      const result = checkSessionPolicyForAgent(policy, { spec: specWithSkills });
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe('allowed_mcp_servers', () => {
+    it('allows specs whose mcp_servers are all in the list', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        allowed_mcp_servers: ['github', 'slack', 'jira'],
+      };
+      expect(checkSessionPolicyForAgent(policy, { spec: specWithMcpServers }).allowed).toBe(true);
+    });
+
+    it('rejects a spec with an mcp_server outside the list', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        allowed_mcp_servers: ['github'],
+      };
+      const result = checkSessionPolicyForAgent(policy, { spec: specWithMcpServers });
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toMatch(/slack/);
+      }
+    });
+
+    it('rejects when only the second server is disallowed (not just first)', () => {
+      const policy: SessionPolicy = {
+        ...UNRESTRICTED_SESSION_POLICY,
+        // github is allowed, slack is not
+        allowed_mcp_servers: ['github'],
+      };
+      const result = checkSessionPolicyForAgent(policy, { spec: specWithMcpServers });
+      expect(result.allowed).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the server-enforced SessionPolicy seam from #541 (Scoped API identities for unattended agent workloads). Adds a SessionPolicyProvider abstraction — mirroring the existing Authorizer pattern — that constrains what a caller may request when creating a session: whether inline agent specs are permitted, which named agents may be used, and which models/skills/MCP servers an inline spec may reference. The default provider is completely unrestricted, preserving current behavior exactly. No operator configuration surface yet — that is deferred to a follow-up once the mechanism is agreed with maintainers.

Closes #541

## Changes
- `src/auth/sessionPolicy.ts` (new) — `SessionPolicy` interface, `UNRESTRICTED_SESSION_POLICY` constant, `SessionPolicyProvider` interface, `UnrestrictedSessionPolicyProvider` class, and `checkSessionPolicyForAgent()` pure function
- `src/routes/sessionRoutes.ts` — adds 403 response to `createSessionRoute`; broadens `getOrCreateSessionByExternalIdRoute` 403 description to mention policy
- `src/apis/sessions.ts` — threads `sessionPolicyProvider` through `SessionsRouterDeps` and `InternalSessionsRouterDeps`; enforces policy in `createSessionHandler` and `createGetOrCreateSessionByExternalIdHandler` before any store calls (named-ref denials return 404 — indistinguishable from non-existent agents — inline-spec denials return 403)
- `src/app.ts` — adds `sessionPolicyProvider` to `ServerDeps`; passes it to both session router constructors
- `src/main.ts` / `scripts/write-openapi.ts` — instantiate and wire `UnrestrictedSessionPolicyProvider`
- `tests/unit/auth/sessionPolicy.test.ts` (new) — 18 pure unit tests for `checkSessionPolicyForAgent` covering all policy dimensions and edge cases
- `tests/unit/apis/sessionHttp.test.ts` — adds `sessionPolicyProvider` to shared deps; two new HTTP-level tests (403 for blocked inline spec, 404 for blocked named agent)
- `tests/unit/apis/deletedSessionCrud.test.ts` — adds required `sessionPolicyProvider` field
- `.changeset/session-policy-seam.md` (new) — `@truefoundry/trueforge`: minor

## How was this tested?
- `pnpm --filter @truefoundry/trueforge typecheck` — pass
- `pnpm --filter @truefoundry/trueforge test` — 466 passed, 0 failed (18 new tests in `sessionPolicy.test.ts`, 2 new HTTP tests in `sessionHttp.test.ts`)
- `pnpm format:check` — pass
- `pnpm build` — pass
- `pnpm lint:ci` — pre-existing failures in `packages/frontend` and `packages/trueforge-ui` only; zero new violations introduced by this diff (confirmed by running lint against clean main)

## Checklist

- [x] I have read the [[contributing guidelines](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)](https://github.com/truefoundry/trueforge/blob/main/CONTRIBUTING.md)
- [x] `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint:ci`, and `pnpm format:check` pass locally
- [x] Tests added/updated where it makes sense
- [x] No hand-edits to generated code (`packages/trueforge-sdk`, `.github/fern/openapi/openapi.json`, `docs/openapi.json`) — fork PRs omit SDK regen; maintainers regenerate after merge
- [ ] Docs / `.env.example` updated if configuration or behavior changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session-creation authorization and error semantics (404 vs 403) on a security-sensitive path, though default policy remains unrestricted and coverage is strong.
> 
> **Overview**
> Introduces a **pluggable `SessionPolicyProvider`** (patterned after `Authorizer`) so operators can later cap what API callers may request when **creating** sessions: inline specs, named agents, and inline models/skills/MCP servers.
> 
> **Enforcement** runs in `createSession` and internal `get-or-create-by-external-id` **before** agent store lookups via `checkSessionPolicyForAgent`. Policy-blocked **named agents** return **404** (same as missing agents, per #541); blocked **inline** requests return **403** with a policy reason. OpenAPI documents the new 403 on create.
> 
> **Default wiring** uses `UnrestrictedSessionPolicyProvider`, so **runtime behavior is unchanged** until a restrictive provider is plugged in (`main.ts`, OpenAPI script, router deps). Unit and HTTP tests cover policy dimensions and response codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e5ea4f332725165a012de79b6902ff277c855d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->